### PR TITLE
Update piratebay url to current

### DIFF
--- a/sickbeard/providers/thepiratebay.py
+++ b/sickbeard/providers/thepiratebay.py
@@ -59,7 +59,7 @@ class ThePirateBayProvider(generic.TorrentProvider):
 
         self.cache = ThePirateBayCache(self)
 
-        self.urls = {'base_url': 'https://oldpiratebay.org/'}
+        self.urls = {'base_url': 'http://thepiratebay.org/'}
 
         self.url = self.urls['base_url']
 


### PR DESCRIPTION
Oldpiratebay.org is a few days behind on new show releases, claims there's nothing to download.   Once changing to original URL things seem to work just fine.  Please review. :)