### PR TITLE
Selected categories in Newznab Providers not getting saved.

### DIFF
--- a/gui/slick/js/configProviders.js
+++ b/gui/slick/js/configProviders.js
@@ -204,7 +204,7 @@ $(document).ready(function(){
                 	$(this).getCategories(isDefault, data);
                 }
                 else {
-                	updateNewznabCaps( null, data );
+                	$(this).updateNewznabCaps( null, data );
                 }
             }
         }


### PR DESCRIPTION
When adding categories other the 5030(SD) or 5040(HD) the new categories are not getting saved.