### PR TITLE
Add notice in addShow for special with TVRage

### DIFF
--- a/gui/slick/interfaces/default/home_newShow.tmpl
+++ b/gui/slick/interfaces/default/home_newShow.tmpl
@@ -61,7 +61,7 @@
 					<option value="0" #if $provided_indexer == 0 then "selected=\"selected\"" else ""#>All Indexers</option>
 					#for $indexer in $indexers
 						<option value="$indexer" #if $provided_indexer == $indexer then "selected=\"selected\"" else ""#>
-						#if $indexers[$indexer] == 'TVRage' then ''.join(($indexers[$indexer], '**')) else $indexers[$indexer]#</option>
+						#if $indexers[$indexer] == 'TVRage' then ''.join(($indexers[$indexer], ' **')) else $indexers[$indexer]#</option>
 					#end for
 				</select>
 				&nbsp;

--- a/gui/slick/interfaces/default/home_newShow.tmpl
+++ b/gui/slick/interfaces/default/home_newShow.tmpl
@@ -60,7 +60,8 @@
 				<select name="providedIndexer" id="providedIndexer" class="form-control form-control-inline input-sm">
 					<option value="0" #if $provided_indexer == 0 then "selected=\"selected\"" else ""#>All Indexers</option>
 					#for $indexer in $indexers
-						<option value="$indexer" #if $provided_indexer == $indexer then "selected=\"selected\"" else ""#>$indexers[$indexer]</option>
+						<option value="$indexer" #if $provided_indexer == $indexer then "selected=\"selected\"" else ""#>
+						#if $indexers[$indexer] == 'TVRage' then ''.join(($indexers[$indexer], '**')) else $indexers[$indexer]#</option>
 					#end for
 				</select>
 				&nbsp;
@@ -69,6 +70,7 @@
 				<br /><br />
 				<b>*</b> This will only affect the language of the retrieved metadata file contents and episode filenames.<br />
 				This <b>DOES NOT</b> allow SickRage to download non-english TV episodes!<br />
+				<b>**</b> The indexer implementation doesn't currently support specials.<br />
 				<br />
 				<div id="searchResults" style="height: 100%;"><br/></div>
 			#end if


### PR DESCRIPTION
Add a notice to inform the user about the current TVRage's indexer implementation missing the ability to retrieve specials.

See SiCKRAGETV/sickrage-issues#292 for more info