### PR TITLE
Fix for 'List type has no attribute' on setting failed

### DIFF
--- a/sickbeard/failedProcessor.py
+++ b/sickbeard/failedProcessor.py
@@ -67,7 +67,7 @@ class FailedProcessor(object):
         for episode in parsed.episode_numbers:
             segment = parsed.show.getEpisode(parsed.season_number, episode)
 
-            cur_failed_queue_item = search_queue.FailedQueueItem(parsed.show, [segment])
+            cur_failed_queue_item = search_queue.FailedQueueItem(parsed.show, segment)
             sickbeard.searchQueueScheduler.action.add_item(cur_failed_queue_item)
 
         return True

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -1654,7 +1654,7 @@ class Home(WebRoot):
             msg += '<ul>'
 
             for season, segment in segments.items():
-                cur_failed_queue_item = search_queue.FailedQueueItem(showObj, [segment])
+                cur_failed_queue_item = search_queue.FailedQueueItem(showObj, segment)
                 sickbeard.searchQueueScheduler.action.add_item(cur_failed_queue_item)
 
                 msg += "<li>Season " + str(season) + "</li>"


### PR DESCRIPTION
- Fixes the erroneous use of segment as a list, when it is already a
list of episodes. This causes various errors in debug log complaining
about missing attributes.
