### PR TITLE
Add syncthing's ".syncthing.*" files to isSyncFile().

### DIFF
--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -129,6 +129,8 @@ def isSyncFile(filename):
     extension = filename.rpartition(".")[2].lower()
     if extension == '!sync' or extension == 'lftp-pget-status':
         return True
+    elif filename.startswith(".syncthing."):
+        return True
     else:
         return False
 


### PR DESCRIPTION
Syncthing is an open source alternative to programs like BT Sync. It would be helpful for these files to be ignored by default.