### PR TITLE
Change update restart page to restart.tmpl instead of restart_bare.tmpl

### DIFF
--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -1139,7 +1139,7 @@ class Home(WebRoot):
             # do a hard restart
             sickbeard.events.put(sickbeard.events.SystemEvent.RESTART)
 
-            t = PageTemplate(rh=self, file="restart_bare.tmpl")
+            t = PageTemplate(rh=self, file="restart.tmpl")
             return t.respond()
         else:
             return self._genericMessage("Update Failed",


### PR DESCRIPTION
- Fixes the update not using the inc_top.tmpl which handles the css

The restarting page when updating was foogly because it called restart_bare.tmpl. Restart_bare.tmpl is called by restart.tmpl in between the top and bottom templates. This makes sure it uses the correct css for the currently selected theme... This should make it look a lot better.