### PR TITLE
Fix issues with newznab provider

### DIFF
--- a/sickbeard/providers/newznab.py
+++ b/sickbeard/providers/newznab.py
@@ -360,16 +360,16 @@ class NewznabProvider(generic.NZBProvider):
 
                 try:
                     result_date = datetime.datetime(*item['published_parsed'][0:6])
-                except AttributeError:
+                except (AttributeError, KeyError):
                     try:
                         result_date = datetime.datetime(*item['updated_parsed'][0:6])
-                    except AttributeError:
+                    except (AttributeError, KeyError):
                         try:
                             result_date = datetime.datetime(*item['created_parsed'][0:6])
-                        except AttributeError:
+                        except (AttributeError, KeyError):
                             try:
                                 result_date = datetime.datetime(*item['date'][0:6])
-                            except AttributeError:
+                            except (AttributeError, KeyError):
                                 logger.log(u"Unable to figure out the date for entry " + title + ", skipping it")
                                 continue
 

--- a/sickbeard/search.py
+++ b/sickbeard/search.py
@@ -242,10 +242,11 @@ def pickBestResult(results, show, quality_list=None):
                        logger.INFO)
             continue
 
-        if sickbeard.USE_FAILED_DOWNLOADS and failed_history.hasFailed(cur_result.name, cur_result.size,
-                                                                       cur_result.provider.name):
-            logger.log(cur_result.name + u" has previously failed, rejecting it")
-            continue
+        if hasattr(cur_result, 'size'):
+            if sickbeard.USE_FAILED_DOWNLOADS and failed_history.hasFailed(cur_result.name, cur_result.size,
+                                                                           cur_result.provider.name):
+                logger.log(cur_result.name + u" has previously failed, rejecting it")
+                continue
 
         if not bestResult or bestResult.quality < cur_result.quality and cur_result.quality != Quality.UNKNOWN:
             bestResult = cur_result


### PR DESCRIPTION
Some newznab feed don't return a date when the proper is a movie resulting in a KeyError.
When findpropper call pickBestResult the instance provided as no attribute
'size'. Added a check.