### PR TITLE
Added Hidden Folder check for Windows Attributes

### DIFF
--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -19,6 +19,7 @@
 from __future__ import with_statement
 
 import os
+import ctypes
 import random
 import re
 import shutil
@@ -943,8 +944,21 @@ def is_hidden_folder(folder):
     On Linux based systems hidden folders start with . (dot)
     folder: Full path of folder to check
     """
+    def is_hidden(filepath):
+        name = os.path.basename(os.path.abspath(filepath))
+        return name.startswith('.') or has_hidden_attribute(filepath)
+
+    def has_hidden_attribute(filepath):
+        try:
+            attrs = ctypes.windll.kernel32.GetFileAttributesW(unicode(filepath))
+            assert attrs != -1
+            result = bool(attrs & 2)
+        except (AttributeError, AssertionError):
+            result = False
+        return result
+    
     if ek.ek(os.path.isdir, folder):
-        if ek.ek(os.path.basename, folder).startswith('.'):
+        if is_hidden(folder):
             return True
 
     return False

--- a/sickbeard/processTV.py
+++ b/sickbeard/processTV.py
@@ -251,7 +251,7 @@ def validateDir(path, dirName, nzbNameOriginal, failed, result):
         process_failed(os.path.join(path, dirName), nzbNameOriginal, result)
         return False
 
-    if helpers.is_hidden_folder(dirName):
+    if helpers.is_hidden_folder(os.path.join(path, dirName)):
         result.output += logHelper(u"Ignoring hidden folder: " + dirName, logger.DEBUG)
         return False
 


### PR DESCRIPTION
- Changed helpers.is_hidden_folder to utilize Windows GetAttributesW DLL
function to get folder attributes.
- Changed call to is_hidden_folder to use the entire path for the call,
instead of just the foldername.

Fixes https://github.com/SiCKRAGETV/sickrage-issues/issues/554