### PR TITLE
Fix for RARBG provider

### DIFF
--- a/sickbeard/providers/rarbg.py
+++ b/sickbeard/providers/rarbg.py
@@ -198,7 +198,7 @@ class RarbgProvider(generic.TorrentProvider):
                                         torrent_name = str(torrentName)
                                         torrentId = result.find_all('td')[1].find_all('a')[0]['href'][1:].replace(
                                             'torrent/', '')
-                                        torrent_download_url = (self.urls['download'] % (torrentId, torrent_name + '-[rarbg.com].torrent')).encode('utf8')
+                                        torrent_download_url = (self.urls['download'] % (torrentId, urllib.quote(torrent_name) + '-[rarbg.com].torrent')).encode('utf8')
                                     except (AttributeError, TypeError):
                                         continue
 


### PR DESCRIPTION
Manage the case where the torrent name got spaces in it

(Thanks @fernandog for noticing it)