### PR TITLE
Safety feature to convert sqlite3.row results to dict 

### DIFF
--- a/sickbeard/webapi.py
+++ b/sickbeard/webapi.py
@@ -749,7 +749,11 @@ class CMD_ComingEpisodes(ApiCall):
         for curType in self.type:
             finalEpResults[curType] = []
 
-        for ep in sql_results:
+        # Safety Measure to convert rows in sql_results to dict.
+        # This should not be required as the DB connections should only be returning dict results not sqlite3.row_type
+        dict_results = [dict(row) for row in sql_results]
+        
+        for ep in dict_results:
             """
                 Missed:   yesterday... (less than 1week)
                 Today:    today


### PR DESCRIPTION
Phantom changes to the DB connection results in the return of
sqlite3.row results when the connections was set to return dict.row
results before queries are called.  Possible cause is multi-threading
with a global DB connection.