### PR TITLE
Add Branch Warning when branch is not master

### DIFF
--- a/gui/slick/interfaces/default/inc_top.tmpl
+++ b/gui/slick/interfaces/default/inc_top.tmpl
@@ -253,7 +253,13 @@
 		</span>
 		</div>
 		#end if
-	  
+	  	
+	  	#if $sickbeard.BRANCH and $sickbeard.BRANCH != 'master':	
+		<div class="alert alert-danger upgrade-notification" role="alert">
+			<span>You're using the $sickbeard.BRANCH branch. Please use 'master' unless specifically asked</span>
+		</div>
+		#end if
+		
 		#if $sickbeard.NEWEST_VERSION_STRING:	
 		<div class="alert alert-success upgrade-notification" role="alert">
 			<span>$sickbeard.NEWEST_VERSION_STRING</span>


### PR DESCRIPTION
- Adds warning at the top of the page when branch is anything other than
master. Encourages users to switch to master.