### PR TITLE
Travis-CI has not actually been running the tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,8 @@ before_script:
  - chmod +x ./tests/all_tests.py
 
 script:
-  - ./tests/all_tests.py
+  - cd ./tests
+  - ./all_tests.py
 
 notifications:
   irc: "irc.freenode.net#sickrage-updates"

--- a/tests/all_tests.py
+++ b/tests/all_tests.py
@@ -22,9 +22,17 @@ import glob
 import unittest
 import sys
 
+# Some tests should not be run on a regular basis
+# such as those which will connect to the internet
+blacklist = [
+    'all_tests.py',
+    'issue_submitter_tests.py',
+]
+
+
 class AllTests(unittest.TestCase):
     def setUp(self):
-        self.test_file_strings = [ x for x in glob.glob('*_tests.py') if not x in __file__]
+        self.test_file_strings = [ x for x in glob.glob('*_tests.py') if not x in blacklist ]
         self.module_strings = [file_string[0:len(file_string) - 3] for file_string in self.test_file_strings]
         self.suites = [unittest.defaultTestLoader.loadTestsFromName(file_string) for file_string in self.module_strings]
         self.testSuite = unittest.TestSuite(self.suites)


### PR DESCRIPTION
When `./all_tests.py` is run from outside of the tests directory it fails to run the
majority of the test suite. This is either something that needs to be fixed in
all_tests.py or we need to cd into the tests dir before running them.

This pull request does the later, but if someone would rather solve this problem in all_tests.py this can serve as a place to discuss that.