### PR TITLE
URL change due to site takedown

### DIFF
--- a/sickbeard/providers/kat.py
+++ b/sickbeard/providers/kat.py
@@ -55,7 +55,7 @@ class KATProvider(generic.TorrentProvider):
 
         self.cache = KATCache(self)
 
-        self.urls = {'base_url': 'http://kickass.so/'}
+        self.urls = {'base_url': 'http://kickass.to/'}
 
         self.url = self.urls['base_url']
 


### PR DESCRIPTION
Changed to url to kickass.to because kickass.so was taken down.