### PR TITLE
Fix deluge move completed default value

### DIFF
--- a/sickbeard/clients/deluge.py
+++ b/sickbeard/clients/deluge.py
@@ -97,8 +97,7 @@ class DelugeAPI(GenericClient):
     def _add_torrent_uri(self, result):
 
         post_data = json.dumps({"method": "core.add_torrent_magnet",
-                                "params": [result.url, {"move_completed": "true",
-                                                        "move_completed_path": sickbeard.TV_DOWNLOAD_DIR}],
+                                "params": [result.url],
                                 "id": 2
         })
         self._request(method='post', data=post_data)
@@ -110,9 +109,7 @@ class DelugeAPI(GenericClient):
     def _add_torrent_file(self, result):
 
         post_data = json.dumps({"method": "core.add_torrent_file",
-                                "params": [result.name + '.torrent', b64encode(result.content),
-                                           {"move_completed": "true",
-                                            "move_completed_path": sickbeard.TV_DOWNLOAD_DIR}],
+                                "params": [result.name + '.torrent', b64encode(result.content)],
                                 "id": 2
         })
         self._request(method='post', data=post_data)


### PR DESCRIPTION
Use deluge configuration when `move_completed_path` is not defined in sickrage.

With actual code, if deluge is configured to move downloaded files to another directory, it will be overriden with a blank path making deluge keep files in initial download location.

Tested OK !