### PR TITLE
Fix for issue 358 (filename-thumb.jpg not renaming)

### DIFF
--- a/sickbeard/postProcessor.py
+++ b/sickbeard/postProcessor.py
@@ -19,6 +19,7 @@
 from __future__ import with_statement
 
 import glob
+import fnmatch
 import os
 import re
 import subprocess
@@ -154,13 +155,19 @@ class PostProcessor(object):
 
         Returns: A list containing all files which are associated to the given file
         """
+        def recursive_glob(treeroot, pattern):
+            results = []
+            for base, dirs, files in os.walk(treeroot):
+                goodfiles = fnmatch.filter(files, pattern)
+                results.extend(os.path.join(base, f) for f in goodfiles)
+            return results
 
         if not file_path:
             return []
 
         file_path_list = []
 
-        base_name = file_path.rpartition('.')[0]
+        base_name = ek.ek(os.path.basename, file_path).rpartition('.')[0]
 
         if not base_name_only:
             base_name = base_name + '.'
@@ -171,8 +178,8 @@ class PostProcessor(object):
 
         # don't confuse glob with chars we didn't mean to use
         base_name = re.sub(r'[\[\]\*\?]', r'[\g<0>]', base_name)
-
-        for associated_file_path in ek.ek(glob.glob, base_name + '*'):
+        
+        for associated_file_path in ek.ek(recursive_glob, self.folder_path,  base_name + '*'):
             # only add associated to list
             if associated_file_path == file_path:
                 continue

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -2428,7 +2428,7 @@ class TVEpisode(object):
             return
 
         related_files = postProcessor.PostProcessor(self.location).list_associated_files(
-            self.location)
+            self.location, base_name_only=True)
 
         if self.show.subtitles and sickbeard.SUBTITLES_DIR != '':
             related_subs = postProcessor.PostProcessor(self.location).list_associated_files(sickbeard.SUBTITLES_DIR,
@@ -2442,8 +2442,17 @@ class TVEpisode(object):
 
         # move related files
         for cur_related_file in related_files:
-            cur_result = helpers.rename_ep_file(cur_related_file, absolute_proper_path,
-                                                absolute_current_path_no_ext_length)
+            #We need to fix something here because related files can be in subfolders and the original code doesn't handle this (at all)
+            cur_related_dir = ek.ek(os.path.dirname, ek.ek(os.path.abspath, cur_related_file))
+            subfolder = cur_related_dir.replace(ek.ek(os.path.dirname, ek.ek(os.path.abspath, self.location)), '')
+            #We now have a subfolder. We need to add that to the absolute_proper_path.
+            #First get the absolute proper-path dir
+            proper_related_dir = ek.ek(os.path.dirname, ek.ek(os.path.abspath, absolute_proper_path + file_ext))
+            proper_related_path = absolute_proper_path.replace(proper_related_dir, proper_related_dir + subfolder)
+            
+            
+            cur_result = helpers.rename_ep_file(cur_related_file, proper_related_path,
+                                                absolute_current_path_no_ext_length + len(subfolder))
             if not cur_result:
                 logger.log(str(self.indexerid) + u": Unable to rename file " + cur_related_file, logger.ERROR)
 


### PR DESCRIPTION
- Renamer now handles metadata files that have add-ons to the
filename itself (fixes
https://github.com/SiCKRAGETV/sickrage-issues/issues/358)
- Renamer now handles subfolders for metadata (fixes
MediaBrowser and TiVO metadata renaming issues)


