### PR TITLE
Set UNKNOWN quality as Low Quality

### DIFF
--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -1269,6 +1269,8 @@ class TVShow(object):
 
             if epStatus == FAILED:
                 return Overview.WANTED
+            if curQuality == Quality.UNKNOWN:
+                return Overview.QUAL
             elif epStatus in (SNATCHED_BEST, SNATCHED, SNATCHED_PROPER ) and curQuality == maxBestQuality:
                 return Overview.SNATCHED
             # if they don't want re-downloads then we call it good if they have anything


### PR DESCRIPTION
https://github.com/SiCKRAGETV/sickrage-issues/issues/493#issuecomment-71538630

UNKNOWN quality will always be low quality no matter what.
It's different from unknown episode status.