### PR TITLE
base_url 'https://thepirateboat.eu/'

### DIFF
--- a/sickbeard/providers/thepiratebay.py
+++ b/sickbeard/providers/thepiratebay.py
@@ -59,7 +59,7 @@ class ThePirateBayProvider(generic.TorrentProvider):
 
         self.cache = ThePirateBayCache(self)
 
-        self.urls = {'base_url': 'https://thepiratebay.se/'}
+        self.urls = {'base_url': 'https://thepirateboat.eu/'}
 
         self.url = self.urls['base_url']
 


### PR DESCRIPTION
Hi, the former one wasn't working, so if you change this you can download pirate bay's torrent