### PR TITLE
Possible Fix for Pushbullet update notification

### DIFF
--- a/sickbeard/notifiers/pushbullet.py
+++ b/sickbeard/notifiers/pushbullet.py
@@ -53,7 +53,7 @@ class PushbulletNotifier:
         if sickbeard.USE_PUSHBULLET:
             update_text=common.notifyStrings[common.NOTIFY_GIT_UPDATE_TEXT]
             title=common.notifyStrings[common.NOTIFY_GIT_UPDATE]
-            self._sendPushbullet(pushbullet_api=None, event=title, message=update_text + new_version, method="POST")
+            self._sendPushbullet(pushbullet_api=None, event=title, message=update_text + new_version, notificationType="note", method="POST")
 
     def _sendPushbullet(self, pushbullet_api=None, pushbullet_device=None, event=None, message=None,
                         notificationType=None, method=None, force=False):


### PR DESCRIPTION
- notify_git_update missed the notificationType value on calling
_sendPushbullet, which may cause the Content-length header to be
corrupted.

Hopefully fixes:
2015-03-05 09:06:58 ERROR    Thread-186 :: Pushbullet notification
failed.
AA
AA  
POST requests require a Content-length header.  That’s all we know.
AA  

411. That’s an error.
AA  
AA