### PR TITLE
Fix Exception generated: Cannot find attribute 'contentrating'

### DIFF
--- a/sickbeard/metadata/mede8er.py
+++ b/sickbeard/metadata/mede8er.py
@@ -304,7 +304,7 @@ class Mede8erMetadata(mediabrowser.MediaBrowserMetadata):
                     Overview.text = ""
 
                 mpaa = etree.SubElement(episode, "mpaa")
-                if myShow["contentrating"] != None:
+                if getattr(myShow, 'contentrating', None) is not None:
                     mpaa.text = myShow["contentrating"]
 
                 if not ep_obj.relatedEps:


### PR DESCRIPTION
- Fixes POSTPROCESSER :: Exception generated in thread POSTPROCESSER:
Cannot find attribute 'contentrating' errors in Mede8ter metadata
creation.