### PR TITLE
Possible fix to always show collapsed menu menu on mobile

### DIFF
--- a/gui/slick/interfaces/default/inc_top.tmpl
+++ b/gui/slick/interfaces/default/inc_top.tmpl
@@ -6,7 +6,7 @@
 	<head>
 		<meta charset="utf-8">
 		<meta http-equiv="X-UA-Compatible" content="IE=edge">
-		<meta name="viewport" content="width=device-width, initial-scale=1">
+		<meta name="viewport" content="width=device-width, initial-scale=1 user-scalable=no">
 	
 		<title>SickRage - BRANCH:[$sickbeard.BRANCH] - $title</title>
 	


### PR DESCRIPTION
**Pro**: collapsed menu will be always in the screen. Don't need to scroll
**Con**: user can't zoom-in / zoom-out in the phone (or when menu is collapsed. (I still can zoom-in/zoom-on in Chrome for desktop)

http://stackoverflow.com/questions/27319200/bootstrap-navbar-covers-content-on-zoom

Don't know if we can to this too:
http://stackoverflow.com/a/257972

***Before this change:***

![2015-03-07 22 48 27](https://cloud.githubusercontent.com/assets/2620870/6544111/8c0c950a-c51c-11e4-95b7-37c09b40972f.png)

***After this change:***

![2015-03-07 22 47 01](https://cloud.githubusercontent.com/assets/2620870/6544112/927f40c2-c51c-11e4-877c-46d796e64dce.png)

@joshjowen can you check this ? What do you think?