### PR TITLE
correct jquery syntax to select value to fix issue #285

### DIFF
--- a/gui/slick/js/displayShow.js
+++ b/gui/slick/js/displayShow.js
@@ -38,7 +38,7 @@ $(document).ready(function () {
         if (epArr.length == 0)
             return false;
 
-        url = sbRoot + '/home/setStatus?show=' + $('#showID').attr('value') + '&eps=' + epArr.join('|') + '&status=' + $('#statusSelect').attr('value');
+        url = sbRoot + '/home/setStatus?show=' + $('#showID').attr('value') + '&eps=' + epArr.join('|') + '&status=' + $('#statusSelect').val();
         window.location.href = url
 
     });

--- a/gui/slick/js/displayShow.js
+++ b/gui/slick/js/displayShow.js
@@ -105,7 +105,7 @@ $(document).ready(function () {
     // handle the show selection dropbox
     $('#pickShow').change(function () {
         var sbRoot = $('#sbRoot').val();
-        var val = $(this).attr('value');
+        var val = $(this).val();
         if (val == 0)
             return;
         url = sbRoot + '/home/displayShow?show=' + val;


### PR DESCRIPTION
this correctly selects the value for the statusSelect id and fixes the ``invalid literal for int() with base 10: 'undefined'`` error when scheduling shows to wanted for example.