### PR TITLE
Remove "aoeu" div from the default "add new shows" template

### DIFF
--- a/gui/slick/interfaces/default/home_newShow.tmpl
+++ b/gui/slick/interfaces/default/home_newShow.tmpl
@@ -32,7 +32,6 @@
 
 	<div id="core-component-group1" class="tab-pane active component-group">
 				
-
 	<form id="addShowForm" method="post" action="$sbRoot/home/addShows/addNewShow" accept-charset="utf-8">
 
 	<fieldset class="sectionwrap">

--- a/gui/slick/interfaces/default/home_newShow.tmpl
+++ b/gui/slick/interfaces/default/home_newShow.tmpl
@@ -32,8 +32,6 @@
 
 	<div id="core-component-group1" class="tab-pane active component-group">
 				
-	<div id="displayText">aoeu</div>
-	<br />
 
 	<form id="addShowForm" method="post" action="$sbRoot/home/addShows/addNewShow" accept-charset="utf-8">
 


### PR DESCRIPTION
first commit removed the div, the second removed a blank line that I should have deleted with the first commit.