### PR TITLE
Fix for errors on setting episodes to failed

### DIFF
--- a/sickbeard/search_queue.py
+++ b/sickbeard/search_queue.py
@@ -250,7 +250,7 @@ class FailedQueueItem(generic_queue.QueueItem):
         self.started = True
         
         try:
-            for epObj in self.segment:
+            for epObj in self.segment[0]:
             
                 logger.log(u"Marking episode as bad: [" + epObj.prettyName() + "]")
                 

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -1800,7 +1800,7 @@ class Home(WebRoot):
                                 'status': statusStrings[searchThread.segment.status],
                                 'quality': self.getQualityClass(searchThread.segment)})
             else:
-                for epObj in searchThread.segment:
+                for epObj in searchThread.segment[0]:
                     results.append({'episode': epObj.episode,
                                     'episodeindexid': epObj.indexerid,
                                     'season': epObj.season,
@@ -1838,7 +1838,7 @@ class Home(WebRoot):
                     episodes += getEpisodes(searchThread, searchstatus)
             else:
                 ### These are only Failed Downloads/Retry SearchThreadItems.. lets loop through the segement/episodes
-                if not [i for i, j in zip(searchThread.segment, episodes) if i.indexerid == j['episodeindexid']]:
+                if not [i for i, j in zip(searchThread.segment[0], episodes) if i.indexerid == j['episodeindexid']]:
                     episodes += getEpisodes(searchThread, searchstatus)
 
         return json.dumps({'show': show, 'episodes': episodes})


### PR DESCRIPTION
- Added an index to search_queue.segment as it is a list of 1 segment,
instead of just a segment. epObj would therefor become the entire
segment instead of just the epObj beneath it, resulting in object type
list has no attribute 'prettyName' or 'episode' errors.