### PR TITLE
config.clean_url may add trailing /'s in unsuitable circumstances.

### DIFF
--- a/sickbeard/config.py
+++ b/sickbeard/config.py
@@ -326,10 +326,8 @@ def clean_url(url):
 
         scheme, netloc, path, query, fragment = urlparse.urlsplit(url, 'http')
 
-        if not path.endswith('/'):
-            basename, ext = ek.ek(os.path.splitext, ek.ek(os.path.basename, path))  # @UnusedVariable
-            if not ext:
-                path = path + '/'
+        if not path:
+            path = path + '/'
 
         cleaned_url = urlparse.urlunsplit((scheme, netloc, path, query, fragment))
 

--- a/tests/config_tests.py
+++ b/tests/config_tests.py
@@ -1,0 +1,20 @@
+import unittest
+
+import sys
+import os.path
+sys.path.append(os.path.abspath('..'))
+
+from sickbeard import config
+
+
+class QualityTests(unittest.TestCase):
+
+    def test_clean_url(self):
+        self.assertEqual(config.clean_url("https://subdomain.domain.tld/endpoint"), "https://subdomain.domain.tld/endpoint")
+        self.assertEqual(config.clean_url("google.com/xml.rpc"), "http://google.com/xml.rpc")
+        self.assertEqual(config.clean_url("google.com"), "http://google.com/")
+        self.assertEqual(config.clean_url("http://www.example.com/folder/"), "http://www.example.com/folder/")
+
+if __name__ == '__main__':
+    suite = unittest.TestLoader().loadTestsFromTestCase(QualityTests)
+    unittest.TextTestRunner(verbosity=2).run(suite)


### PR DESCRIPTION
Also adds some simple tests so we can avoid future regressions.

Upstream SickBeard pull request is available here: https://github.com/midgetspy/Sick-Beard/pull/910