### PR TITLE
Use Scene Exceptions in Post Processing

### DIFF
--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -917,7 +917,7 @@ def _check_against_names(nameInQuestion, show, season=-1):
     return False
 
 
-def get_show(name, tryIndexers=False):
+def get_show(name, tryIndexers=False, trySceneExceptions=False):
     if not sickbeard.showList:
         return
 
@@ -930,11 +930,16 @@ def get_show(name, tryIndexers=False):
         if cache:
             fromCache = True
             showObj = findCertainShow(sickbeard.showList, int(cache))
-
+        
+        #try indexers    
         if not showObj and tryIndexers:
             showObj = findCertainShow(sickbeard.showList,
                                       searchIndexerForShowID(full_sanitizeSceneName(name), ui=classes.ShowListUI)[2])
-
+        
+        #try scene exceptions
+        if not showObj and trySceneExceptions:
+            showObj = findCertainShow(sickbeard.showList,
+                                      int(sickbeard.scene_exceptions.get_scene_exception_by_name(name)[0]))
         # add show to cache
         if showObj and not fromCache:
             sickbeard.name_cache.addNameToCache(name, showObj.indexerid)

--- a/sickbeard/name_parser/parser.py
+++ b/sickbeard/name_parser/parser.py
@@ -35,12 +35,13 @@ class NameParser(object):
     NORMAL_REGEX = 1
     ANIME_REGEX = 2
 
-    def __init__(self, file_name=True, showObj=None, tryIndexers=False, convert=False,
+    def __init__(self, file_name=True, showObj=None, tryIndexers=False, trySceneExceptions=False, convert=False,
                  naming_pattern=False):
 
         self.file_name = file_name
         self.showObj = showObj
         self.tryIndexers = tryIndexers
+        self.trySceneExceptions = trySceneExceptions
         self.convert = convert
         self.naming_pattern = naming_pattern
 
@@ -191,7 +192,7 @@ class NameParser(object):
             show = None
             if not self.naming_pattern:
                 # try and create a show object for this result
-                show = helpers.get_show(bestResult.series_name, self.tryIndexers)
+                show = helpers.get_show(bestResult.series_name, self.tryIndexers, self.trySceneExceptions)
 
             # confirm passed in show object indexer id matches result show object indexer id
             if show:

--- a/sickbeard/postProcessor.py
+++ b/sickbeard/postProcessor.py
@@ -492,7 +492,7 @@ class PostProcessor(object):
         name = helpers.remove_non_release_groups(helpers.remove_extension(name))
 
         # parse the name to break it into show name, season, and episode
-        np = NameParser(file, tryIndexers=True, convert=True)
+        np = NameParser(file, tryIndexers=True, trySceneExceptions=True, convert=True)
         parse_result = np.parse(name)
 
         # show object

--- a/sickbeard/processTV.py
+++ b/sickbeard/processTV.py
@@ -419,7 +419,7 @@ def already_postprocessed(dirName, videofile, force, result):
         
         #Needed if we have downloaded the same episode @ different quality
         #But we need to make sure we check the history of the episode we're going to PP, and not others
-        np = NameParser(dirName, tryIndexers=True, convert=True)
+        np = NameParser(dirName, tryIndexers=True, trySceneExceptions=True, convert=True)
         try: #if it fails to find any info (because we're doing an unparsable folder (like the TV root dir) it will throw an exception, which we want to ignore
             parse_result = np.parse(dirName)
         except: #ignore the exception, because we kind of expected it, but create parse_result anyway so we can perform a check on it.


### PR DESCRIPTION
- Changed NameParser to include trySceneExceptions boolean
- Changed calls to NameParser from Post Processing function to include
trySceneException=True when tryIndexers is also True.
- Changed get_show function to try looking up a parsed showname in the
scene exceptions table (using get_scene_exception_by_name) if both cache
and Indexer lookups fail and trySceneException is True.

As found here:
https://github.com/SiCKRAGETV/sickrage-issues/issues/25
https://github.com/SiCKRAGETV/sickrage-issues/issues/769
https://github.com/SiCKRAGETV/sickrage-issues/issues/582
https://github.com/SiCKRAGETV/sickrage-issues/issues/356
https://github.com/SiCKRAGETV/sickrage-issues/issues/864

And others.