### PR TITLE
Subtitles 1/3: Windows UTF-8 console via cp65001

### DIFF
--- a/SickBeard.py
+++ b/SickBeard.py
@@ -146,7 +146,7 @@ class SickRage(object):
         if not hasattr(sys, "setdefaultencoding"):
             reload(sys)
   
-        if sys.getwindowsversion()[0] >= 6 and sickbeard.SYS_ENCODING in ['ascii','cp1252'] and sys.stdout.encoding == 'cp65001':
+        if sys.getwindowsversion()[0] >= 6 and sys.stdout.encoding == 'cp65001':
             sickbeard.SYS_ENCODING = 'UTF-8'
 
         try:

--- a/SickBeard.py
+++ b/SickBeard.py
@@ -20,6 +20,9 @@
 # Check needed software dependencies to nudge users to fix their setup
 from __future__ import with_statement
 
+import codecs
+codecs.register(lambda name: codecs.lookup('utf-8') if name == 'cp65001' else None)
+
 import time
 import signal
 import sys
@@ -142,6 +145,9 @@ class SickRage(object):
 
         if not hasattr(sys, "setdefaultencoding"):
             reload(sys)
+  
+        if sys.getwindowsversion()[0] >= 6 and sickbeard.SYS_ENCODING in ['ascii','cp1252'] and sys.stdout.encoding == 'cp65001':
+            sickbeard.SYS_ENCODING = 'UTF-8'
 
         try:
             # pylint: disable=E1101

--- a/SickBeard.py
+++ b/SickBeard.py
@@ -146,8 +146,9 @@ class SickRage(object):
         if not hasattr(sys, "setdefaultencoding"):
             reload(sys)
   
-        if sys.getwindowsversion()[0] >= 6 and sys.stdout.encoding == 'cp65001':
-            sickbeard.SYS_ENCODING = 'UTF-8'
+        if sys.platform == 'win32':
+            if sys.getwindowsversion()[0] >= 6 and sys.stdout.encoding == 'cp65001':
+                sickbeard.SYS_ENCODING = 'UTF-8'
 
         try:
             # pylint: disable=E1101

--- a/sickbeard/logger.py
+++ b/sickbeard/logger.py
@@ -28,6 +28,7 @@ import platform
 import sickbeard
 from sickbeard import classes, encodingKludge as ek
 from github import Github, InputFileContent
+import codecs
 
 # log levels
 ERROR = logging.ERROR
@@ -103,7 +104,7 @@ class Logger(object):
         # console log handler
         if self.consoleLogging:
             console = logging.StreamHandler()
-            console.setFormatter(CensoredFormatter('%(asctime)s %(levelname)s::%(message)s', '%H:%M:%S'))
+            console.setFormatter(CensoredFormatter(u'%(asctime)s %(levelname)s::%(message)s', '%H:%M:%S'))
             console.setLevel(INFO if not self.debugLogging else DEBUG)
 
             for logger in self.loggers:
@@ -112,7 +113,7 @@ class Logger(object):
         # rotating log file handler
         if self.fileLogging:
             rfh = logging.handlers.RotatingFileHandler(self.logFile, maxBytes=sickbeard.LOG_SIZE, backupCount=sickbeard.LOG_NR, encoding='utf-8')
-            rfh.setFormatter(CensoredFormatter('%(asctime)s %(levelname)-8s %(message)s', '%Y-%m-%d %H:%M:%S'))
+            rfh.setFormatter(CensoredFormatter(u'%(asctime)s %(levelname)-8s %(message)s', '%Y-%m-%d %H:%M:%S'))
             rfh.setLevel(DEBUG)
 
             for logger in self.loggers:
@@ -154,7 +155,7 @@ class Logger(object):
             # read log file
             log_data = None
             if self.logFile and os.path.isfile(self.logFile):
-                with ek.ek(open, self.logFile) as f:
+                with ek.ek(codecs.open, *[self.logFile, 'r', 'utf-8']) as f:
                     log_data = f.readlines()
                 log_data = [line for line in reversed(log_data)]
 

--- a/sickbeard/webapi.py
+++ b/sickbeard/webapi.py
@@ -38,6 +38,7 @@ from sickbeard import network_timezones, sbdatetime
 from sickbeard.exceptions import ex
 from sickbeard.common import Quality, Overview, qualityPresetStrings, statusStrings, SNATCHED, SNATCHED_PROPER, DOWNLOADED, SKIPPED, UNAIRED, IGNORED, ARCHIVED, WANTED, UNKNOWN
 from sickbeard.webserve import WebRoot
+import codecs
 
 try:
     import json
@@ -1318,7 +1319,7 @@ class CMD_Logs(ApiCall):
 
         data = []
         if os.path.isfile(logger.logFile):
-            with ek.ek(open, logger.logFile) as f:
+            with ek.ek(codecs.open, *[logger.logFile, 'r', 'utf-8']) as f:
                 data = f.readlines()
 
         regex = "^(\d\d\d\d)\-(\d\d)\-(\d\d)\s*(\d\d)\:(\d\d):(\d\d)\s*([A-Z]+)\s*(.+?)\s*\:\:\s*(.*)$"

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -24,6 +24,7 @@ import time
 import urllib
 import re
 import datetime
+import codecs
 
 import sickbeard
 from sickbeard import config, sab
@@ -4774,7 +4775,7 @@ class ErrorLogs(WebRoot):
 
         data = []
         if os.path.isfile(logger.logFile):
-            with ek.ek(open, logger.logFile) as f:
+            with ek.ek(codecs.open, *[logger.logFile, 'r', 'utf-8']) as f:
                 data = f.readlines()
 
         regex = "^(\d\d\d\d)\-(\d\d)\-(\d\d)\s*(\d\d)\:(\d\d):(\d\d)\s*([A-Z]+)\s*(.+?)\s*\:\:\s*(.*)$"


### PR DESCRIPTION
Windows UTF-8 console via cp65001
Enable usage of UTF-8 in Windows console via cp65001
To enable: chcp 65001 before launching SickRage
Fix opening log with cp1252 decode error