### PR TITLE
Remove torrent file after download

### DIFF
--- a/sickbeard/clients/generic.py
+++ b/sickbeard/clients/generic.py
@@ -153,6 +153,13 @@ class GenericClient(object):
 
         return result
 
+    def remove_torrent_downloaded(self,hash):
+        """
+        This should be overridden should return the True/False from the client
+        when a torrent is set with pause
+        """
+        return True
+
     def sendTORRENT(self, result):
 
         r_code = False

--- a/sickbeard/clients/transmission.py
+++ b/sickbeard/clients/transmission.py
@@ -155,5 +155,16 @@ class TransmissionAPI(GenericClient):
 
         return self.response.json()['result'] == "success"
 
+    def remove_torrent_downloaded(self,hash):
+
+        arguments = { 'ids': [hash]
+                      }
+        post_data = json.dumps({'arguments': arguments,
+                                'method': 'torrent-remove',
+                                })
+        self._request(method='post', data=post_data)
+
+        return self.response.json()['result'] == "success"
+
 
 api = TransmissionAPI()

--- a/sickbeard/databases/mainDB.py
+++ b/sickbeard/databases/mainDB.py
@@ -27,7 +27,7 @@ from sickbeard import encodingKludge as ek
 from sickbeard.name_parser.parser import NameParser, InvalidNameException, InvalidShowException
 
 MIN_DB_VERSION = 9  # oldest db version we support migrating from
-MAX_DB_VERSION = 42
+MAX_DB_VERSION = 43
 
 class MainSanityCheck(db.DBSanityCheck):
     def check(self):
@@ -972,5 +972,20 @@ class AlterTVShowsFieldTypes(AddDefaultEpStatusToTvShows):
         self.connection.action("CREATE TABLE tv_shows (show_id INTEGER PRIMARY KEY, indexer_id NUMERIC, indexer NUMERIC, show_name TEXT, location TEXT, network TEXT, genre TEXT, classification TEXT, runtime NUMERIC, quality NUMERIC, airs TEXT, status TEXT, flatten_folders NUMERIC, paused NUMERIC, startyear NUMERIC, air_by_date NUMERIC, lang TEXT, subtitles NUMERIC, notify_list TEXT, imdb_id TEXT, last_update_indexer NUMERIC, dvdorder NUMERIC, archive_firstmatch NUMERIC, rls_require_words TEXT, rls_ignore_words TEXT, sports NUMERIC, anime NUMERIC, scene NUMERIC, default_ep_status NUMERIC)")
         self.connection.action("INSERT INTO tv_shows SELECT * FROM tmp_tv_shows")
         self.connection.action("DROP TABLE tmp_tv_shows")
+
+        self.incDBVersion()
+
+class AddTorrentHash(AlterTVShowsFieldTypes):
+    """ Adding column torrent_hash to tv_episodes for removing torrent instance after donwloading it """
+
+    def test(self):
+        return self.checkDBVersion() >= 43
+
+    def execute(self):
+        backupDatabase(self.checkDBVersion())
+
+        logger.log(u"Adding column torrent_hash in tv_episodes")
+        if not self.hasColumn("tv_episodes", "torrent_hash"):
+            self.addColumn("tv_episodes", "torrent_hash", 'TEXT', None)
 
         self.incDBVersion()

--- a/sickbeard/postProcessor.py
+++ b/sickbeard/postProcessor.py
@@ -28,6 +28,7 @@ import stat
 import sickbeard
 
 from sickbeard import db
+from sickbeard import clients
 from sickbeard import common
 from sickbeard import exceptions
 from sickbeard import helpers
@@ -901,6 +902,15 @@ class PostProcessor(object):
                     cur_ep.release_name = self.release_name
                 else:
                     cur_ep.release_name = ""
+
+                if cur_ep.torrent_hash != '':
+                    client = clients.getClientIstance(sickbeard.TORRENT_METHOD)()
+                    torrent_removed = client.remove_torrent_downloaded(cur_ep.torrent_hash)
+                    if torrent_removed:
+                        logger.log("Torrent removed correctly", logger.DEBUG)
+                    else:
+                        self._log(u"Error removing torrent from client, ids: " + cur_ep.torrent_hash, logger.ERROR)
+                    cur_ep.torrent_hash = ''
 
                 if ep_obj.status in common.Quality.SNATCHED_BEST:
                     cur_ep.status = common.Quality.compositeStatus(common.ARCHIVED, new_ep_quality)

--- a/sickbeard/search.py
+++ b/sickbeard/search.py
@@ -132,6 +132,7 @@ def snatchEpisode(result, endStatus=SNATCHED):
         else:
             #result.content = result.provider.getURL(result.url) if not result.url.startswith('magnet') else None
             client = clients.getClientIstance(sickbeard.TORRENT_METHOD)()
+            result = client._get_torrent_hash(result)
             dlResult = client.sendTORRENT(result)
     else:
         logger.log(u"Unknown result type, unable to download it", logger.ERROR)
@@ -156,6 +157,8 @@ def snatchEpisode(result, endStatus=SNATCHED):
             else:
                 curEpObj.status = Quality.compositeStatus(endStatus, result.quality)
 
+	        if result.resultType == "torrent":
+                    curEpObj.torrent_hash = result.hash
             sql_l.append(curEpObj.get_sql())
 
         if curEpObj.status not in Quality.DOWNLOADED:

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -1316,6 +1316,7 @@ class TVEpisode(object):
         self._file_size = 0
         self._release_name = ''
         self._is_proper = False
+        self._torrent_hash = ""
         self._version = 0
         self._release_group = ''
 
@@ -1360,6 +1361,7 @@ class TVEpisode(object):
     file_size = property(lambda self: self._file_size, dirty_setter("_file_size"))
     release_name = property(lambda self: self._release_name, dirty_setter("_release_name"))
     is_proper = property(lambda self: self._is_proper, dirty_setter("_is_proper"))
+    torrent_hash = property(lambda self: self._torrent_hash, dirty_setter("_torrent_hash"))
     version = property(lambda self: self._version, dirty_setter("_version"))
     release_group = property(lambda self: self._release_group, dirty_setter("_release_group"))
 
@@ -1589,6 +1591,9 @@ class TVEpisode(object):
 
             if sqlResults[0]["is_proper"]:
                 self.is_proper = int(sqlResults[0]["is_proper"])
+
+            if sqlResults[0]["torrent_hash"] is not None:
+                self.torrent_hash = sqlResults[0]["torrent_hash"]
 
             if sqlResults[0]["version"]:
                 self.version = int(sqlResults[0]["version"])
@@ -1953,38 +1958,38 @@ class TVEpisode(object):
                 return [
                     "UPDATE tv_episodes SET indexerid = ?, indexer = ?, name = ?, description = ?, subtitles = ?, "
                     "subtitles_searchcount = ?, subtitles_lastsearch = ?, airdate = ?, hasnfo = ?, hastbn = ?, status = ?, "
-                    "location = ?, file_size = ?, release_name = ?, is_proper = ?, showid = ?, season = ?, episode = ?, "
+                    "location = ?, file_size = ?, release_name = ?, is_proper = ?, showid = ?, season = ?, episode = ?, torrent_hash = ?, "
                     "absolute_number = ?, version = ?, release_group = ? WHERE episode_id = ?",
                     [self.indexerid, self.indexer, self.name, self.description, ",".join([sub for sub in self.subtitles]),
                      self.subtitles_searchcount, self.subtitles_lastsearch, self.airdate.toordinal(), self.hasnfo,
                      self.hastbn,
                      self.status, self.location, self.file_size, self.release_name, self.is_proper, self.show.indexerid,
-                     self.season, self.episode, self.absolute_number, self.version, self.release_group, epID]]
+                     self.season, self.episode, self.torrent_hash, self.absolute_number, self.version, self.release_group, epID]]
             else:
                 # Don't update the subtitle language when the srt file doesn't contain the alpha2 code, keep value from subliminal
                 return [
                     "UPDATE tv_episodes SET indexerid = ?, indexer = ?, name = ?, description = ?, "
                     "subtitles_searchcount = ?, subtitles_lastsearch = ?, airdate = ?, hasnfo = ?, hastbn = ?, status = ?, "
-                    "location = ?, file_size = ?, release_name = ?, is_proper = ?, showid = ?, season = ?, episode = ?, "
+                    "location = ?, file_size = ?, release_name = ?, is_proper = ?, showid = ?, season = ?, episode = ?, torrent_hash = ?, "
                     "absolute_number = ?, version = ?, release_group = ? WHERE episode_id = ?",
                     [self.indexerid, self.indexer, self.name, self.description,
                      self.subtitles_searchcount, self.subtitles_lastsearch, self.airdate.toordinal(), self.hasnfo,
                      self.hastbn,
                      self.status, self.location, self.file_size, self.release_name, self.is_proper, self.show.indexerid,
-                     self.season, self.episode, self.absolute_number, self.version, self.release_group, epID]]
+                     self.season, self.episode, self.torrent_hash, self.absolute_number, self.version, self.release_group, epID]]
         else:
             # use a custom insert method to get the data into the DB.
             return [
                 "INSERT OR IGNORE INTO tv_episodes (episode_id, indexerid, indexer, name, description, subtitles, "
                 "subtitles_searchcount, subtitles_lastsearch, airdate, hasnfo, hastbn, status, location, file_size, "
-                "release_name, is_proper, showid, season, episode, absolute_number, version, release_group) VALUES "
+                "release_name, is_proper, showid, season, episode, torrent_hash, absolute_number, version, release_group) VALUES "
                 "((SELECT episode_id FROM tv_episodes WHERE showid = ? AND season = ? AND episode = ?)"
-                ",?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?);",
+                ",?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?);",
                 [self.show.indexerid, self.season, self.episode, self.indexerid, self.indexer, self.name,
                  self.description,
                  ",".join([sub for sub in self.subtitles]), self.subtitles_searchcount, self.subtitles_lastsearch,
                  self.airdate.toordinal(), self.hasnfo, self.hastbn, self.status, self.location, self.file_size,
-                 self.release_name, self.is_proper, self.show.indexerid, self.season, self.episode,
+                 self.release_name, self.is_proper, self.show.indexerid, self.season, self.episode, self.torrent_hash, 
                  self.absolute_number, self.version, self.release_group]]
 
     def saveToDB(self, forceSave=False):
@@ -2018,6 +2023,7 @@ class TVEpisode(object):
                         "file_size": self.file_size,
                         "release_name": self.release_name,
                         "is_proper": self.is_proper,
+                        "torrent_hash": self.torrent_hash,
                         "absolute_number": self.absolute_number,
                         "version": self.version,
                         "release_group": self.release_group

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -3525,7 +3525,6 @@ class ConfigGeneral(Config):
         sickbeard.TRASH_REMOVE_SHOW = config.checkbox_to_value(trash_remove_show)
         sickbeard.TRASH_ROTATE_LOGS = config.checkbox_to_value(trash_rotate_logs)
         config.change_UPDATE_FREQUENCY(update_frequency)
-        sickbeard.LAUNCH_BROWSER = config.checkbox_to_value(launch_browser)
         sickbeard.SORT_ARTICLE = config.checkbox_to_value(sort_article)
         sickbeard.CPU_PRESET = cpu_preset
         sickbeard.ANON_REDIRECT = anon_redirect


### PR DESCRIPTION
For now is it working for transmission client.
Need to be implemented remove_torrent_downloaded for other clients.

Hope not to have mess something with this pull request.

I remember some issue on this topic but have no chance to find it.