### PR TITLE
Fixed exception on failing to find show in Scene Exceptions

### DIFF
--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -938,8 +938,10 @@ def get_show(name, tryIndexers=False, trySceneExceptions=False):
         
         #try scene exceptions
         if not showObj and trySceneExceptions:
-            showObj = findCertainShow(sickbeard.showList,
-                                      int(sickbeard.scene_exceptions.get_scene_exception_by_name(name)[0]))
+            ShowID = sickbeard.scene_exceptions.get_scene_exception_by_name(name)[0]
+            if ShowID:
+                showObj = findCertainShow(sickbeard.showList, int(ShowID))
+                
         # add show to cache
         if showObj and not fromCache:
             sickbeard.name_cache.addNameToCache(name, showObj.indexerid)


### PR DESCRIPTION
Whoops... I failed to account for shows actually not being in the scene exceptions. Since it then passes a None to int(), that will throw an exception.
- Assigns ShowID instead of direct calling it. If not None, then it will pass to findCertainShow as an int.
