### PR TITLE
Fix for https://github.com/SiCKRAGETV/sickrage-issues/issues/178

### DIFF
--- a/sickbeard/providers/t411.py
+++ b/sickbeard/providers/t411.py
@@ -79,7 +79,7 @@ class T411Provider(generic.TorrentProvider):
         self.session = requests.Session()
 
         try:
-            response = self.session.post(self.urls['login_page'], data=login_params, timeout=30, verify=False)
+            response = self.session.post(self.urls['login_page'], data=login_params, timeout=30, verify=False, headers=self.headers)
         except (requests.exceptions.ConnectionError, requests.exceptions.HTTPError), e:
             logger.log(u'Unable to connect to ' + self.name + ' provider: ' + ex(e), logger.ERROR)
             return False


### PR DESCRIPTION
Problem with the user-agent. I logged with python User-Agent and download torrent with SickRage User-Agent. I think t411 have migrated to cloudflare. When you're logged with a different User-Agent, you have a different authKey in the cookie and 2 request with 2 User-Agent don't work.