### PR TITLE
Fix time display for fuzzy dates with trim zero and 24 hour time style 

### DIFF
--- a/gui/slick/js/fuzzyMoment.js
+++ b/gui/slick/js/fuzzyMoment.js
@@ -64,7 +64,8 @@
         });
 
     if (trimZero) {
-        timeToken = timeToken.replace(/hh/ig, 'h');
+        timeToken = timeToken.replace(/hh/g, 'h');
+        timeToken = timeToken.replace(/HH/g, 'H');
         dateToken = dateToken.replace(/\bDD\b/g, 'D');
     }
 


### PR DESCRIPTION
When enabling 'Display fuzzy dates' and 'Trim zero padding' in
combination with an 24 hour time style, SickRage would for example show
"Last Thu, 9:59:31" instead of "Last Thu, 21:59:31". This happened because fuzzy would case-insensitive replace "hh" with "h", thus also replacing "HH"(21h) with "h"(9h).

*This is the simplest solution I could find. If anybody has a better solution, please let me know (not sure how to change the pull though, haha).*

**Screenshots**
[Settings](http://i.imgur.com/kAsk3BJ.png) - [Wrong (old) display](http://i.imgur.com/XCstrSe.png) - [Good (new) display](http://i.imgur.com/LnwBoCF.png)