### PR TITLE
Improve code check for list comprehensions on subtitle

### DIFF
--- a/sickbeard/subtitles.py
+++ b/sickbeard/subtitles.py
@@ -71,7 +71,7 @@ def subtitlesLanguages(video_path):
     subtitles = video.scan()
     languages = set()
     for subtitle in subtitles:
-        if subtitle.language:
+        if subtitle.language and subtitle.language.alpha2:
             languages.add(subtitle.language.alpha2)
         else:
             languages.add(SINGLE)


### PR DESCRIPTION
Related to :
https://github.com/SiCKRAGETV/sickrage-issues/issues/457
This is why we have comma on the database like here ",en". Because alpha2 variable is empty.
Also, they have an error on the display page, this is already PR https://github.com/SiCKRAGETV/SickRage/pull/1260