### PR TITLE
Newznab Categories not beeing saved

### DIFF
--- a/gui/slick/js/configProviders.js
+++ b/gui/slick/js/configProviders.js
@@ -204,7 +204,7 @@ $(document).ready(function(){
                 	$(this).getCategories(isDefault, data);
                 }
                 else {
-                	updateNewznabCaps( null, data );
+                	$(this).updateNewznabCaps( null, data );
                 }
             }
         }


### PR DESCRIPTION
When adding Newznab Categories other than 5030(SD) or 5040(HD), new categories don't get saved.