### PR TITLE
Fix access to webcal without password.

### DIFF
--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -521,6 +521,18 @@ class WebRoot(WebHandler):
 
         return t.respond()
 
+
+class CalendarHandler(BaseHandler):
+    def get(self, *args, **kwargs):
+        if sickbeard.CALENDAR_UNPROTECTED:
+            self.write(self.calendar())
+        else:
+            self.calendar_auth()
+
+    @authenticated
+    def calendar_auth(self):
+        self.write(self.calendar())
+
     # Raw iCalendar implementation by Pedro Jose Pereira Vieito (@pvieito).
     #
     # iCalendar (iCal) - Standard RFC 5545 <http://tools.ietf.org/html/rfc5546>

--- a/sickbeard/webserveInit.py
+++ b/sickbeard/webserveInit.py
@@ -95,7 +95,7 @@ class SRWebServer(threading.Thread):
 
         # Web calendar handler (Needed because option Unprotected calendar)
         self.app.add_handlers('.*$', [
-            (r'%s/calendar(/?.*)' % self.options['web_root'], CalendarHandler),
+            (r'%s/calendar' % self.options['web_root'], CalendarHandler),
         ])
 
         # Static File Handlers

--- a/sickbeard/webserveInit.py
+++ b/sickbeard/webserveInit.py
@@ -3,7 +3,7 @@ import threading
 import sys
 import sickbeard
 
-from sickbeard.webserve import LoginHandler, LogoutHandler, KeyHandler
+from sickbeard.webserve import LoginHandler, LogoutHandler, KeyHandler, CalendarHandler
 from sickbeard.webapi import ApiHandler
 from sickbeard import logger
 from sickbeard.helpers import create_https_certificates, generateApiKey
@@ -92,6 +92,11 @@ class SRWebServer(threading.Thread):
 
             # webui handlers
         ] + route.get_routes(self.options['web_root']))
+
+        # Web calendar handler (Needed because option Unprotected calendar)
+        self.app.add_handlers('.*$', [
+            (r'%s/calendar(/?.*)' % self.options['web_root'], CalendarHandler),
+        ])
 
         # Static File Handlers
         self.app.add_handlers(".*$", [


### PR DESCRIPTION
This commit put webcal in its own handler so the option CALENDAR_UNPROTECTED can work.

See SiCKRAGETV/sickrage-issues#456 for more info.