### PR TITLE
Don't check SSL certificate when fetching DB version

### DIFF
--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -1159,7 +1159,7 @@ class Home(WebRoot):
         if not branchDest:
             return json.dumps({ "status": "error", 'message': 'branchDest empty' })
         try:
-            response = requests.get("https://raw.githubusercontent.com/SICKRAGETV/SickRage/" + str(branchDest) +"/sickbeard/databases/mainDB.py")
+            response = requests.get("https://raw.githubusercontent.com/SICKRAGETV/SickRage/" + str(branchDest) +"/sickbeard/databases/mainDB.py", verify=False)
             response.raise_for_status()
             match = re.search(r"MAX_DB_VERSION\s=\s(?P<version>\d{2,3})",response.text)
             branchDestDBversion = int(match.group('version'))


### PR DESCRIPTION
```
2015-03-04 14:17:18 ERROR Thread-53 :: Checkout branch couldn't compare DB version - Requests error AASSLError: [Errno 1] _ssl.c:499: error:14090086:SSL routines:SSL3_GET_SERVER_CERTIFICATE:certificate verify failed AA raise SSLError(e, request=request) AA File "/share/MD0_DATA/.qpkg/SickRage/lib/requests/adapters.py", line 431, in send AA r = adapter.send(request, **kwargs) AA File "/share/MD0_DATA/.qpkg/SickRage/lib/requests/sessions.py", line 573, in send AA resp = self.send(prep, **send_kwargs) AA File "/share/MD0_DATA/.qpkg/SickRage/lib/requests/sessions.py", line 461, in request AA response = session.request(method=method, url=url, **kwargs) AA File "/share/MD0_DATA/.qpkg/SickRage/lib/requests/api.py", line 49, in request AA return request('get', url, **kwargs) AA File "/share/MD0_DATA/.qpkg/SickRage/lib/requests/api.py", line 65, in get AA response = requests.get("https://raw.githubusercontent.com/SICKRAGETV/SickRage/" + str(branchDest) +"/sickbeard/databases/mainDB.py") AA File "/share/MD0_DATA/.qpkg/SickRage/sickbeard/webserve.py", line 1162, in getDBcompare AATraceback (most recent call last):
2015-03-04 14:15:59 ERROR Thread-48 :: Checkout branch couldn't compare DB version - Requests error
```