### PR TITLE
Change reading torrent content from info to info_hash

### DIFF
--- a/sickbeard/clients/generic.py
+++ b/sickbeard/clients/generic.py
@@ -148,7 +148,13 @@ class GenericClient(object):
             if len(result.hash) == 32:
                 result.hash = b16encode(b32decode(result.hash)).lower()
         else:
-            info = bdecode(result.content)["info"]
+            if 'info_hash' in result.content:
+                info = bdecode(result.content)["info_hash"]
+            elif 'info' in result.content:
+                info = bdecode(result.content)["info"]
+            else:
+                #Raise error
+                info = None
             result.hash = sha1(bencode(info)).hexdigest()
 
         return result


### PR DESCRIPTION
https://wiki.theory.org/BitTorrent_Tracker_Protocol

```
info_hash 
The 20 byte sha1 hash of the bencoded form of the info value from the metainfo file. Note that this is a substring of the metainfo file. Don't forget to URL-encode this.
```