### PR TITLE
Added iTunes parser

### DIFF
--- a/sickbeard/name_parser/regexes.py
+++ b/sickbeard/name_parser/regexes.py
@@ -19,6 +19,12 @@
 # all regexes are case insensitive
 
 normal_regexes = [
+    ('itunes',
+     # 01 Ep Name
+     '''
+     ^(?P<ep_num>\d{1,3})[ ](?P<extra_info>.*)$      # 02 Episode Name
+     '''),
+
     ('standard_repeat',
      # Show.Name.S01E02.S01E03.Source.Quality.Etc-Group
      # Show Name - S01E02 - S01E03 - S01E04 - Ep Name


### PR DESCRIPTION
For show folders that are also managed by iTunes (re)scanning existing episodes can fail. Added a simple regex to match the format used by iTunes: [Show Name]\\[Season folder]\\[Ep#] [Epsiode name]

This regex was put first as otherwise other regexes could get in the way.