### PR TITLE
Fix coloring episodes as good when "archive first match" selected

### DIFF
--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -1280,6 +1280,9 @@ class TVShow(object):
             # if they don't want re-downloads then we call it good if they have anything
             elif maxBestQuality == None:
                 return Overview.GOOD
+            # if the want only first match and already have one call it good
+            elif self.archive_firstmatch and curQuality in bestQualities:
+                return Overview.GOOD
             # if they have one but it's not the best they want then mark it as qual
             elif curQuality < maxBestQuality:
                 return Overview.QUAL

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -1266,8 +1266,10 @@ class TVShow(object):
             anyQualities, bestQualities = Quality.splitQuality(self.quality)  # @UnusedVariable
             if bestQualities:
                 maxBestQuality = max(bestQualities)
+                minBestQuality = min(bestQualities)
             else:
                 maxBestQuality = None
+                minBestQuality = None
 
             epStatus, curQuality = Quality.splitCompositeStatus(epStatus)
 
@@ -1282,6 +1284,9 @@ class TVShow(object):
                 return Overview.GOOD
             # if the want only first match and already have one call it good
             elif self.archive_firstmatch and curQuality in bestQualities:
+                return Overview.GOOD
+            # if they want only first match and current quality is higher than minimal best quality call it good
+            elif self.archive_firstmatch and minBestQuality != None and curQuality > minBestQuality:
                 return Overview.GOOD
             # if they have one but it's not the best they want then mark it as qual
             elif curQuality < maxBestQuality:


### PR DESCRIPTION
Currently when "archive first match" is selected and custom quality is used downloaded episodes with quality in archive list but lower than best are colored as low quality (despite they wont be redownloaded). 

It also applies to qualities that are better than minimal archive quality but are not in archive list (for example when downloaded manually or quality preference was changed).
