### PR TITLE
Postpone Processing for incomplete torrents.

### DIFF
--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -127,7 +127,7 @@ def replaceExtension(filename, newExt):
 
 def isSyncFile(filename):
     extension = filename.rpartition(".")[2].lower()
-    if extension == '!sync' or extension == 'lftp-pget-status':
+    if extension == '!sync' or extension == 'lftp-pget-status' or extension == 'part':
         return True
     else:
         return False


### PR DESCRIPTION
Processing postpone will happened if there is file with .part extension - incomplete transmission file.