### PR TITLE
Remove tvcache traceback and change to DEBUG

### DIFF
--- a/sickbeard/tvcache.py
+++ b/sickbeard/tvcache.py
@@ -134,8 +134,7 @@ class TVCache():
         except AuthException, e:
             logger.log(u"Authentication error: " + ex(e), logger.ERROR)
         except Exception, e:
-            logger.log(u"Error while searching " + self.provider.name + ", skipping: " + ex(e), logger.ERROR)
-            logger.log(traceback.format_exc(), logger.DEBUG)
+            logger.log(u"Error while searching " + self.provider.name + ", skipping: " + repr(e), logger.DEBUG)
 
     def getRSSFeed(self, url, post_data=None, items=[]):
         handlers = []


### PR DESCRIPTION
Avoid all this. DebuG log is full with this traceback. We only need the error message: timeout

```
2015-03-15 09:01:26 DEBUG    SEARCHQUEUE-BACKLOG-262414 :: [<PROVIDER>] :: Traceback (most recent call last):
AAConnectTimeout: HTTPSConnectionPool(host='****', port=443): Max retries exceeded with url: /login.php (Caused by ConnectTimeoutError(<requests.packages.urllib3.connection.VerifiedHTTPSConnection object at 0x2b11090>, 'Connection to **** timed out. (connect timeout=30)'))
AA    raise ConnectTimeout(e, request=request)
AA  File "/home/pi/SickRage/lib/requests/adapters.py", line 419, in send
AA    r = adapter.send(request, **kwargs)
AA  File "/home/pi/SickRage/lib/requests/sessions.py", line 573, in send
AA    resp = self.send(prep, **send_kwargs)
AA  File "/home/pi/SickRage/lib/requests/sessions.py", line 461, in request
AA    return self.request('POST', url, data=data, json=json, **kwargs)
AA  File "/home/pi/SickRage/lib/requests/sessions.py", line 504, in post
AA    response = self.session.post(self.urls['login'], data=login_params, timeout=30, verify=False)
AA  File "/home/pi/SickRage/sickbeard/providers/<PROVIDER>.py", line 109, in _doLogin
AA    if not self._doLogin():
AA  File "/home/pi/SickRage/sickbeard/providers/<PROVIDER>.py", line 181, in _doSearch
AA    return {'entries': self.provider._doSearch(search_params)}
AA  File "/home/pi/SickRage/sickbeard/providers/<PROVIDER>.py", line 345, in _getRSSData
AA    data = self._getRSSData()
AA  File "/home/pi/SickRage/sickbeard/tvcache.py", line 116, in updateCache
AATraceback (most recent call last):
2015-03-15 09:01:26 ERROR    SEARCHQUEUE-BACKLOG-262414 :: [<PROVIDER>] :: Error while searching <PROVIDER>, skipping: error HTTPSConnectionPool(host='****', port=443): Max retries exceeded with url: /login.php (Caused by ConnectTimeoutError(<requests.packages.urllib3.connection.VerifiedHTTPSConnection object at 0x2b11090>, 'Connection to **** timed out. (connect timeout=30)'))
```