### PR TITLE
Temporary fix for Python 2.7.9 for SSL

### DIFF
--- a/SickBeard.py
+++ b/SickBeard.py
@@ -50,6 +50,10 @@ sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), 'lib'
 if sys.hexversion >= 0x020600F0:
     from multiprocessing import freeze_support  # @UnresolvedImport
 
+if sys.version_info >= (2, 7, 9):
+    import ssl
+    ssl._create_default_https_context = ssl._create_unverified_context
+
 import locale
 import datetime
 import threading


### PR DESCRIPTION
See https://www.python.org/dev/peps/pep-0476/ for more info.