### PR TITLE
Fix case issue for accesstoken

### DIFF
--- a/gui/slick/js/configNotifications.js
+++ b/gui/slick/js/configNotifications.js
@@ -102,7 +102,7 @@ $(document).ready(function(){
         $('#boxcar2_accesstoken').removeClass('warning');
 		$(this).prop('disabled', true);
         $('#testBoxcar2-result').html(loading);
-        $.get(sbRoot + '/home/testBoxcar2', {'accessToken': boxcar2_accesstoken})
+        $.get(sbRoot + '/home/testBoxcar2', {'accesstoken': boxcar2_accesstoken})
             .done(function (data) {
                 $('#testBoxcar2-result').html(data);
                 $('#testBoxcar2').prop('disabled', false);


### PR DESCRIPTION
Fix TypeError: testBoxcar2() got an unexpected keyword argument 'accessToken'