### PR TITLE
Change PostProcessor._delete function to delete ALL associated files

### DIFF
--- a/sickbeard/postProcessor.py
+++ b/sickbeard/postProcessor.py
@@ -217,7 +217,7 @@ class PostProcessor(object):
         # figure out which files we want to delete
         file_list = [file_path]
         if associated_files:
-            file_list = file_list + self.list_associated_files(file_path)
+            file_list = file_list + self.list_associated_files(file_path, base_name_only=True, subfolders=True)
 
         if not file_list:
             self._log(u"There were no files associated with " + file_path + ", not deleting anything", logger.DEBUG)


### PR DESCRIPTION
- Changed PostProcessor._delete to include base_name_only = True, and
subfolders = True

Makes sure that when replacing old episodes in PostProcessing ALL the
old metadata is deleted, including those that have an addition to the
filename (-thumb.jpg) or are in subfolders (.meta and .metadata
subfolders for some mediaplayers).

Fixes https://github.com/SiCKRAGETV/sickrage-issues/issues/842