### PR TITLE
TPB: Suppressed torrent list not found error message

### DIFF
--- a/sickbeard/providers/thepiratebay.py
+++ b/sickbeard/providers/thepiratebay.py
@@ -122,7 +122,9 @@ class ThePirateBayProvider(generic.TorrentProvider):
         filesList = re.findall('<td.+>(.*?)</td>', data)
 
         if not filesList:
-            logger.log(u"Unable to get the torrent file list for " + title, logger.ERROR)
+            # disabled errormsg for now
+            # logger.log(u"Unable to get the torrent file list for " + title, logger.ERROR)
+            return None
 
         videoFiles = filter(lambda x: x.rpartition(".")[2].lower() in mediaExtensions, filesList)
 


### PR DESCRIPTION
TPB's ajax_details_filelist.php call seems to only return 
> File list not available. 

so season search mode will not work using TPB at this moment.
I suppressed the error message as it's annoying (see SiCKRAGETV/sickrage-issues#631 and SiCKRAGETV/sickrage-issues#641) and also added a missing `return None` when the file list cannot be retrieved (so always atm.)