### PR TITLE
Fix shutil import error

### DIFF
--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -24,6 +24,7 @@ import socket
 import os
 import re
 import os.path
+import shutil
 import lib.shutil_custom
 
 shutil.copyfile = lib.shutil_custom.copyfile_custom


### PR DESCRIPTION
- Fixes NameError: name 'shutil' is not defined caused by monkeypatching
shutil.copyfile