### PR TITLE
Use WayBack Machine to search dead EZTV RSS provider

### DIFF
--- a/sickbeard/providers/ezrss.py
+++ b/sickbeard/providers/ezrss.py
@@ -36,7 +36,7 @@ from sickbeard import helpers
 class EZRSSProvider(generic.TorrentProvider):
     def __init__(self):
 
-        self.urls = {'base_url': 'https://www.ezrss.it/'}
+        self.urls = {'base_url': 'https://web.archive.org/web/20120901132106/http://www.ezrss.it/'}
 
         self.url = self.urls['base_url']
 


### PR DESCRIPTION
Please do not merge this Pull Request as its more of a proof of concept .It is more as an ideia that anything else (Also It wont work for shows older than 2012, and most wont even work in the first place...)