### PR TITLE
Add note to reminder user to add quality pattern in PP renaming

### DIFF
--- a/gui/slick/interfaces/default/config_postProcessing.tmpl
+++ b/gui/slick/interfaces/default/config_postProcessing.tmpl
@@ -283,6 +283,10 @@
                                         <img src="$sbRoot/images/legend16.png" width="16" height="16" alt="[Toggle Key]" id="show_naming_key" title="Toggle Naming Legend" class="legend" class="legend" />
                                     </span>
                                 </label>
+                                <label class="nocheck">
+                                    <span class="component-title">&nbsp;</span>
+                                    <span class="component-desc"><b>NOTE:</b> Dont' forget to add quality pattern. Otherwise after post-procesing the episode will have UNKNOWN quality</span>
+                                 </label>
                             </div>
 
                             <div id="naming_key" class="nocheck" style="display: none;">


### PR DESCRIPTION
@TagForce until we change DB to fix this

UPDATE: the name patterns that SR have, only one have "quality" in it. Won't this cause issues if user select them?

![1](https://cloud.githubusercontent.com/assets/2620870/6708409/bc83d092-cd4e-11e4-8ad8-edba7c2ebb9d.png)
