### PR TITLE
Torrentrss custom title tag

### DIFF
--- a/gui/slick/interfaces/default/config_providers.tmpl
+++ b/gui/slick/interfaces/default/config_providers.tmpl
@@ -37,7 +37,7 @@ var show_nzb_providers = #if $sickbeard.USE_NZBS then "true" else "false"#;
 <!--
 \$(document).ready(function(){
 #for $curTorrentRssProvider in $sickbeard.torrentRssProviderList:
-    \$(this).addTorrentRssProvider('$curTorrentRssProvider.getID()', '$curTorrentRssProvider.name', '$curTorrentRssProvider.url', '$curTorrentRssProvider.cookies');
+    \$(this).addTorrentRssProvider('$curTorrentRssProvider.getID()', '$curTorrentRssProvider.name', '$curTorrentRssProvider.url', '$curTorrentRssProvider.cookies', '$curTorrentRssProvider.titleTAG');
 #end for
 });
 //-->
@@ -688,7 +688,16 @@ var show_nzb_providers = #if $sickbeard.USE_NZBS then "true" else "false"#;
                                 <span class="component-desc">eg. uid=xx;pass=yy</span>
                             </label>
                         </div>
-                        
+                        <div class="field-pair">
+                            <label for="torrentrss_titleTAG">
+                                <span class="component-title">Title tag</span>
+                                <input type="text" id="torrentrss_titleTAG" class="form-control input-sm input200" />
+                            </label>
+                            <label>
+                                <span class="component-title">&nbsp;</span>
+                                <span class="component-desc">default: 'title'</span>
+                            </label>
+                        </div>
                         <div id="torrentrss_add_div">
                             <input type="button" class="btn torrentrss_save" id="torrentrss_add" value="Add" />
                         </div>

--- a/gui/slick/interfaces/default/config_providers.tmpl
+++ b/gui/slick/interfaces/default/config_providers.tmpl
@@ -690,7 +690,7 @@ var show_nzb_providers = #if $sickbeard.USE_NZBS then "true" else "false"#;
                         </div>
                         <div class="field-pair">
                             <label for="torrentrss_titleTAG">
-                                <span class="component-title">Title tag</span>
+                                <span class="component-title">custom Title tag:</span>
                                 <input type="text" id="torrentrss_titleTAG" class="form-control input-sm input200" />
                             </label>
                             <label>

--- a/gui/slick/js/configProviders.js
+++ b/gui/slick/js/configProviders.js
@@ -80,9 +80,9 @@ $(document).ready(function(){
 
     }
 
-    $.fn.addTorrentRssProvider = function (id, name, url, cookies) {
+    $.fn.addTorrentRssProvider = function (id, name, url, cookies, titleTAG) {
 
-        var newData = [name, url, cookies];
+        var newData = [name, url, cookies, titleTAG];
         torrentRssProviders[id] = newData;
 
         $('#editATorrentRssProvider').addOption(id, name);
@@ -122,9 +122,10 @@ $(document).ready(function(){
 
     }
 
-    $.fn.updateTorrentRssProvider = function (id, url, cookies) {
+    $.fn.updateTorrentRssProvider = function (id, url, cookies, titleTAG) {
         torrentRssProviders[id][1] = url;
         torrentRssProviders[id][2] = cookies;
+        torrentRssProviders[id][3] = titleTAG;
         $(this).populateTorrentRssSection();
         $(this).makeTorrentRssProviderString();
     }
@@ -277,7 +278,7 @@ $(document).ready(function(){
         var selectedProvider = $('#editATorrentRssProvider :selected').val();
 
         if (selectedProvider == 'addTorrentRss') {
-            var data = ['','',''];
+            var data = ['','','',''];
             $('#torrentrss_add_div').show();
             $('#torrentrss_update_div').hide();
         } else {
@@ -289,15 +290,18 @@ $(document).ready(function(){
         $('#torrentrss_name').val(data[0]);
         $('#torrentrss_url').val(data[1]);
         $('#torrentrss_cookies').val(data[2]);
+        $('#torrentrss_titleTAG').val(data[3]);
 
         if (selectedProvider == 'addTorrentRss') {
             $('#torrentrss_name').removeAttr("disabled");
             $('#torrentrss_url').removeAttr("disabled");
             $('#torrentrss_cookies').removeAttr("disabled");
+            $('#torrentrss_titleTAG').removeAttr("disabled");
         } else {
             $('#torrentrss_name').attr("disabled", "disabled");
             $('#torrentrss_url').removeAttr("disabled");
             $('#torrentrss_cookies').removeAttr("disabled");
+            $('#torrentrss_titleTAG').removeAttr("disabled");
             $('#torrentrss_delete').removeAttr("disabled");
         }
 
@@ -386,7 +390,7 @@ $(document).ready(function(){
 
     });
 
-    $('#torrentrss_url,#torrentrss_cookies').change(function(){
+    $('#torrentrss_url,#torrentrss_cookies,#torrentrss_titleTAG').change(function(){
 
         var selectedProvider = $('#editATorrentRssProvider :selected').val();
 
@@ -395,8 +399,9 @@ $(document).ready(function(){
 
         var url = $('#torrentrss_url').val();
         var cookies = $('#torrentrss_cookies').val();
+        var titleTAG = $('#torrentrss_titleTAG').val();
 
-        $(this).updateTorrentRssProvider(selectedProvider, url, cookies);
+        $(this).updateTorrentRssProvider(selectedProvider, url, cookies, titleTAG);
     });
 
     $('body').on('change', '#editAProvider',function(){
@@ -504,7 +509,8 @@ $(document).ready(function(){
         var name = $('#torrentrss_name').val();
         var url = $('#torrentrss_url').val();
         var cookies = $('#torrentrss_cookies').val();
-        var params = { name: name, url: url, cookies: cookies}
+        var titleTAG = $('#torrentrss_titleTAG').val();
+        var params = { name: name, url: url, cookies: cookies, titleTAG: titleTAG}
 
         // send to the form with ajax, get a return value
         $.getJSON(sbRoot + '/config/providers/canAddTorrentRssProvider', params,
@@ -514,7 +520,7 @@ $(document).ready(function(){
                     return;
                 }
 
-                $(this).addTorrentRssProvider(data.success, name, url, cookies);
+                $(this).addTorrentRssProvider(data.success, name, url, cookies, titleTAG);
                 $(this).refreshEditAProvider();
         });
     });

--- a/sickbeard/providers/__init__.py
+++ b/sickbeard/providers/__init__.py
@@ -167,6 +167,7 @@ def makeTorrentRssProvider(configString):
         return None
 
     cookies = None
+    titleTAG = 'title'
     search_mode = 'eponly'
     search_fallback = 0
     enable_daily = 0
@@ -174,12 +175,14 @@ def makeTorrentRssProvider(configString):
 
     try:
         values = configString.split('|')
-        if len(values) == 8:
+        if len(values) == 9:
+            name, url, cookies, titleTAG, enabled, search_mode, search_fallback, enable_daily, enable_backlog = values
+        elif len(values) == 8:
             name, url, cookies, enabled, search_mode, search_fallback, enable_daily, enable_backlog = values
         else:
             name = values[0]
             url = values[1]
-            enabled = values[3]
+            enabled = values[4]
     except ValueError:
         logger.log(u"Skipping RSS Torrent provider string: '" + configString + "', incorrect format",
                    logger.ERROR)
@@ -190,7 +193,7 @@ def makeTorrentRssProvider(configString):
     except:
         return
 
-    newProvider = torrentRss.TorrentRssProvider(name, url, cookies, search_mode, search_fallback, enable_daily,
+    newProvider = torrentRss.TorrentRssProvider(name, url, cookies, titleTAG, search_mode, search_fallback, enable_daily,
                                                 enable_backlog)
     newProvider.enabled = enabled == '1'
 

--- a/sickbeard/providers/rsstorrent.py
+++ b/sickbeard/providers/rsstorrent.py
@@ -76,7 +76,7 @@ class TorrentRssProvider(generic.TorrentProvider):
 
     def _get_title_and_url(self, item):
 
-        title = item.get(titleTAG)
+        title = item.get(self.titleTAG)
         if title:
             title = u'' + title
             title = title.replace(' ', '.')

--- a/sickbeard/providers/rsstorrent.py
+++ b/sickbeard/providers/rsstorrent.py
@@ -33,7 +33,7 @@ from lib.bencode import bdecode
 
 
 class TorrentRssProvider(generic.TorrentProvider):
-    def __init__(self, name, url, cookies='', search_mode='eponly', search_fallback=False, enable_daily=False,
+    def __init__(self, name, url, cookies='', titleTAG='title', search_mode='eponly', search_fallback=False, enable_daily=False,
                  enable_backlog=False):
         generic.TorrentProvider.__init__(self, name)
         self.cache = TorrentRssCache(self)
@@ -51,11 +51,13 @@ class TorrentRssProvider(generic.TorrentProvider):
         self.enable_daily = enable_daily
         self.enable_backlog = enable_backlog
         self.cookies = cookies
+        self.titleTAG = titleTAG
 
     def configStr(self):
-        return "%s|%s|%s|%d|%s|%d|%d|%d" % (self.name or '',
+        return "%s|%s|%s|%s|%d|%s|%d|%d|%d" % (self.name or '',
                                             self.url or '',
                                             self.cookies or '',
+                                            self.titleTAG or '',
                                             self.enabled,
                                             self.search_mode or '',
                                             self.search_fallback,
@@ -74,7 +76,7 @@ class TorrentRssProvider(generic.TorrentProvider):
 
     def _get_title_and_url(self, item):
 
-        title = item.get('title')
+        title = item.get(titleTAG)
         if title:
             title = u'' + title
             title = title.replace(' ', '.')

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -4189,7 +4189,7 @@ class ConfigProviders(Config):
         return '1'
 
 
-    def canAddTorrentRssProvider(self, name, url, cookies):
+    def canAddTorrentRssProvider(self, name, url, cookies, titleTAG):
 
         if not name:
             return json.dumps({'error': 'Invalid name specified'})
@@ -4197,7 +4197,7 @@ class ConfigProviders(Config):
         providerDict = dict(
             zip([x.getID() for x in sickbeard.torrentRssProviderList], sickbeard.torrentRssProviderList))
 
-        tempProvider = rsstorrent.TorrentRssProvider(name, url, cookies)
+        tempProvider = rsstorrent.TorrentRssProvider(name, url, cookies, titleTAG)
 
         if tempProvider.getID() in providerDict:
             return json.dumps({'error': 'Exists as ' + providerDict[tempProvider.getID()].name})
@@ -4209,7 +4209,7 @@ class ConfigProviders(Config):
                 return json.dumps({'error': errMsg})
 
 
-    def saveTorrentRssProvider(self, name, url, cookies):
+    def saveTorrentRssProvider(self, name, url, cookies, titleTAG):
 
         if not name or not url:
             return '0'
@@ -4220,11 +4220,12 @@ class ConfigProviders(Config):
             providerDict[name].name = name
             providerDict[name].url = config.clean_url(url)
             providerDict[name].cookies = cookies
+            providerDict[name].titleTAG = titleTAG
 
             return providerDict[name].getID() + '|' + providerDict[name].configStr()
 
         else:
-            newProvider = rsstorrent.TorrentRssProvider(name, url, cookies)
+            newProvider = rsstorrent.TorrentRssProvider(name, url, cookies, titleTAG)
             sickbeard.torrentRssProviderList.append(newProvider)
             return newProvider.getID() + '|' + newProvider.configStr()
 
@@ -4326,10 +4327,10 @@ class ConfigProviders(Config):
                 if not curTorrentRssProviderStr:
                     continue
 
-                curName, curURL, curCookies = curTorrentRssProviderStr.split('|')
+                curName, curURL, curCookies, curTitleTAG = curTorrentRssProviderStr.split('|')
                 curURL = config.clean_url(curURL)
 
-                newProvider = rsstorrent.TorrentRssProvider(curName, curURL, curCookies)
+                newProvider = rsstorrent.TorrentRssProvider(curName, curURL, curCookies, curTitleTAG)
 
                 curID = newProvider.getID()
 
@@ -4338,6 +4339,7 @@ class ConfigProviders(Config):
                     torrentRssProviderDict[curID].name = curName
                     torrentRssProviderDict[curID].url = curURL
                     torrentRssProviderDict[curID].cookies = curCookies
+                    torrentRssProviderDict[curID].curTitleTAG = curTitleTAG
                 else:
                     sickbeard.torrentRssProviderList.append(newProvider)
 


### PR DESCRIPTION
I have created a field to the torrent rss providers config so that a custom title tag can be used instead of just the text 'title' it was tested and working with 'http://showrss.info/feeds/all.rss' using 'showrss_rawtitle'. Hopefully the label and description are good, let me know if you think it should automatically replace ':' with '_'  and if '<' & '>' should be striped if it was put in the text box.
This feature was requested https://github.com/SiCKRAGETV/sickrage-issues/issues/607