### PR TITLE
Always sort last by asc name.

### DIFF
--- a/gui/slick/interfaces/default/home.tmpl
+++ b/gui/slick/interfaces/default/home.tmpl
@@ -104,7 +104,8 @@
             filter_columnFilters: false,
 			filter_reset: '.resetshows'
 		},
-        sortStable: true
+        sortStable: true,
+        sortAppend: [[1,0]]
     });
 	
 	\$("#showListTableAnime:has(tbody tr)").tablesorter({
@@ -126,7 +127,8 @@
             filter_columnFilters: false,
 			filter_reset: '.resetanime'
 		},
-        sortStable: true
+        sortStable: true,
+        sortAppend: [[1,0]]
     });
 
 	\$.tablesorter.filter.bindSearch( "#showListTableShows", \$('.search') );


### PR DESCRIPTION
Added sortAppend in the home.tmpl table to always sort by name asc
after selecting an other column.
See SiCKRAGETV/sickrage-issues#51 for more info