### PR TITLE
Update TorrentDay URL

### DIFF
--- a/sickbeard/providers/torrentday.py
+++ b/sickbeard/providers/torrentday.py
@@ -54,10 +54,10 @@ class TorrentDayProvider(generic.TorrentProvider):
 
         self.cache = TorrentDayCache(self)
 
-        self.urls = {'base_url': 'http://www.td.af',
-                'login': 'http://www.td.af/torrents/',
-                'search': 'http://www.td.af/V3/API/API.php',
-                'download': 'http://www.td.af/download.php/%s/%s'
+        self.urls = {'base_url': 'https://www.torrentday.eu',
+                'login': 'https://www.torrentday.eu/torrents/',
+                'search': 'https://www.torrentday.eu/V3/API/API.php',
+                'download': 'https://www.torrentday.eu/download.php/%s/%s'
         }
 
         self.url = self.urls['base_url']


### PR DESCRIPTION
From Torrentday staff:
UK ISP users don't need to use VPN/proxy to access TD. You can start using our new SSL Secured domain name: https://torrentday.eu

https://github.com/SiCKRAGETV/sickrage-issues/issues/435


@echel0n Do I need to change anything else because of the HTTPS?