### PR TITLE
Fix sickrage UI header when adding 'trending' show

### DIFF
--- a/gui/slick/interfaces/default/home_trendingShows.tmpl
+++ b/gui/slick/interfaces/default/home_trendingShows.tmpl
@@ -10,7 +10,7 @@
 
 #set global $sbPath='..'
 
-#set global $topmenu='comingEpisodes'
+#set global $topmenu='home'
 #import os.path
 #include $os.path.join($sickbeard.PROG_DIR, 'gui/slick/interfaces/default/inc_top.tmpl')
 

--- a/gui/slick/interfaces/default/home_trendingShows.tmpl
+++ b/gui/slick/interfaces/default/home_trendingShows.tmpl
@@ -10,7 +10,7 @@
 
 #set global $sbPath='..'
 
-#set global $topmenu='home'
+#set global $topmenu='comingShows'
 #import os.path
 #include $os.path.join($sickbeard.PROG_DIR, 'gui/slick/interfaces/default/inc_top.tmpl')
 

--- a/gui/slick/interfaces/default/home_trendingShows.tmpl
+++ b/gui/slick/interfaces/default/home_trendingShows.tmpl
@@ -10,7 +10,7 @@
 
 #set global $sbPath='..'
 
-#set global $topmenu='comingShows'
+#set global $topmenu='home'
 #import os.path
 #include $os.path.join($sickbeard.PROG_DIR, 'gui/slick/interfaces/default/inc_top.tmpl')
 


### PR DESCRIPTION
When adding trending show, the UI header has 'Coming Episodes' selected. 
![](http://i.imgur.com/yy2kqaR.png)

Correct behavior would be having 'Shows' selected, as with recommended shows, adding shows etc.
![](http://i.imgur.com/8Ad5f9w.png)
 


