### PR TITLE
Don't remove logs folder when git reset is enabled in UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ cache/
 cache.db*
 config.ini*
 Logs/*
+Logs/
 sickbeard.db*
 failed.db*
 autoProcessTV/autoProcessTV.cfg

--- a/.gitignore
+++ b/.gitignore
@@ -1,17 +1,15 @@
 #  SR User Related   #
 ######################
-cache/*
 cache/
+Logs/
+restore/
 cache.db*
 config.ini*
-Logs/*
-Logs/
 sickbeard.db*
 failed.db*
 autoProcessTV/autoProcessTV.cfg
 server.crt
 server.key
-restore/
 
 #  SR Test Related   #
 ######################


### PR DESCRIPTION
git reset should only reset git files not user files
@abeloin what do you think about set "get reset" by default in config.ini?