### PR TITLE
Updated to new domain of Kickasstorrent

### DIFF
--- a/sickbeard/providers/kat.py
+++ b/sickbeard/providers/kat.py
@@ -55,7 +55,7 @@ class KATProvider(generic.TorrentProvider):
 
         self.cache = KATCache(self)
 
-        self.urls = {'base_url': 'http://kickass.so/'}
+        self.urls = {'base_url': 'http://kickass.to/'}
 
         self.url = self.urls['base_url']
 


### PR DESCRIPTION
Already tried and it is working. The domain kickass.so is deprecated. Updated to the working one.