### PR TITLE
Changed Releasegroup handling in Renamer

### DIFF
--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -2126,7 +2126,27 @@ class TVEpisode(object):
             show_name = re.sub("\(\d+\)$", "", self.show.name).rstrip()
         else:
             show_name = self.show.name
-
+        
+        #try to get the release group
+        rel_grp = {};
+        rel_grp["SiCKRAGE"] = 'SiCKRAGE';
+        if hasattr(self, 'location'): #from the location name 
+            rel_grp['location'] = release_group(self.show, self.location);
+            if (rel_grp['location'] == ''): del rel_grp['location']
+        if hasattr(self, '_release_group'): #from the release group field in db
+            rel_grp['database'] = self._release_group;
+            if (rel_grp['database'] == ''): del rel_grp['database']
+        if hasattr(self, 'release_name'): #from the release name field in db
+            rel_grp['release_name'] = release_group(self.show, self.release_name);
+            if (rel_grp['release_name'] == ''): del rel_grp['release_name']
+        
+        # use release_group, release_name, location in that order 
+        if ('database' in rel_grp): relgrp = 'database'
+        elif ('release_name' in rel_grp): relgrp = 'release_name'
+        elif ('location' in rel_grp): relgrp = 'location'
+        else: relgrp = 'SiCKRAGE' 
+            
+        
         return {
             '%SN': show_name,
             '%S.N': dot(show_name),
@@ -2148,7 +2168,7 @@ class TVEpisode(object):
             '%AB': '%(#)03d' % {'#': self.absolute_number},
             '%XAB': '%(#)03d' % {'#': self.scene_absolute_number},
             '%RN': release_name(self.release_name),
-            '%RG': release_group(self.show, self.release_name),
+            '%RG': rel_grp[relgrp],
             '%AD': str(self.airdate).replace('-', ' '),
             '%A.D': str(self.airdate).replace('-', '.'),
             '%A_D': us(str(self.airdate)),
@@ -2193,21 +2213,30 @@ class TVEpisode(object):
         replace_map = self._replace_map()
 
         result_name = pattern
-
-        # if there's no release group then replace it with a reasonable facsimile
+        
+        # if there's no release group in the db, let the user know we replaced it
+        if (not hasattr(self, '_release_group') and (not replace_map['%RG'] == 'SiCKRAGE')):        
+            logger.log(u"Episode has no release group, replacing it with '" + replace_map['%RG'] + "'", logger.DEBUG);
+            self._release_group = replace_map['%RG'] #if release_group is not in the db, put it there
+        elif ((self._release_group == '') and (not replace_map['%RG'] == 'SiCKRAGE')):
+            logger.log(u"Episode has no release group, replacing it with '" + replace_map['%RG'] + "'", logger.DEBUG);
+            self._release_group = replace_map['%RG'] #if release_group is not in the db, put it there
+    
+        # if there's no release name then replace it with a reasonable facsimile
         if not replace_map['%RN']:
-            if self.show.air_by_date or self.show.sports:
-                result_name = result_name.replace('%RN', '%S.N.%A.D.%E.N-SiCKRAGE')
-                result_name = result_name.replace('%rn', '%s.n.%A.D.%e.n-sickrage')
-            elif anime_type != 3:
-                result_name = result_name.replace('%RN', '%S.N.%AB.%E.N-SiCKRAGE')
-                result_name = result_name.replace('%rn', '%s.n.%ab.%e.n-sickrage')
-            else:
-                result_name = result_name.replace('%RN', '%S.N.S%0SE%0E.%E.N-SiCKRAGE')
-                result_name = result_name.replace('%rn', '%s.n.s%0se%0e.%e.n-sickrage')
 
-            result_name = result_name.replace('%RG', 'SICKRAGE')
-            result_name = result_name.replace('%rg', 'sickrage')
+            if self.show.air_by_date or self.show.sports:
+                result_name = result_name.replace('%RN', '%S.N.%A.D.%E.N-' + replace_map['%RG'])
+                result_name = result_name.replace('%rn', '%s.n.%A.D.%e.n-' + replace_map['%RG'].lower())
+                    
+            elif anime_type != 3:
+                result_name = result_name.replace('%RN', '%S.N.%AB.%E.N-' + replace_map['%RG'])
+                result_name = result_name.replace('%rn', '%s.n.%ab.%e.n-' + replace_map['%RG'].lower())
+                                
+            else:
+                result_name = result_name.replace('%RN', '%S.N.S%0SE%0E.%E.N-' + replace_map['%RG'])
+                result_name = result_name.replace('%rn', '%s.n.s%0se%0e.%e.n-' + replace_map['%RG'].lower())
+            
             logger.log(u"Episode has no release name, replacing it with a generic one: " + result_name, logger.DEBUG)
 
         if not replace_map['%RT']:


### PR DESCRIPTION
- Added a check for release_group field in db
- Added a check for location field in db (filename, requires
qual-RLSGROUP convention to be succesful)

- If release_group field in db empty and the releasegroup was found in
either release_name or location fields, then updates the db with the
releasegroup. Except when releasegroup is 'SiCKRAGE'
- If release_name is empty, and SR wants to replace it with a generic
one, it will now use the releasegroup if found, and otherwise replace
with SiCKRAGE.