### PR TITLE
Add SD search to RARBG provider

### DIFF
--- a/sickbeard/providers/rarbg.py
+++ b/sickbeard/providers/rarbg.py
@@ -67,7 +67,7 @@ class RarbgProvider(generic.TorrentProvider):
 
         self.url = self.urls['base_url']
 
-        self.subcategories = [41] #18
+        self.subcategories = ['18;41']
 
 
     def getURL(self, url, post_data=None, params=None, timeout=30, json=False):


### PR DESCRIPTION
Previously, the search was conducted only TV HD Episodes. Now searches
into TV Episodes, without making 2 http requests