### PR TITLE
Fix versionchecker

### DIFF
--- a/sickbeard/versionChecker.py
+++ b/sickbeard/versionChecker.py
@@ -40,6 +40,7 @@ class CheckVersion():
 
     def __init__(self):
         self.updater = None
+        install_type = None
 
         if sickbeard.gh:
             self.install_type = self.find_install_type()


### PR DESCRIPTION
In CheckVersion.__init__ (sickbeard/versionChecker.py, line 41), the install_type attribute is only assigned if sickbeard.gh has been set, and it won't be if SR couldn't connect to Github. The restart code (SickBeard.py, line 482) tries to access install_type to determine which update command to run, which raises an AttributeError and prevents SR from restarting.

https://github.com/SiCKRAGETV/sickrage-issues/issues/307#issuecomment-70713312