### PR TITLE
Change provider base_url back to official TPB URL

### DIFF
--- a/sickbeard/providers/thepiratebay.py
+++ b/sickbeard/providers/thepiratebay.py
@@ -59,7 +59,7 @@ class ThePirateBayProvider(generic.TorrentProvider):
 
         self.cache = ThePirateBayCache(self)
 
-        self.urls = {'base_url': 'https://oldpiratebay.org/'}
+        self.urls = {'base_url': 'https://thepiratebay.se/'}
 
         self.url = self.urls['base_url']
 


### PR DESCRIPTION
Now that The Pirate Bay is back online, modify the base_url for thepiratebay.py provider to utilize the official pirate bay URL instead of what is current 'oldpiratebay.org'