### PR TITLE
Don't clean user files when GIT CLEAN

### DIFF
--- a/sickbeard/versionChecker.py
+++ b/sickbeard/versionChecker.py
@@ -419,7 +419,7 @@ class GitUpdateManager(UpdateManager):
         Calls git clean to remove all untracked files. Returns a bool depending
         on the call's success.
         """
-        output, err, exit_status = self._run_git(self._git_path, 'clean -d -fx ""')  # @UnusedVariable
+        output, err, exit_status = self._run_git(self._git_path, 'clean -df ""')  # @UnusedVariable
         if exit_status == 0:
             return True
 


### PR DESCRIPTION
The "x" option ignores the .gitignore

-x
Don’t use the standard ignore rules read from .gitignore (per directory) and $GIT_DIR/info/exclude, but do still use the ignore rules given with -e options. This allows removing all untracked files, including build products. This can be used (possibly in conjunction with git reset) to create a pristine working directory to test a clean build.

http://git-scm.com/docs/git-clean