### PR TITLE
Use consistent behavior in word filtering (global and show settings)

### DIFF
--- a/gui/slick/interfaces/default/config_search.tmpl
+++ b/gui/slick/interfaces/default/config_search.tmpl
@@ -122,7 +122,9 @@
 								<span class="component-title">Ignore words</span>
 								<span class="component-desc">
 									<input type="text" name="ignore_words" value="$sickbeard.IGNORE_WORDS" class="form-control input-sm input350" />
-									<div class="clear-left">results containing any word in the comma separated word list will be ignored</div>
+									<div class="clear-left">results with one or more word from this list will be ignored<br />
+									separate words with a comma, e.g. "word1,word2,word3"
+									</div>
 								</span>
 							</label>
 						</div>
@@ -132,7 +134,9 @@
 								<span class="component-title">Require words</span>
 								<span class="component-desc">
 									<input type="text" name="require_words" value="$sickbeard.REQUIRE_WORDS" class="form-control input-sm input350" />
-									<div class="clear-left">results not containing all words in the comma separated word list will be ignored</div>
+									<div class="clear-left">results with no word from this list will be ignored<br />
+									separate words with a comma, e.g. "word1,word2,word3"
+									</div>
 								</span>
 							</label>
 						</div>

--- a/gui/slick/interfaces/default/editShow.tmpl
+++ b/gui/slick/interfaces/default/editShow.tmpl
@@ -120,13 +120,13 @@
 
 <b>Ignored Words:</b></br>
 <input type="text" name="rls_ignore_words" id="rls_ignore_words" value="$show.rls_ignore_words" class="form-control form-control-inline input-sm input350" /><br />
-Results with any of these words in the title will be filtered out<br />
+Results with one or more word from this list will be ignored<br />
 Separate words with a comma, e.g. "word1,word2,word3"<br />
 <br />
 
 <b>Required Words:</b></br>
 <input type="text" name="rls_require_words" id="rls_require_words" value="$show.rls_require_words" class="form-control form-control-inline input-sm input350" /><br />
-Results without one of these words in the title will be filtered out <br />
+Results with no word from this list will be ignored<br />
 Separate words with a comma, e.g. "word1,word2,word3"<br />
 <br />
 

--- a/sickbeard/search.py
+++ b/sickbeard/search.py
@@ -181,25 +181,6 @@ def snatchEpisode(result, endStatus=SNATCHED):
     return True
 
 
-def filter_release_name(name, filter_words):
-    """
-    Filters out results based on filter_words
-
-    name: name to check
-    filter_words : Words to filter on, separated by comma
-
-    Returns: False if the release name is OK, True if it contains one of the filter_words
-    """
-    if filter_words:
-        filters = [re.compile('.*%s.*' % filter.strip(), re.I) for filter in filter_words.split(',')]
-        for regfilter in filters:
-            if regfilter.search(name):
-                logger.log(u"" + name + " contains pattern: " + regfilter.pattern, logger.DEBUG)
-                return True
-
-    return False
-
-
 def pickBestResult(results, show, quality_list=None):
     results = results if isinstance(results, list) else [results]
 
@@ -240,12 +221,12 @@ def pickBestResult(results, show, quality_list=None):
             logger.log(cur_result.name + " is a quality we know we don't want, rejecting it", logger.DEBUG)
             continue
 
-        if show.rls_ignore_words and filter_release_name(cur_result.name, cur_result.show.rls_ignore_words):
+        if show.rls_ignore_words and show_name_helpers.containsAtLeastOneWord(cur_result.name, cur_result.show.rls_ignore_words):
             logger.log(u"Ignoring " + cur_result.name + " based on ignored words filter: " + show.rls_ignore_words,
                        logger.INFO)
             continue
 
-        if show.rls_require_words and not filter_release_name(cur_result.name, cur_result.show.rls_require_words):
+        if show.rls_require_words and not show_name_helpers.containsAtLeastOneWord(cur_result.name, cur_result.show.rls_require_words):
             logger.log(u"Ignoring " + cur_result.name + " based on required words filter: " + show.rls_require_words,
                        logger.INFO)
             continue


### PR DESCRIPTION
Following discution from https://github.com/SiCKRAGETV/sickrage-issues/issues/919

This implements consistent word filtering for global words filtering and show words filtering. In both case, regexp are escaped and only full words are catched.

This has been refactored using a single function `show_name_helpers.containsAtLeastOneWord`. Also labels in UI have been updated accordingly.