### PR TITLE
PP Syncfiles, List_associated_files fix, and Delete RAR contents fix

### DIFF
--- a/gui/slick/interfaces/default/config_postProcessing.tmpl
+++ b/gui/slick/interfaces/default/config_postProcessing.tmpl
@@ -123,12 +123,21 @@
                                 <span class="component-desc">Move srr/srt/sfv/etc files with the episode when processed?</span>
                             </label>
                         </div>
-						
+						<div class="field-pair">
+                            <label class="nocheck">
+                                <span class="component-title">Sync File Extensions</span>
+                                <input type="text" name="sync_files" id="sync_files" value="$sickbeard.SYNC_FILES" class="form-control input-sm input350" />
+                            </label>
+                            <label class="nocheck">
+                                <span class="component-title">&nbsp;</span>
+                                <span class="component-desc">comma seperated list of extensions SickRage ignores when Post Processing</span>
+                            </label>
+                        </div>
                         <div class="field-pair">
                             <input type="checkbox" name="postpone_if_sync_files" id="postpone_if_sync_files" #if $sickbeard.POSTPONE_IF_SYNC_FILES == True then "checked=\"checked\"" else ""# />
                             <label for="postpone_if_sync_files">
                                 <span class="component-title">Postpone post processing</span>
-                                <span class="component-desc">if !sync files are present in the TV download dir</span>
+                                <span class="component-desc">if sync files are present in the TV download dir</span>
                             </label>
                         </div>
 

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -489,6 +489,7 @@ EXTRA_SCRIPTS = []
 
 IGNORE_WORDS = "german,french,core2hd,dutch,swedish,reenc,MrLss"
 REQUIRE_WORDS = ""
+SYNC_FILES = "!sync,lftp-pget-status,part,bts"
 
 CALENDAR_UNPROTECTED = False
 
@@ -540,7 +541,7 @@ def initialize(consoleLogging=True):
             USE_SYNOLOGYNOTIFIER, SYNOLOGYNOTIFIER_NOTIFY_ONSNATCH, SYNOLOGYNOTIFIER_NOTIFY_ONDOWNLOAD, SYNOLOGYNOTIFIER_NOTIFY_ONSUBTITLEDOWNLOAD, \
             USE_EMAIL, EMAIL_HOST, EMAIL_PORT, EMAIL_TLS, EMAIL_USER, EMAIL_PASSWORD, EMAIL_FROM, EMAIL_NOTIFY_ONSNATCH, EMAIL_NOTIFY_ONDOWNLOAD, EMAIL_NOTIFY_ONSUBTITLEDOWNLOAD, EMAIL_LIST, \
             USE_LISTVIEW, METADATA_KODI, METADATA_KODI_12PLUS, METADATA_MEDIABROWSER, METADATA_PS3, metadata_provider_dict, \
-            NEWZBIN, NEWZBIN_USERNAME, NEWZBIN_PASSWORD, GIT_PATH, MOVE_ASSOCIATED_FILES, POSTPONE_IF_SYNC_FILES, dailySearchScheduler, NFO_RENAME, \
+            NEWZBIN, NEWZBIN_USERNAME, NEWZBIN_PASSWORD, GIT_PATH, MOVE_ASSOCIATED_FILES, SYNC_FILES, POSTPONE_IF_SYNC_FILES, dailySearchScheduler, NFO_RENAME, \
             GUI_NAME, HOME_LAYOUT, HISTORY_LAYOUT, DISPLAY_SHOW_SPECIALS, COMING_EPS_LAYOUT, COMING_EPS_SORT, COMING_EPS_DISPLAY_PAUSED, COMING_EPS_MISSED_RANGE, DISPLAY_FILESIZE, FUZZY_DATING, TRIM_ZERO, DATE_PRESET, TIME_PRESET, TIME_PRESET_W_SECONDS, THEME_NAME, \
             POSTER_SORTBY, POSTER_SORTDIR, \
             METADATA_WDTV, METADATA_TIVO, METADATA_MEDE8ER, IGNORE_WORDS, REQUIRE_WORDS, CALENDAR_UNPROTECTED, CREATE_MISSING_SHOW_DIRS, \
@@ -822,6 +823,7 @@ def initialize(consoleLogging=True):
         DELRARCONTENTS = bool(check_setting_int(CFG, 'General', 'del_rar_contents', 0))
         MOVE_ASSOCIATED_FILES = bool(check_setting_int(CFG, 'General', 'move_associated_files', 0))
         POSTPONE_IF_SYNC_FILES = bool(check_setting_int(CFG, 'General', 'postpone_if_sync_files', 1))
+        SYNC_FILES = check_setting_str(CFG, 'General', 'sync_files', SYNC_FILES)
         NFO_RENAME = bool(check_setting_int(CFG, 'General', 'nfo_rename', 1))
         CREATE_MISSING_SHOW_DIRS = bool(check_setting_int(CFG, 'General', 'create_missing_show_dirs', 0))
         ADD_SHOWS_WO_DIR = bool(check_setting_int(CFG, 'General', 'add_shows_wo_dir', 0))
@@ -1593,6 +1595,7 @@ def save_config():
     new_config['General']['process_method'] = PROCESS_METHOD
     new_config['General']['del_rar_contents'] = int(DELRARCONTENTS)
     new_config['General']['move_associated_files'] = int(MOVE_ASSOCIATED_FILES)
+    new_config['General']['sync_files'] = SYNC_FILES
     new_config['General']['postpone_if_sync_files'] = int(POSTPONE_IF_SYNC_FILES)
     new_config['General']['nfo_rename'] = int(NFO_RENAME)
     new_config['General']['process_automatically'] = int(PROCESS_AUTOMATICALLY)

--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -131,7 +131,9 @@ def replaceExtension(filename, newExt):
 
 def isSyncFile(filename):
     extension = filename.rpartition(".")[2].lower()
-    if extension == '!sync' or extension == 'lftp-pget-status' or extension == 'part' or extension == 'bts':
+    #if extension == '!sync' or extension == 'lftp-pget-status' or extension == 'part' or extension == 'bts':
+    syncfiles = sickbeard.SYNC_FILES
+    if extension in syncfiles.split(","):
         return True
     else:
         return False

--- a/sickbeard/postProcessor.py
+++ b/sickbeard/postProcessor.py
@@ -145,7 +145,7 @@ class PostProcessor(object):
                       logger.DEBUG)
             return PostProcessor.DOESNT_EXIST
 
-    def list_associated_files(self, file_path, base_name_only=False, subtitles_only=False):
+    def list_associated_files(self, file_path, base_name_only=False, subtitles_only=False, subfolders=False):
         """
         For a given file path searches for files with the same name but different extension and returns their absolute paths
 
@@ -179,7 +179,11 @@ class PostProcessor(object):
         # don't confuse glob with chars we didn't mean to use
         base_name = re.sub(r'[\[\]\*\?]', r'[\g<0>]', base_name)
         
-        for associated_file_path in ek.ek(recursive_glob, self.folder_path,  base_name + '*'):
+        if subfolders:
+            filelist = ek.ek(recursive_glob, self.folder_path,  base_name + '*')
+        else:
+            filelist = ek.ek(glob.glob, base_name + '*')
+        for associated_file_path in filelist:
             # only add associated to list
             if associated_file_path == file_path:
                 continue

--- a/sickbeard/processTV.py
+++ b/sickbeard/processTV.py
@@ -68,9 +68,11 @@ def delete_folder(folder, check_empty=True):
 
     return True
 
-def delete_files(processPath, notwantedFiles, result):
+def delete_files(processPath, notwantedFiles, result, force=False):
 
-    if not result.result:
+    if not result.result and force:
+        result.output += logHelper(u"Forcing deletion of files, even though last result was not success", logger.DEBUG)
+    elif not result.result:
         return
 
     #Delete all file not needed
@@ -178,7 +180,7 @@ def processDir(dirName, nzbName=None, process_method=None, force=False, is_prior
             result.result = process_media(path, [video], nzbName, process_method, force, is_priority, result)
     elif sickbeard.DELRARCONTENTS and videoInRar:
         result.result = process_media(path, videoInRar, nzbName, process_method, force, is_priority, result)
-        delete_files(path, rarContent, result)
+        delete_files(path, rarContent, result, True)
         for video in set(videoFiles) - set(videoInRar):
             result.result = process_media(path, [video], nzbName, process_method, force, is_priority, result)
     else:
@@ -216,7 +218,7 @@ def processDir(dirName, nzbName=None, process_method=None, force=False, is_prior
                 process_media(processPath, videoInRar, nzbName, process_method, force, is_priority, result)
                 process_media(processPath, set(videoFiles) - set(videoInRar), nzbName, process_method, force,
                               is_priority, result)
-                delete_files(processPath, rarContent, result)
+                delete_files(processPath, rarContent, result, True)
             else:
                 process_media(processPath, videoFiles, nzbName, process_method, force, is_priority, result)
 

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -2488,11 +2488,11 @@ class TVEpisode(object):
             return
 
         related_files = postProcessor.PostProcessor(self.location).list_associated_files(
-            self.location, base_name_only=True)
+            self.location, base_name_only=True, subfolders=True)
 
         if self.show.subtitles and sickbeard.SUBTITLES_DIR != '':
             related_subs = postProcessor.PostProcessor(self.location).list_associated_files(sickbeard.SUBTITLES_DIR,
-                                                                                            subtitles_only=True)
+                                                                                            subtitles_only=True, subfolders=True)
             absolute_proper_subs_path = ek.ek(os.path.join, sickbeard.SUBTITLES_DIR, self.formatted_filename())
 
         logger.log(u"Files associated to " + self.location + ": " + str(related_files), logger.DEBUG)

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -3769,7 +3769,7 @@ class ConfigPostProcessing(Config):
                            wdtv_data=None, tivo_data=None, mede8er_data=None,
                            keep_processed_dir=None, process_method=None, del_rar_contents=None, process_automatically=None,
                            rename_episodes=None, airdate_episodes=None, unpack=None,
-                           move_associated_files=None, postpone_if_sync_files=None, nfo_rename=None,
+                           move_associated_files=None, sync_files=None, postpone_if_sync_files=None, nfo_rename=None,
                            tv_download_dir=None, naming_custom_abd=None,
                            naming_anime=None,
                            naming_abd_pattern=None, naming_strip_year=None, use_failed_downloads=None,
@@ -3816,6 +3816,7 @@ class ConfigPostProcessing(Config):
         sickbeard.RENAME_EPISODES = config.checkbox_to_value(rename_episodes)
         sickbeard.AIRDATE_EPISODES = config.checkbox_to_value(airdate_episodes)
         sickbeard.MOVE_ASSOCIATED_FILES = config.checkbox_to_value(move_associated_files)
+        sickbeard.SYNC_FILES = sync_files
         sickbeard.POSTPONE_IF_SYNC_FILES = config.checkbox_to_value(postpone_if_sync_files)
         sickbeard.NAMING_CUSTOM_ABD = config.checkbox_to_value(naming_custom_abd)
         sickbeard.NAMING_CUSTOM_SPORTS = config.checkbox_to_value(naming_custom_sports)


### PR DESCRIPTION
Fixes the following:
- List_associated_files also looks in subfolders to allow metadata in subfolders to be renamed properly. This causes associated_files for Post Processing (not renaming) to also include subfolders, which in turn can lead to files being deleted that are still in the queue to be processed.
- Delete RAR contents uses delete_files, which checks if result is true. If it isn't then it won't delete rar contents. It will now Delete RAR contents regardless if the process_method is not 'move'.

Adds the following:
- Config option under Post Processing to add your own syncfile extensions in a comma seperated value list.
- Changed is_syncfile function to accept a list, rather than hardcoded values.