### PR TITLE
Fix progress bar vanishing when shows table empty.

### DIFF
--- a/gui/slick/interfaces/default/home.tmpl
+++ b/gui/slick/interfaces/default/home.tmpl
@@ -129,10 +129,12 @@
         sortStable: true
     });
 
-	\$.tablesorter.filter.bindSearch( "#showListTableShows", \$('.search') );
+	if (\$("#showListTableShows").find("tbody").find("tr").size() > 0)
+		\$.tablesorter.filter.bindSearch( "#showListTableShows", \$('.search') );
 	
 	#if $sickbeard.ANIME_SPLIT_HOME:
-	\$.tablesorter.filter.bindSearch( "#showListTableAnime", \$('.search') );
+		if (\$("#showListTableAnime").find("tbody").find("tr").size() > 0)
+			\$.tablesorter.filter.bindSearch( "#showListTableAnime", \$('.search') );
 	#end if
 	
     #set $fuzzydate = 'airdate'


### PR DESCRIPTION
Exception in tablesorter.bindsearch when table empty.

See SiCKRAGETV/sickrage-issues#7 for more info.