### PR TITLE
Fix error 32: file in use on logrotation on Windows

### DIFF
--- a/SickBeard.py
+++ b/SickBeard.py
@@ -521,9 +521,11 @@ class SickRage(object):
                     if '--nolaunch' not in popen_list:
                         popen_list += ['--nolaunch']
                     logger.log(u"Restarting SickRage with " + str(popen_list))
+                    logger.shutdown() #shutdown the logger to make sure it's released the logfile BEFORE it restarts SR.
                     subprocess.Popen(popen_list, cwd=os.getcwd())
 
         # system exit
+        logger.shutdown() #Make sure the logger has stopped, just in case
         os._exit(0)
 
 

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -1469,9 +1469,6 @@ def halt():
                     ADBA_CONNECTION.join(10)
                 except:
                     pass
-
-            #stop logging, otherwise logrotation will fail on windows
-            logger.shutdown()
             
             __INITIALIZED__ = False
             started = False


### PR DESCRIPTION
- Moved logging.shutdown() from sickbeard/init to SickRage.py
- Call logging.shutdown() right before spawning new SR instance
- Call logging.shutdown() right before os._exit(0)

This makes sure that the file handles are closed, and that they do not
get reopened by late log entries in the shutdown process (last log entry
is about restarting SR right before respawning the process).