### PR TITLE
Ability to delete media files with status change

### DIFF
--- a/gui/slick/css/style.css
+++ b/gui/slick/css/style.css
@@ -1113,6 +1113,10 @@ ul.tags li a{
 	vertical-align: -2px;
 }
 
+.delete {
+  background-color: #B2B2B2 !important;
+  text-decoration: line-through;
+}
 .unaired {
   background-color: #f5f1e4;
 }
@@ -2535,6 +2539,11 @@ input sizing (for config pages)
 
 .btn-inline {
 	margin-top: -3px;
+}
+
+.input50 {
+	width: 50px;
+	margin-top: -4px;
 }
 
 .input75 {

--- a/gui/slick/interfaces/default/config_postProcessing.tmpl
+++ b/gui/slick/interfaces/default/config_postProcessing.tmpl
@@ -34,7 +34,8 @@
                 	<li><a href="#core-component-group3">Metadata</a></li>
                 </ul>
                 
-                <div id="core-component-group1" class="component-group">
+                <div id="core-component-group1">
+				<div class="component-group">
 
                     <div class="component-group-desc">
                         <h3>Post-Processing</h3>
@@ -242,6 +243,68 @@
                         <input type="submit" class="btn config_submitter" value="Save Changes" /><br/>
 
                     </fieldset>
+               </div>
+			   <div class="component-group">
+
+					<div class="component-group-desc">
+						<h3>Delete Media</h3>
+						<p>Options to delete media files.</p>
+					</div>
+
+					<fieldset class="component-group-list">
+						<div class="field-pair">
+							<label for="delete_checker">
+								<span class="component-title">Delete media files</span>
+								<span class="component-desc">
+									<input type="checkbox" name="delete_checker" id="delete_checker" #if $sickbeard.DELETE_CHECKER == True then "checked=\"checked\"" else ""# />
+									<p>Ability to delete media and associated files when episode status is changed. This feature can be used to delete 'watched' episodes through Sickrage. Example: If the setting below is archived, media files will be deleted when status is changed to archived. NOTE: to prevent accidental deletion use 'delay media frequency'.</p>
+								</span>
+							</label>
+						</div>
+						<div class="field-pair">
+							<label>
+								<span class="component-title">Delete Media Frequency</span>
+								<input type="text" name="delete_checker_frequency" id="delete_checker_frequency" value="$sickbeard.DELETE_CHECKER_FREQUENCY" class="form-control input-sm input50" />
+							</label>
+							<label>
+								<span class="component-title">&nbsp;</span>
+								<span class="component-desc">
+									<p>Time in minutes to the delay deletion of files. If necessary deletion can be canceled. <b>WARNING:</b> when zero (0) minutes delay is chosen, files are deleted instantly.</p>
+								</span>
+							</label>
+						</div>
+						<div class="field-pair">
+							<label for="delete_files_status">
+								<span class="component-title">Delete media files</span>
+								<span class="component-desc">
+									<select id="delete_files_status" name="delete_files_status" class="form-control input-sm">
+										<option value="ARCHIVED" #if $sickbeard.DELETE_FILES_STATUS == 'ARCHIVED' then "selected=\"selected\"" else ""#>Archived</option>
+										<option value="IGNORED" #if $sickbeard.DELETE_FILES_STATUS == 'IGNORED' then "selected=\"selected\"" else ""#>Ignored</option>
+										<option value="SKIPPED" #if $sickbeard.DELETE_FILES_STATUS == 'SKIPPED' then "selected=\"selected\"" else ""#>Skipped</option>
+									</select>
+								</span>
+							</label>
+							<label>
+								<span class="component-title">&nbsp;</span>
+								<span class="component-desc">Status to be used to delete watched files. </span>
+							</label>
+						</div>
+						<div class="field-pair">
+							<span class="component-title">Send to trash</span>
+							<span class="component-desc">
+								<label for="trash_remove_media_files" class="nextline-block">
+									<input type="checkbox" name="trash_remove_media_files" id="trash_remove_media_files" #if $sickbeard.TRASH_REMOVE_MEDIA_FILES then 'checked="checked"' else ''#/>
+									<p>Can be used to send deleted files to the trashcan instead of permanent deletion.</p>
+								</label>
+							</span>
+						</div><br>
+						
+						<input type="submit" class="btn config_submitter" value="Save Changes" /><br/>
+
+					</fieldset>
+
+				</div>
+
                 </div><!-- /component-group1 //-->
 
                 <div id="core-component-group2" class="component-group">

--- a/gui/slick/interfaces/default/displayShow.tmpl
+++ b/gui/slick/interfaces/default/displayShow.tmpl
@@ -397,8 +397,9 @@
 		#end if    
 
 		#set $epLoc = $epResult["location"]
+		#set $curDelete = $epResult["delete_media"]
 		
-		<tr class="$Overview.overviewStrings[$epCats[$epStr]] season-$curSeason seasonstyle">
+		<tr class="$Overview.overviewStrings[$epCats[$epStr]] $curDelete season-$curSeason seasonstyle">
 		
 		<td class="col-checkbox">
 		
@@ -527,6 +528,7 @@
 			#end if
 		
 		<td class="col-search">
+			#if $sickbeard.DELETE_CHECKER and str($epResult["delete_media"]) != 'delete'
 			#if int($epResult["season"]) != 0:
 			#if ( int($epResult["status"]) in $Quality.SNATCHED or int($epResult["status"]) in $Quality.DOWNLOADED ) and $sickbeard.USE_FAILED_DOWNLOADS:
 				<a class="epRetry" id="<%=str(epResult["season"])+'x'+str(epResult["episode"])%>" name="<%=str(epResult["season"]) +"x"+str(epResult["episode"]) %>" href="retryEpisode?show=$show.indexerid&amp;season=$epResult["season"]&amp;episode=$epResult["episode"]"><img src="$sbRoot/images/search16.png" height="16" alt="retry" title="Retry Download" /></a>
@@ -534,9 +536,16 @@
 				<a class="epSearch" id="<%=str(epResult["season"])+'x'+str(epResult["episode"])%>" name="<%=str(epResult["season"]) +"x"+str(epResult["episode"]) %>" href="searchEpisode?show=$show.indexerid&amp;season=$epResult["season"]&amp;episode=$epResult["episode"]"><img src="$sbRoot/images/search16.png" width="16" height="16" alt="search" title="Manual Search" /></a>
 			#end if
 			#end if
+			#end if
 			
+			#if $sickbeard.DELETE_CHECKER and str($epResult["delete_media"]) != 'delete'
 			#if $sickbeard.USE_SUBTITLES and $show.subtitles and len(set(str($epResult["subtitles"]).split(',')).intersection(set($subtitles.wantedLanguages()))) < len($subtitles.wantedLanguages()) and $epResult["location"]
 				<a class="epSubtitlesSearch" href="searchEpisodeSubtitles?show=$show.indexerid&amp;season=$epResult["season"]&amp;episode=$epResult["episode"]"><img src="$sbRoot/images/closed_captioning.png" height="16" alt="search subtitles" title="Search Subtitles" /></a>
+			#end if
+			#end if
+
+			#if $sickbeard.DELETE_CHECKER and str($epResult["delete_media"]) == 'delete'
+				<a class="epCancelDelete" href="cancelDeleteMedia?show=$show.indexerid&amp;season=$epResult["season"]&amp;episode=$epResult["episode"]"><img src="$sbRoot/images/cancel32.png" height="16" alt="cancel deletion" title="Cancel Deletion" /></a>
 			#end if
 		</td>
 	</tr>

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -42,7 +42,7 @@ from providers import ezrss, btn, newznab, womble, thepiratebay, oldpiratebay, t
 from sickbeard.config import CheckSection, check_setting_int, check_setting_str, check_setting_float, ConfigMigrator, \
     naming_ep_type
 from sickbeard import searchBacklog, showUpdater, versionChecker, properFinder, autoPostProcesser, \
-    subtitles, traktChecker
+    subtitles, traktChecker, deleteChecker
 from sickbeard import helpers, db, exceptions, show_queue, search_queue, scheduler, show_name_helpers
 from sickbeard import logger
 from sickbeard import naming
@@ -100,6 +100,7 @@ properFinderScheduler = None
 autoPostProcesserScheduler = None
 subtitlesFinderScheduler = None
 traktCheckerScheduler = None
+deleteCheckerScheduler = None
 
 showList = None
 loadingShowList = None
@@ -177,6 +178,7 @@ UPDATE_SHOWS_ON_START = False
 UPDATE_SHOWS_ON_SNATCH = False
 TRASH_REMOVE_SHOW = False
 TRASH_ROTATE_LOGS = False
+TRASH_REMOVE_MEDIA_FILES = False
 SORT_ARTICLE = False
 DEBUG = False
 
@@ -232,11 +234,13 @@ DAILYSEARCH_STARTUP = False
 BACKLOG_FREQUENCY = None
 BACKLOG_STARTUP = False
 SHOWUPDATE_HOUR = 3
+DELETE_CHECKER_FREQUENCY = None
 
 DEFAULT_AUTOPOSTPROCESSER_FREQUENCY = 10
 DEFAULT_DAILYSEARCH_FREQUENCY = 40
 DEFAULT_BACKLOG_FREQUENCY = 21
 DEFAULT_UPDATE_FREQUENCY = 1
+DEFAULT_DELETE_CHECKER_FREQUENCY = 60
 
 MIN_AUTOPOSTPROCESSER_FREQUENCY = 1
 MIN_DAILYSEARCH_FREQUENCY = 10
@@ -259,6 +263,8 @@ NFO_RENAME = True
 TV_DOWNLOAD_DIR = None
 UNPACK = False
 SKIP_REMOVED_FILES = False
+DELETE_FILES_STATUS = None
+DELETE_CHECKER = False
 
 NZBS = False
 NZBS_UID = None
@@ -526,7 +532,7 @@ def initialize(consoleLogging=True):
             USE_TRAKT, TRAKT_USERNAME, TRAKT_PASSWORD, TRAKT_REMOVE_WATCHLIST, TRAKT_SYNC_WATCHLIST, TRAKT_METHOD_ADD, TRAKT_START_PAUSED, traktCheckerScheduler, TRAKT_USE_RECOMMENDED, TRAKT_SYNC, TRAKT_DEFAULT_INDEXER, TRAKT_REMOVE_SERIESLIST, TRAKT_DISABLE_SSL_VERIFY, TRAKT_TIMEOUT, \
             USE_PLEX, PLEX_NOTIFY_ONSNATCH, PLEX_NOTIFY_ONDOWNLOAD, PLEX_NOTIFY_ONSUBTITLEDOWNLOAD, PLEX_UPDATE_LIBRARY, \
             PLEX_SERVER_HOST, PLEX_SERVER_TOKEN, PLEX_HOST, PLEX_USERNAME, PLEX_PASSWORD, DEFAULT_BACKLOG_FREQUENCY, MIN_BACKLOG_FREQUENCY, BACKLOG_STARTUP, SKIP_REMOVED_FILES, \
-            showUpdateScheduler, __INITIALIZED__, LAUNCH_BROWSER, UPDATE_SHOWS_ON_START, UPDATE_SHOWS_ON_SNATCH, TRASH_REMOVE_SHOW, TRASH_ROTATE_LOGS, SORT_ARTICLE, showList, loadingShowList, \
+            showUpdateScheduler, __INITIALIZED__, LAUNCH_BROWSER, UPDATE_SHOWS_ON_START, UPDATE_SHOWS_ON_SNATCH, TRASH_REMOVE_SHOW, TRASH_ROTATE_LOGS, TRASH_REMOVE_MEDIA_FILES, SORT_ARTICLE, showList, loadingShowList, \
             NEWZNAB_DATA, NZBS, NZBS_UID, NZBS_HASH, INDEXER_DEFAULT, INDEXER_TIMEOUT, USENET_RETENTION, TORRENT_DIR, \
             QUALITY_DEFAULT, FLATTEN_FOLDERS_DEFAULT, SUBTITLES_DEFAULT, STATUS_DEFAULT, DAILYSEARCH_STARTUP, \
             GROWL_NOTIFY_ONSNATCH, GROWL_NOTIFY_ONDOWNLOAD, GROWL_NOTIFY_ONSUBTITLEDOWNLOAD, TWITTER_NOTIFY_ONSNATCH, TWITTER_NOTIFY_ONDOWNLOAD, TWITTER_NOTIFY_ONSUBTITLEDOWNLOAD, USE_FREEMOBILE, FREEMOBILE_ID, FREEMOBILE_APIKEY, FREEMOBILE_NOTIFY_ONSNATCH, FREEMOBILE_NOTIFY_ONDOWNLOAD, FREEMOBILE_NOTIFY_ONSUBTITLEDOWNLOAD, \
@@ -535,8 +541,8 @@ def initialize(consoleLogging=True):
             USE_NMA, NMA_NOTIFY_ONSNATCH, NMA_NOTIFY_ONDOWNLOAD, NMA_NOTIFY_ONSUBTITLEDOWNLOAD, NMA_API, NMA_PRIORITY, \
             USE_PUSHALOT, PUSHALOT_NOTIFY_ONSNATCH, PUSHALOT_NOTIFY_ONDOWNLOAD, PUSHALOT_NOTIFY_ONSUBTITLEDOWNLOAD, PUSHALOT_AUTHORIZATIONTOKEN, \
             USE_PUSHBULLET, PUSHBULLET_NOTIFY_ONSNATCH, PUSHBULLET_NOTIFY_ONDOWNLOAD, PUSHBULLET_NOTIFY_ONSUBTITLEDOWNLOAD, PUSHBULLET_API, PUSHBULLET_DEVICE, \
-            versionCheckScheduler, VERSION_NOTIFY, AUTO_UPDATE, NOTIFY_ON_UPDATE, PROCESS_AUTOMATICALLY, UNPACK, CPU_PRESET, \
-            KEEP_PROCESSED_DIR, PROCESS_METHOD, DELRARCONTENTS, TV_DOWNLOAD_DIR, MIN_DAILYSEARCH_FREQUENCY, DEFAULT_UPDATE_FREQUENCY, MIN_UPDATE_FREQUENCY, UPDATE_FREQUENCY, \
+            versionCheckScheduler, VERSION_NOTIFY, AUTO_UPDATE, NOTIFY_ON_UPDATE, PROCESS_AUTOMATICALLY, UNPACK, CPU_PRESET, DELETE_CHECKER, deleteCheckerScheduler, \
+            KEEP_PROCESSED_DIR, PROCESS_METHOD, DELRARCONTENTS, TV_DOWNLOAD_DIR, MIN_DAILYSEARCH_FREQUENCY, DEFAULT_UPDATE_FREQUENCY, MIN_UPDATE_FREQUENCY, UPDATE_FREQUENCY, DELETE_FILES_STATUS, \
             showQueueScheduler, searchQueueScheduler, ROOT_DIRS, CACHE_DIR, ACTUAL_CACHE_DIR, TIMEZONE_DISPLAY, \
             NAMING_PATTERN, NAMING_MULTI_EP, NAMING_ANIME_MULTI_EP, NAMING_FORCE_FOLDERS, NAMING_ABD_PATTERN, NAMING_CUSTOM_ABD, NAMING_SPORTS_PATTERN, NAMING_CUSTOM_SPORTS, NAMING_ANIME_PATTERN, NAMING_CUSTOM_ANIME, NAMING_STRIP_YEAR, \
             RENAME_EPISODES, AIRDATE_EPISODES, properFinderScheduler, PROVIDER_ORDER, autoPostProcesserScheduler, \
@@ -555,7 +561,7 @@ def initialize(consoleLogging=True):
             METADATA_WDTV, METADATA_TIVO, METADATA_MEDE8ER, IGNORE_WORDS, REQUIRE_WORDS, CALENDAR_UNPROTECTED, CREATE_MISSING_SHOW_DIRS, \
             ADD_SHOWS_WO_DIR, USE_SUBTITLES, SUBTITLES_LANGUAGES, SUBTITLES_DIR, SUBTITLES_SERVICES_LIST, SUBTITLES_SERVICES_ENABLED, SUBTITLES_HISTORY, SUBTITLES_FINDER_FREQUENCY, SUBTITLES_MULTI, subtitlesFinderScheduler, \
             USE_FAILED_DOWNLOADS, DELETE_FAILED, ANON_REDIRECT, LOCALHOST_IP, TMDB_API_KEY, DEBUG, PROXY_SETTING, PROXY_INDEXERS, \
-            AUTOPOSTPROCESSER_FREQUENCY, SHOWUPDATE_HOUR, DEFAULT_AUTOPOSTPROCESSER_FREQUENCY, MIN_AUTOPOSTPROCESSER_FREQUENCY, \
+            AUTOPOSTPROCESSER_FREQUENCY, SHOWUPDATE_HOUR, DEFAULT_AUTOPOSTPROCESSER_FREQUENCY, MIN_AUTOPOSTPROCESSER_FREQUENCY, DELETE_CHECKER_FREQUENCY, \
             ANIME_DEFAULT, NAMING_ANIME, ANIMESUPPORT, USE_ANIDB, ANIDB_USERNAME, ANIDB_PASSWORD, ANIDB_USE_MYLIST, \
             ANIME_SPLIT_HOME, SCENE_DEFAULT, PLAY_VIDEOS, DOWNLOAD_URL, BACKLOG_DAYS, GIT_ORG, GIT_REPO, GIT_USERNAME, GIT_PASSWORD, \
             GIT_AUTOISSUES, DEVELOPER, gh
@@ -729,6 +735,7 @@ def initialize(consoleLogging=True):
         UPDATE_SHOWS_ON_SNATCH = bool(check_setting_int(CFG, 'General', 'update_shows_on_snatch', 0))
         TRASH_REMOVE_SHOW = bool(check_setting_int(CFG, 'General', 'trash_remove_show', 0))
         TRASH_ROTATE_LOGS = bool(check_setting_int(CFG, 'General', 'trash_rotate_logs', 0))
+        TRASH_REMOVE_MEDIA_FILES = bool(check_setting_int(CFG, 'General', 'trash_remove_media_files', 0))
 
         SORT_ARTICLE = bool(check_setting_int(CFG, 'General', 'sort_article', 0))
 
@@ -796,12 +803,19 @@ def initialize(consoleLogging=True):
         BACKLOG_STARTUP = bool(check_setting_int(CFG, 'General', 'backlog_startup', 1))
         SKIP_REMOVED_FILES = bool(check_setting_int(CFG, 'General', 'skip_removed_files', 0))
 
+        DELETE_FILES_STATUS = check_setting_str(CFG, 'General', 'delete_files_status', '')
+        if DELETE_FILES_STATUS not in ('ARCHIVED', 'IGNORED', 'SKIPPED'):
+            DELETE_FILES_STATUS = 'ARCHIVED'
+
         USENET_RETENTION = check_setting_int(CFG, 'General', 'usenet_retention', 500)
 
         AUTOPOSTPROCESSER_FREQUENCY = check_setting_int(CFG, 'General', 'autopostprocesser_frequency',
                                                         DEFAULT_AUTOPOSTPROCESSER_FREQUENCY)
         if AUTOPOSTPROCESSER_FREQUENCY < MIN_AUTOPOSTPROCESSER_FREQUENCY:
             AUTOPOSTPROCESSER_FREQUENCY = MIN_AUTOPOSTPROCESSER_FREQUENCY
+
+        DELETE_CHECKER_FREQUENCY = check_setting_int(CFG, 'General', 'delete_checker_frequency',
+                                                        DEFAULT_DELETE_CHECKER_FREQUENCY)
 
         DAILYSEARCH_FREQUENCY = check_setting_int(CFG, 'General', 'dailysearch_frequency',
                                                   DEFAULT_DAILYSEARCH_FREQUENCY)
@@ -828,6 +842,7 @@ def initialize(consoleLogging=True):
 
         TV_DOWNLOAD_DIR = check_setting_str(CFG, 'General', 'tv_download_dir', '')
         PROCESS_AUTOMATICALLY = bool(check_setting_int(CFG, 'General', 'process_automatically', 0))
+        DELETE_CHECKER = bool(check_setting_int(CFG, 'General', 'delete_checker', 0))
         UNPACK = bool(check_setting_int(CFG, 'General', 'unpack', 0))
         RENAME_EPISODES = bool(check_setting_int(CFG, 'General', 'rename_episodes', 1))
         AIRDATE_EPISODES = bool(check_setting_int(CFG, 'General', 'airdate_episodes', 0))
@@ -1312,6 +1327,11 @@ def initialize(consoleLogging=True):
                                                        threadName="FINDSUBTITLES",
                                                        silent=not USE_SUBTITLES)
 
+        deleteCheckerScheduler = scheduler.Scheduler(deleteChecker.DeleteChecker(),
+                                                       cycleTime=datetime.timedelta(minutes=DELETE_CHECKER_FREQUENCY),
+                                                       threadName="DELETECHECKER",
+                                                       silent=not DELETE_CHECKER or DELETE_CHECKER == 1 and DELETE_CHECKER_FREQUENCY == 0)
+
         showList = []
         loadingShowList = {}
 
@@ -1323,7 +1343,7 @@ def start():
     global __INITIALIZED__, backlogSearchScheduler, \
         showUpdateScheduler, versionCheckScheduler, showQueueScheduler, \
         properFinderScheduler, autoPostProcesserScheduler, searchQueueScheduler, \
-        subtitlesFinderScheduler, USE_SUBTITLES, traktCheckerScheduler, \
+        subtitlesFinderScheduler, USE_SUBTITLES, traktCheckerScheduler, deleteCheckerScheduler, \
         dailySearchScheduler, events, started
 
     with INIT_LOCK:
@@ -1365,6 +1385,10 @@ def start():
             if USE_TRAKT:
                 traktCheckerScheduler.start()
 
+            # start the delete checker
+            if DELETE_CHECKER == 1 and DELETE_CHECKER_FREQUENCY > 0:
+                deleteCheckerScheduler.start()
+
             started = True
 
 
@@ -1372,7 +1396,7 @@ def halt():
     global __INITIALIZED__, backlogSearchScheduler, \
         showUpdateScheduler, versionCheckScheduler, showQueueScheduler, \
         properFinderScheduler, autoPostProcesserScheduler, searchQueueScheduler, \
-        subtitlesFinderScheduler, traktCheckerScheduler, \
+        subtitlesFinderScheduler, traktCheckerScheduler, deleteCheckerScheduler, \
         dailySearchScheduler, events, started
 
     with INIT_LOCK:
@@ -1443,6 +1467,14 @@ def halt():
                 logger.log(u"Waiting for the TRAKTCHECKER thread to exit")
                 try:
                     traktCheckerScheduler.join(10)
+                except:
+                    pass
+
+            if DELETE_CHECKER == 1 and DELETE_CHECKER_FREQUENCY > 0:
+                deleteCheckerScheduler.stop.set()
+                logger.log(u"Waiting for the DELETECHECKER thread to exit")
+                try:
+                    deleteCheckerScheduler.join(10)
                 except:
                     pass
 
@@ -1549,6 +1581,7 @@ def save_config():
     new_config['General']['torrent_method'] = TORRENT_METHOD
     new_config['General']['usenet_retention'] = int(USENET_RETENTION)
     new_config['General']['autopostprocesser_frequency'] = int(AUTOPOSTPROCESSER_FREQUENCY)
+    new_config['General']['delete_checker_frequency'] = int(DELETE_CHECKER_FREQUENCY)
     new_config['General']['dailysearch_frequency'] = int(DAILYSEARCH_FREQUENCY)
     new_config['General']['backlog_frequency'] = int(BACKLOG_FREQUENCY)
     new_config['General']['update_frequency'] = int(UPDATE_FREQUENCY)
@@ -1587,6 +1620,7 @@ def save_config():
     new_config['General']['update_shows_on_snatch'] = int(UPDATE_SHOWS_ON_SNATCH)
     new_config['General']['trash_remove_show'] = int(TRASH_REMOVE_SHOW)
     new_config['General']['trash_rotate_logs'] = int(TRASH_ROTATE_LOGS)
+    new_config['General']['trash_remove_media_files'] = int(TRASH_REMOVE_MEDIA_FILES)
     new_config['General']['sort_article'] = int(SORT_ARTICLE)
     new_config['General']['proxy_setting'] = PROXY_SETTING
     new_config['General']['proxy_indexers'] = int(PROXY_INDEXERS)
@@ -1607,12 +1641,14 @@ def save_config():
     new_config['General']['tv_download_dir'] = TV_DOWNLOAD_DIR
     new_config['General']['keep_processed_dir'] = int(KEEP_PROCESSED_DIR)
     new_config['General']['process_method'] = PROCESS_METHOD
+    new_config['General']['delete_files_status'] = DELETE_FILES_STATUS
     new_config['General']['del_rar_contents'] = int(DELRARCONTENTS)
     new_config['General']['move_associated_files'] = int(MOVE_ASSOCIATED_FILES)
     new_config['General']['sync_files'] = SYNC_FILES
     new_config['General']['postpone_if_sync_files'] = int(POSTPONE_IF_SYNC_FILES)
     new_config['General']['nfo_rename'] = int(NFO_RENAME)
     new_config['General']['process_automatically'] = int(PROCESS_AUTOMATICALLY)
+    new_config['General']['delete_checker'] = int(DELETE_CHECKER)
     new_config['General']['unpack'] = int(UNPACK)
     new_config['General']['rename_episodes'] = int(RENAME_EPISODES)
     new_config['General']['airdate_episodes'] = int(AIRDATE_EPISODES)

--- a/sickbeard/deleteChecker.py
+++ b/sickbeard/deleteChecker.py
@@ -1,0 +1,57 @@
+# Author: Eiber
+# URL: http://code.google.com/p/sickbeard/
+#
+# This file is part of SickRage.
+#
+# SickRage is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# SickRage is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with SickRage. If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import traceback
+import datetime
+import sickbeard
+
+from sickbeard import db
+from sickbeard import tv
+from sickbeard import logger
+from sickbeard import helpers
+
+class DeleteChecker():
+
+    def run(self, force=False):
+        logger.log(u"Begin check if files need to be deleted/trashed")
+
+        myDB = db.DBConnection()
+        sqlResults = myDB.select("SELECT * FROM delete_media")
+
+        for sqlEp in sqlResults:
+
+            if datetime.datetime.strptime(sqlEp["action_time"], "%Y-%m-%d %H:%M:%S.%f") + datetime.timedelta(minutes=sickbeard.DELETE_CHECKER_FREQUENCY) < datetime.datetime.now():
+
+                showObj = helpers.findCertainShow(sickbeard.showList, int(sqlEp["showid"]))
+                if not showObj:
+                    logger.log(u'Show not found', logger.DEBUG)
+                    return
+                
+                epObj = showObj.getEpisode(int(sqlEp["season"]), int(sqlEp["episode"]))
+                if isinstance(epObj, str):
+                    logger.log(u'Episode not found', logger.DEBUG)
+                    return
+
+                if epObj.deleteMedia() == False:
+                    logger.log(u'Removing file(s) has failed. Retry on next run', logger.ERROR)
+                else:
+                    sql_l = [["DELETE FROM delete_media WHERE showid=? AND season=? AND episode=?", [sqlEp["showid"], sqlEp["season"], sqlEp["episode"]]],
+                             ["UPDATE tv_episodes SET delete_media=? WHERE showid=? AND season=? AND episode=?", ['', sqlEp["showid"], sqlEp["season"], sqlEp["episode"]]]]
+                    myDB = db.DBConnection()
+                    myDB.mass_action(sql_l)

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -1337,6 +1337,7 @@ class TVEpisode(object):
         self._is_proper = False
         self._version = 0
         self._release_group = ''
+        self._delete_media = ''
 
         # setting any of the above sets the dirty flag
         self.dirty = True
@@ -1381,6 +1382,7 @@ class TVEpisode(object):
     is_proper = property(lambda self: self._is_proper, dirty_setter("_is_proper"))
     version = property(lambda self: self._version, dirty_setter("_version"))
     release_group = property(lambda self: self._release_group, dirty_setter("_release_group"))
+    delete_media = property(lambda self: self._delete_media, dirty_setter("_delete_media"))
 
     def _set_location(self, new_location):
         logger.log(u"Setter sets location to " + new_location, logger.DEBUG)
@@ -1527,6 +1529,80 @@ class TVEpisode(object):
                         raise exceptions.EpisodeNotFoundException(
                             "Couldn't find episode " + str(season) + "x" + str(episode))
 
+    def list_associated_files(self, file_path, base_name_only=True):
+
+        file_path_list = []
+        base_name = file_path.rpartition('.')[0]
+
+        if not base_name_only:
+            base_name = base_name + '.'
+
+        # don't strip it all and use cwd by accident
+        if not base_name:
+            return []
+
+        # don't confuse glob with chars we didn't mean to use
+        base_name = re.sub(r'[\[\]\*\?]', r'[\g<0>]', base_name)
+        for associated_file_path in ek.ek(glob.glob, base_name + '*'):
+		   # only add associated to list
+            if associated_file_path == file_path:
+                continue
+            if ek.ek(os.path.isfile, associated_file_path):
+                file_path_list.append(associated_file_path)
+        return file_path_list
+
+    def deleteMedia(self):
+
+        file_path = self.location
+        file_list = [file_path]
+        file_list = file_list + self.list_associated_files(file_path)
+
+        action = ('delete', 'trash')[sickbeard.TRASH_REMOVE_MEDIA_FILES]
+
+        if not file_path:
+            logger.log(u"There were no files associated, not deleting anything", logger.DEBUG)
+            return
+
+        # delete media file	
+        for cur_file in file_list:
+            logger.log(u'Attempt to %s file %s' % (action, cur_file))
+            if ek.ek(os.path.isfile, cur_file):
+                try:
+                    ek.ek(os.chmod, cur_file, stat.S_IWRITE)
+                    if sickbeard.TRASH_REMOVE_MEDIA_FILES:
+                        send2trash(cur_file)
+                        logger.log(u'%s file %s' % (('Deleted', 'Trashed')[sickbeard.TRASH_REMOVE_MEDIA_FILES], cur_file))
+                    else:
+                        ek.ek(os.remove, cur_file)
+                        logger.log(u'%s file %s' % (('Deleted', 'Trashed')[sickbeard.TRASH_REMOVE_MEDIA_FILES], cur_file))
+                except Exception as e:
+                    logger.log(u'Unable to %s file: %s' % (('delete', 'trash')[sickbeard.TRASH_REMOVE_MEDIA_FILES], str(e)), logger.ERROR)
+                    return False
+
+        self.location = ""
+        self.subtitles = list()
+        self.release_name = ""
+        self.delete_media = ""
+        self.subtitles_searchcount = 0
+        self.subtitles_lastsearch = str(datetime.datetime.min)
+        self.hasnfo = False
+        self.hastbn = False
+        self.saveToDB()
+        myDB = db.DBConnection()
+        myDB.action("DELETE FROM history WHERE showid=? AND season=? AND episode=?", [self.show.indexerid, self.season, self.episode])
+        return True
+
+    def delaydeleteMedia(self):
+
+        file_path = self.location
+        if not file_path:
+            logger.log(u"There were no files associated, not deleting anything", logger.DEBUG)
+            return
+
+        self.delete_media = 'delete'
+        myDB = db.DBConnection()
+        myDB.action("INSERT INTO delete_media (showid, season, episode, location, status, action_time) VALUES (?,?,?,?,?,?)", [self.show.indexerid, self.season, self.episode, self.location, self.status, datetime.datetime.now()])
+
     def loadFromDB(self, season, episode):
         logger.log(
             str(self.show.indexerid) + u": Loading episode details from DB for episode " + str(season) + "x" + str(
@@ -1614,6 +1690,9 @@ class TVEpisode(object):
 
             if sqlResults[0]["release_group"] is not None:
                 self.release_group = sqlResults[0]["release_group"]
+
+            if sqlResults[0]["delete_media"] is not None:
+                self.delete_media = sqlResults[0]["delete_media"]
 
             self.dirty = False
             return True
@@ -1973,12 +2052,12 @@ class TVEpisode(object):
                     "UPDATE tv_episodes SET indexerid = ?, indexer = ?, name = ?, description = ?, subtitles = ?, "
                     "subtitles_searchcount = ?, subtitles_lastsearch = ?, airdate = ?, hasnfo = ?, hastbn = ?, status = ?, "
                     "location = ?, file_size = ?, release_name = ?, is_proper = ?, showid = ?, season = ?, episode = ?, "
-                    "absolute_number = ?, version = ?, release_group = ? WHERE episode_id = ?",
+                    "absolute_number = ?, version = ?, release_group = ?, delete_media = ? WHERE episode_id = ?",
                     [self.indexerid, self.indexer, self.name, self.description, ",".join([sub for sub in self.subtitles]),
                      self.subtitles_searchcount, self.subtitles_lastsearch, self.airdate.toordinal(), self.hasnfo,
                      self.hastbn,
                      self.status, self.location, self.file_size, self.release_name, self.is_proper, self.show.indexerid,
-                     self.season, self.episode, self.absolute_number, self.version, self.release_group, epID]]
+                     self.season, self.episode, self.absolute_number, self.version, self.release_group, self.delete_media, epID]]
             else:
                 # Don't update the subtitle language when the srt file doesn't contain the alpha2 code, keep value from subliminal
                 return [
@@ -1996,15 +2075,15 @@ class TVEpisode(object):
             return [
                 "INSERT OR IGNORE INTO tv_episodes (episode_id, indexerid, indexer, name, description, subtitles, "
                 "subtitles_searchcount, subtitles_lastsearch, airdate, hasnfo, hastbn, status, location, file_size, "
-                "release_name, is_proper, showid, season, episode, absolute_number, version, release_group) VALUES "
+                "release_name, is_proper, showid, season, episode, absolute_number, version, release_group, delete_media) VALUES "
                 "((SELECT episode_id FROM tv_episodes WHERE showid = ? AND season = ? AND episode = ?)"
-                ",?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?);",
+                ",?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?);",
                 [self.show.indexerid, self.season, self.episode, self.indexerid, self.indexer, self.name,
                  self.description,
                  ",".join([sub for sub in self.subtitles]), self.subtitles_searchcount, self.subtitles_lastsearch,
                  self.airdate.toordinal(), self.hasnfo, self.hastbn, self.status, self.location, self.file_size,
                  self.release_name, self.is_proper, self.show.indexerid, self.season, self.episode,
-                 self.absolute_number, self.version, self.release_group]]
+                 self.absolute_number, self.version, self.release_group, self.delete_media]]
 
     def saveToDB(self, forceSave=False):
         """
@@ -2039,7 +2118,8 @@ class TVEpisode(object):
                         "is_proper": self.is_proper,
                         "absolute_number": self.absolute_number,
                         "version": self.version,
-                        "release_group": self.release_group
+                        "release_group": self.release_group,
+                        "delete_media": self.delete_media
         }
         controlValueDict = {"showid": self.show.indexerid,
                             "season": self.season,

--- a/sickbeard/webapi.py
+++ b/sickbeard/webapi.py
@@ -1006,6 +1006,19 @@ class CMD_EpisodeSetStatus(ApiCall):
                     failure = True
                     continue
 
+                if sickbeard.DELETE_CHECKER:
+                    if int(status) == ARCHIVED and sickbeard.DELETE_FILES_STATUS == 'ARCHIVED' or int(status) == IGNORED and sickbeard.DELETE_FILES_STATUS == 'IGNORED' or int(status) == SKIPPED and sickbeard.DELETE_FILES_STATUS == 'SKIPPED':
+
+                        # delete media files without delay
+                        if sickbeard.DELETE_CHECKER_FREQUENCY == 0:
+                            if epObj.deleteMedia() == False:
+                                continue
+
+                        # delete media files with delay of xx minutes
+                        if sickbeard.DELETE_CHECKER_FREQUENCY > 0:
+                            if epObj.delaydeleteMedia() == False:
+                                continue
+
                 epObj.status = self.status
                 sql_l.append(epObj.get_sql())
 


### PR DESCRIPTION
Feature: 
Ability to let SickGear delete media files automatically when the status of an episode is changed to the desired state (instantly or with a delay time in minutes to prevent mistakes). The desired state could be archived, ignored or skipped and maybe in the feature a new status: watched. This feature may be useful when you don't have fysical access to your media server, and still would like to delete the watched episodes using the web page or API.

How it works:
1. activate/deactivate ability to delete episodes with a desired state on the postprocess config page
2. choose delay time (in minutes) so any mistake in status change can be corrected
3. choose to either delete files permanently or send to trash first so files can be recoverd.
4. after a mistake the planned deletion can be canceled on the displayshow page

There is one thing not working yet, but I don't know you to fix:

The file ajaxEpCancelDelete.js needs to be created in gui/slick/js to show a loading picture and prevent the page from following the link. I've tried but JS I don't know anything about JS. Maybe someone can help?