### PR TITLE
Updated URL

### DIFF
--- a/sickbeard/providers/torrentday.py
+++ b/sickbeard/providers/torrentday.py
@@ -54,10 +54,10 @@ class TorrentDayProvider(generic.TorrentProvider):
 
         self.cache = TorrentDayCache(self)
 
-        self.urls = {'base_url': 'https://torrentday.eu',
-                'login': 'https://torrentday.eu/torrents/',
-                'search': 'https://torrentday.eu/V3/API/API.php',
-                'download': 'https://torrentday.eu/download.php/%s/%s'
+        self.urls = {'base_url': 'https://www.torrentday.com',
+                'login': 'https://www.torrentday.com/torrents/',
+                'search': 'https://www.torrentday.com/V3/API/API.php',
+                'download': 'https://www.torrentday.com/download.php/%s/%s'
         }
 
         self.url = self.urls['base_url']


### PR DESCRIPTION
Changed https://torrentday.eu/ to https://www.torrentday.com/