### PR TITLE
Fix error 32 file in use when rotating logfiles on windows

### DIFF
--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -1470,6 +1470,9 @@ def halt():
                 except:
                     pass
 
+            #stop logging, otherwise logrotation will fail on windows
+            logger.shutdown()
+            
             __INITIALIZED__ = False
             started = False
 

--- a/sickbeard/logger.py
+++ b/sickbeard/logger.py
@@ -120,7 +120,11 @@ class Logger(object):
 
             for logger in self.loggers:
                 logger.addHandler(rfh)
-
+                
+    def shutdown(self):
+        
+        logging.shutdown()
+        
     def log(self, msg, level=INFO, *args, **kwargs):
         meThread = threading.currentThread().getName()
         message = meThread + u" :: " + msg


### PR DESCRIPTION
- Added logging.shutdown() on stopping/restarting SR. Should release
opened logfiles.
