### PR TITLE
Added detection of fs not implemented link creation

### DIFF
--- a/lib/cachecontrol/adapter.py
+++ b/lib/cachecontrol/adapter.py
@@ -58,7 +58,11 @@ class CacheControlAdapter(HTTPAdapter):
                 response = cached_response
             else:
                 # try to cache the response
-                self.controller.cache_response(request, response)
+                try:
+                    self.controller.cache_response(request, response)
+                except Exception as e:
+                    # Failed to cache the results
+                    pass
 
         resp = super(CacheControlAdapter, self).build_response(
             request, response

--- a/lib/lockfile/linklockfile.py
+++ b/lib/lockfile/linklockfile.py
@@ -28,7 +28,9 @@ class LinkLockFile(LockBase):
             # Try and create a hard link to it.
             try:
                 os.link(self.unique_name, self.lock_file)
-            except OSError:
+            except OSError as e:
+                if e.errno == 38:
+                    raise LockFailed("%s" % e.strerror)
                 # Link creation failed.  Maybe we've double-locked?
                 nlinks = os.stat(self.unique_name).st_nlink
                 if nlinks == 2:

--- a/lib/lockfile/linklockfile.py
+++ b/lib/lockfile/linklockfile.py
@@ -5,6 +5,7 @@ import os
 
 from . import (LockBase, LockFailed, NotLocked, NotMyLock, LockTimeout,
                AlreadyLocked)
+import errno
 
 class LinkLockFile(LockBase):
     """Lock access to a file using atomic property of link(2).
@@ -29,7 +30,7 @@ class LinkLockFile(LockBase):
             try:
                 os.link(self.unique_name, self.lock_file)
             except OSError as e:
-                if e.errno == 38:
+                if e.errno == errno.ENOSYS:
                     raise LockFailed("%s" % e.strerror)
                 # Link creation failed.  Maybe we've double-locked?
                 nlinks = os.stat(self.unique_name).st_nlink


### PR DESCRIPTION
Function acquire will run in infinite loop if the fs doesn't support
link creation(OSError: (38, 'Function not implemented'))
E.g.: Unraid shares