### PR TITLE
Use os.system for file copies

### DIFF
--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -342,7 +342,11 @@ def listMediaFiles(path):
 
 
 def copyFile(srcFile, destFile):
-    ek.ek(shutil.copyfile, srcFile, destFile)
+    if isPosix():
+        os.system('cp "%s" "%s"' % (srcFile, destFile))
+    else:
+        ek.ek(shutil.copyfile, srcFile, destFile)
+        
     try:
         ek.ek(shutil.copymode, srcFile, destFile)
     except OSError:
@@ -365,6 +369,12 @@ def link(src, dst):
         if ctypes.windll.kernel32.CreateHardLinkW(unicode(dst), unicode(src), 0) == 0: raise ctypes.WinError()
     else:
         os.link(src, dst)
+
+def isPosix(): 
+    if os.name.startswith('posix'):
+        return True
+    else:
+        return False
 
 
 def hardlinkFile(srcFile, destFile):


### PR DESCRIPTION
When post processing using shutil.copyfile can be very slow. Use
os.system for posix systems