### PR TITLE
Fix default new special status

### DIFF
--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -1770,7 +1770,10 @@ class TVEpisode(object):
 
                 # if we somehow are still UNKNOWN then just use the shows defined default status or SKIPPED
                 elif self.status == UNKNOWN:
-                    self.status = self.show.default_ep_status
+                    if self.season > 0: #If it's not a special
+                        self.status = self.show.default_ep_status
+                    else:
+                        self.status = SKIPPED
 
                 else:
                     logger.log(


### PR DESCRIPTION
- When status for a new episode is unknown and it is a special, it
should now change its status to SKIPPED rather than default status set
in Show settings.

https://github.com/SiCKRAGETV/sickrage-issues/issues/21