### PR TITLE
Fix for PP always returning "Problem(s) during Processing"

### DIFF
--- a/sickbeard/processTV.py
+++ b/sickbeard/processTV.py
@@ -179,18 +179,18 @@ def processDir(dirName, nzbName=None, process_method=None, force=False, is_prior
 
     #Don't Link media when the media is extracted from a rar in the same path
     if process_method in ('hardlink', 'symlink') and videoInRar:
-        result.result = process_media(path, videoInRar, nzbName, 'move', force, is_priority, result)
+        process_media(path, videoInRar, nzbName, 'move', force, is_priority, result)
         delete_files(path, rarContent, result)
         for video in set(videoFiles) - set(videoInRar):
-            result.result = process_media(path, [video], nzbName, process_method, force, is_priority, result)
+            process_media(path, [video], nzbName, process_method, force, is_priority, result)
     elif sickbeard.DELRARCONTENTS and videoInRar:
-        result.result = process_media(path, videoInRar, nzbName, process_method, force, is_priority, result)
+        process_media(path, videoInRar, nzbName, process_method, force, is_priority, result)
         delete_files(path, rarContent, result, True)
         for video in set(videoFiles) - set(videoInRar):
-            result.result = process_media(path, [video], nzbName, process_method, force, is_priority, result)
+            process_media(path, [video], nzbName, process_method, force, is_priority, result)
     else:
         for video in videoFiles:
-            result.result = process_media(path, [video], nzbName, process_method, force, is_priority, result)
+            process_media(path, [video], nzbName, process_method, force, is_priority, result)
 
     #Process Video File in all TV Subdir
     for dir in [x for x in dirs if validateDir(path, x, nzbNameOriginal, failed, result)]:


### PR DESCRIPTION
- result.result was falsely assigned the value from the process function
return, which doesn't return anything.
- Will now return the correct strings (Problem when there was a problem,
or succesfully Processed if not)

This problem was exaggerated by changing the function and copying the
erroneous line to all methods.