### PR TITLE
Fix multipart rars causing the same extracted video to be postprocessed more than once

### DIFF
--- a/sickbeard/processTV.py
+++ b/sickbeard/processTV.py
@@ -336,7 +336,11 @@ def unRAR(path, rarFiles, force):
                     continue
 
                 rar_handle.extract(path=path, withSubpath=False, overwrite=False)
-                unpacked_files += [os.path.basename(x.filename) for x in rar_handle.infolist() if not x.isdir]
+                for x in rar_handle.infolist():
+                    if not x.isdir:
+                        basename = os.path.basename(x.filename)
+                        if basename not in unpacked_files:
+                            unpacked_files.append(basename)
                 del rar_handle
             except Exception, e:
                 returnStr += logHelper(u"Failed Unrar archive " + archive + ': ' + ex(e), logger.ERROR)


### PR DESCRIPTION
When post processing a directory with multipart rars, the same video file from each of the parts is added to the list of files to be processed. This causes problems when using symbolic or hard link process method, as the video file is deleted after the first time its processed. Subsequent attempts to process the same video fail.

This fix simply makes sure that the video file name is not already listed in the `unpacked_files` list before adding it. If multiple rars contain different files but identically named, this may cause issues, but I don't think SickRage copes with that situation anyway.

Let me know your thoughts and I'll update the PR with any comments.