### PR TITLE
Added Episode check to PP history check

### DIFF
--- a/sickbeard/processTV.py
+++ b/sickbeard/processTV.py
@@ -378,10 +378,23 @@ def already_postprocessed(dirName, videofile, force, result):
             result.output += logHelper(u"You're trying to post process a video that's already been processed, skipping",
                                    logger.DEBUG)
             return True
-
+        
         #Needed if we have downloaded the same episode @ different quality
-        search_sql = "SELECT tv_episodes.indexerid, history.resource FROM tv_episodes INNER JOIN history ON history.showid=tv_episodes.showid"
+        #But we need to make sure we check the history of the episode we're going to PP, and not others
+        np = NameParser(dirName, tryIndexers=True, convert=True)
+        try: #if it fails to find any info (because we're doing an unparsable folder (like the TV root dir) it will throw an exception, which we want to ignore
+            parse_result = np.parse(dirName)
+        except: #ignore the exception, because we kind of expected it, but create parse_result anyway so we can perform a check on it.
+            parse_result = False
+            pass
+        
+        
+        search_sql = "SELECT tv_episodes.indexerid, history.resource FROM tv_episodes INNER JOIN history ON history.showid=tv_episodes.showid" #This part is always the same
         search_sql += " WHERE history.season=tv_episodes.season and history.episode=tv_episodes.episode"
+        #If we find a showid, a season number, and one or more episode numbers then we need to use those in the query
+        if parse_result and (parse_result.show.indexerid and parse_result.episode_numbers and parse_result.season_number):
+            search_sql += " and tv_episodes.showid = '" + str(parse_result.show.indexerid) + "' and tv_episodes.season = '" + str(parse_result.season_number) + "' and tv_episodes.episode = '" + str(parse_result.episode_numbers[0]) + "'"
+        
         search_sql += " and tv_episodes.status IN (" + ",".join([str(x) for x in common.Quality.DOWNLOADED]) + ")"
         search_sql += " and history.resource LIKE ?"
         sqlResult = myDB.select(search_sql, [u'%' + videofile])


### PR DESCRIPTION
- Fixes issue when Post-Processing a file with a generic filename in a
subfolder resulting in "Already Processed" errors

- Added a Show, Season, Episode parse to the dirname, and if that
results in usable data it adds it to the history check so this is
performed on that specific episode only