### PR TITLE
Use https://kickass.so/ instead of http://kickass.so/ .

### DIFF
--- a/sickbeard/providers/kat.py
+++ b/sickbeard/providers/kat.py
@@ -55,7 +55,7 @@ class KATProvider(generic.TorrentProvider):
 
         self.cache = KATCache(self)
 
-        self.urls = {'base_url': 'http://kickass.so/'}
+        self.urls = {'base_url': 'https://kickass.so/'}
 
         self.url = self.urls['base_url']
 


### PR DESCRIPTION
Signed-off-by: david <db@d1b.org>