### PR TITLE
Added new regex 'itunes'

### DIFF
--- a/sickbeard/name_parser/regexes.py
+++ b/sickbeard/name_parser/regexes.py
@@ -186,6 +186,20 @@ normal_regexes = [
      '''
     ),
 
+    ('itunes',
+     # Show Name - 01 - Ep Name
+     # 01 - Ep Name
+     # 01 - Ep Name
+     '''
+     ^((?P<series_name>.+?)(?:[. _-]{2,}|[. _]))?    # Show_Name and separator
+     (?P<ep_num>\d{1,3})                             # 02
+     (?:-(?P<extra_ep_num>\d{1,3}))*                 # -03-04-05 etc
+     [. _-]+((?P<extra_info>.+?)                     # Source_Quality_Etc-
+     ((?<![. _-])(?<!WEB)                            # Make sure this is really the release group
+     -(?P<release_group>[^- ]+([. _-]\[.*\])?))?)?$  # Group
+     '''
+    ),
+
     ('bare',
      # Show.Name.102.Source.Quality.Etc-Group
      '''


### PR DESCRIPTION
Almost identical to no_season regex but omitted the "of joiner line" to make sure that iTunes maintained TV Show folders can still be scanned.