### PR TITLE
Add option to delete RAR contents when Process_method != Move

### DIFF
--- a/gui/slick/interfaces/default/config_postProcessing.tmpl
+++ b/gui/slick/interfaces/default/config_postProcessing.tmpl
@@ -84,6 +84,13 @@
                             </label>
                         </div>
                         <div class="field-pair">
+                            <input type="checkbox" name="del_rar_contents" id="del_rar_contents" #if $sickbeard.DELRARCONTENTS == True then "checked=\"checked\"" else ""# />
+                            <label for="del_rar_contents">
+                                <span class="component-title">Delete RAR contents</span>
+                                <span class="component-desc">Delete content of RAR files, even if Process Method not set to move?</span>
+                            </label>	
+                        </div>
+                        <div class="field-pair">
                             <input type="checkbox" name="skip_removed_files" id="skip_removed_files" #if $sickbeard.SKIP_REMOVED_FILES == True then "checked=\"checked\"" else ""# />
                             <label for="skip_removed_files">
                                 <span class="component-title">Skip Remove Detection</span>

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -241,6 +241,7 @@ AIRDATE_EPISODES = False
 PROCESS_AUTOMATICALLY = False
 KEEP_PROCESSED_DIR = False
 PROCESS_METHOD = None
+DELRARCONTENTS = False
 MOVE_ASSOCIATED_FILES = False
 POSTPONE_IF_SYNC_FILES = True
 NFO_RENAME = True
@@ -519,7 +520,7 @@ def initialize(consoleLogging=True):
             USE_PUSHALOT, PUSHALOT_NOTIFY_ONSNATCH, PUSHALOT_NOTIFY_ONDOWNLOAD, PUSHALOT_NOTIFY_ONSUBTITLEDOWNLOAD, PUSHALOT_AUTHORIZATIONTOKEN, \
             USE_PUSHBULLET, PUSHBULLET_NOTIFY_ONSNATCH, PUSHBULLET_NOTIFY_ONDOWNLOAD, PUSHBULLET_NOTIFY_ONSUBTITLEDOWNLOAD, PUSHBULLET_API, PUSHBULLET_DEVICE, \
             versionCheckScheduler, VERSION_NOTIFY, AUTO_UPDATE, NOTIFY_ON_UPDATE, PROCESS_AUTOMATICALLY, UNPACK, CPU_PRESET, \
-            KEEP_PROCESSED_DIR, PROCESS_METHOD, TV_DOWNLOAD_DIR, MIN_DAILYSEARCH_FREQUENCY, DEFAULT_UPDATE_FREQUENCY, MIN_UPDATE_FREQUENCY, UPDATE_FREQUENCY, \
+            KEEP_PROCESSED_DIR, PROCESS_METHOD, DELRARCONTENTS, TV_DOWNLOAD_DIR, MIN_DAILYSEARCH_FREQUENCY, DEFAULT_UPDATE_FREQUENCY, MIN_UPDATE_FREQUENCY, UPDATE_FREQUENCY, \
             showQueueScheduler, searchQueueScheduler, ROOT_DIRS, CACHE_DIR, ACTUAL_CACHE_DIR, TIMEZONE_DISPLAY, \
             NAMING_PATTERN, NAMING_MULTI_EP, NAMING_ANIME_MULTI_EP, NAMING_FORCE_FOLDERS, NAMING_ABD_PATTERN, NAMING_CUSTOM_ABD, NAMING_SPORTS_PATTERN, NAMING_CUSTOM_SPORTS, NAMING_ANIME_PATTERN, NAMING_CUSTOM_ANIME, NAMING_STRIP_YEAR, \
             RENAME_EPISODES, AIRDATE_EPISODES, properFinderScheduler, PROVIDER_ORDER, autoPostProcesserScheduler, \
@@ -776,6 +777,7 @@ def initialize(consoleLogging=True):
         AIRDATE_EPISODES = bool(check_setting_int(CFG, 'General', 'airdate_episodes', 0))
         KEEP_PROCESSED_DIR = bool(check_setting_int(CFG, 'General', 'keep_processed_dir', 1))
         PROCESS_METHOD = check_setting_str(CFG, 'General', 'process_method', 'copy' if KEEP_PROCESSED_DIR else 'move')
+        DELRARCONTENTS = bool(check_setting_int(CFG, 'General', 'del_rar_contents', 0))
         MOVE_ASSOCIATED_FILES = bool(check_setting_int(CFG, 'General', 'move_associated_files', 0))
         POSTPONE_IF_SYNC_FILES = bool(check_setting_int(CFG, 'General', 'postpone_if_sync_files', 1))
         NFO_RENAME = bool(check_setting_int(CFG, 'General', 'nfo_rename', 1))
@@ -1537,6 +1539,7 @@ def save_config():
     new_config['General']['tv_download_dir'] = TV_DOWNLOAD_DIR
     new_config['General']['keep_processed_dir'] = int(KEEP_PROCESSED_DIR)
     new_config['General']['process_method'] = PROCESS_METHOD
+    new_config['General']['del_rar_contents'] = int(DELRARCONTENTS)
     new_config['General']['move_associated_files'] = int(MOVE_ASSOCIATED_FILES)
     new_config['General']['postpone_if_sync_files'] = int(POSTPONE_IF_SYNC_FILES)
     new_config['General']['nfo_rename'] = int(NFO_RENAME)

--- a/sickbeard/processTV.py
+++ b/sickbeard/processTV.py
@@ -176,6 +176,11 @@ def processDir(dirName, nzbName=None, process_method=None, force=False, is_prior
         delete_files(path, rarContent, result)
         for video in set(videoFiles) - set(videoInRar):
             result.result = process_media(path, [video], nzbName, process_method, force, is_priority, result)
+    elif sickbeard.DELRARCONTENTS and videoInRar:
+        result.result = process_media(path, videoInRar, nzbName, process_method, force, is_priority, result)
+        delete_files(path, rarContent, result)
+        for video in set(videoFiles) - set(videoInRar):
+            result.result = process_media(path, [video], nzbName, process_method, force, is_priority, result)
     else:
         for video in videoFiles:
             result.result = process_media(path, [video], nzbName, process_method, force, is_priority, result)
@@ -204,6 +209,11 @@ def processDir(dirName, nzbName=None, process_method=None, force=False, is_prior
             #Don't Link media when the media is extracted from a rar in the same path
             if process_method in ('hardlink', 'symlink') and videoInRar:
                 process_media(processPath, videoInRar, nzbName, 'move', force, is_priority, result)
+                process_media(processPath, set(videoFiles) - set(videoInRar), nzbName, process_method, force,
+                              is_priority, result)
+                delete_files(processPath, rarContent, result)
+            elif sickbeard.DELRARCONTENTS and videoInRar:
+                process_media(processPath, videoInRar, nzbName, process_method, force, is_priority, result)
                 process_media(processPath, set(videoFiles) - set(videoInRar), nzbName, process_method, force,
                               is_priority, result)
                 delete_files(processPath, rarContent, result)

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -3745,7 +3745,7 @@ class ConfigPostProcessing(Config):
     def savePostProcessing(self, naming_pattern=None, naming_multi_ep=None,
                            kodi_data=None, kodi_12plus_data=None, mediabrowser_data=None, sony_ps3_data=None,
                            wdtv_data=None, tivo_data=None, mede8er_data=None,
-                           keep_processed_dir=None, process_method=None, process_automatically=None,
+                           keep_processed_dir=None, process_method=None, del_rar_contents=None, process_automatically=None,
                            rename_episodes=None, airdate_episodes=None, unpack=None,
                            move_associated_files=None, postpone_if_sync_files=None, nfo_rename=None,
                            tv_download_dir=None, naming_custom_abd=None,
@@ -3789,6 +3789,7 @@ class ConfigPostProcessing(Config):
 
         sickbeard.KEEP_PROCESSED_DIR = config.checkbox_to_value(keep_processed_dir)
         sickbeard.PROCESS_METHOD = process_method
+        sickbeard.DELRARCONTENTS = config.checkbox_to_value(del_rar_contents)
         sickbeard.EXTRA_SCRIPTS = [x.strip() for x in extra_scripts.split('|') if x.strip()]
         sickbeard.RENAME_EPISODES = config.checkbox_to_value(rename_episodes)
         sickbeard.AIRDATE_EPISODES = config.checkbox_to_value(airdate_episodes)


### PR DESCRIPTION
- Adds option to delete RAR contents to Config -> Post-Processing
- Added check to ProcessTV to delete Rarcontents when Process_Method !=
Move

Implements feature requested here:
https://github.com/SiCKRAGETV/sickrage-issues/issues/539