### PR TITLE
Ability to ignore embedded subtitles and layout fixes in config_subtitles.tmpl

### DIFF
--- a/gui/slick/interfaces/default/config_subtitles.tmpl
+++ b/gui/slick/interfaces/default/config_subtitles.tmpl
@@ -63,56 +63,69 @@
                     
 					<fieldset class="component-group-list">
 			            <div class="field-pair">
-                            <input type="checkbox" class="enabler" #if $sickbeard.USE_SUBTITLES then " checked=\"checked\"" else ""# id="use_subtitles" name="use_subtitles">
                             <label for="use_subtitles" class="clearfix">
                                 <span class="component-title">Search Subtitles</span>
+								<span class="component-desc">
+									<input type="checkbox" class="enabler" #if $sickbeard.USE_SUBTITLES then " checked=\"checked\"" else ""# id="use_subtitles" name="use_subtitles">
+								</span>
                             </label>
                         </div>
                         <div id="content_use_subtitles">
 	                        	<div class="field-pair">
-		                            <label class="nocheck">
+		                            <label>
 		                                <span class="component-title">Subtitle Languages</span>
 		                                <span class="component-desc"><input type="text" id="subtitles_languages" name="subtitles_languages" /></span>
 		                            </label>
 		                        </div>
                         		<div class="field-pair">
-	                        		<label class="nocheck">
+	                        		<label>
 		                                <span class="component-title">Subtitle Directory</span>
 		                                <input type="text" value="$sickbeard.SUBTITLES_DIR" id="subtitles_dir" name="subtitles_dir" class="form-control input-sm input350">
 		                            </label>
-	                            	<label class="nocheck">
+	                            	<label>
 	    	                            	<span class="component-title">&nbsp;</span>
 			                                <span class="component-desc">The directory where SickRage should store your <i>Subtitles</i> files.</span>
 	          	                	</label>
-	                            	<label class="nocheck">
+	                            	<label>
 	    	                            	<span class="component-title">&nbsp;</span>
 			                                <span class="component-desc"><b>NOTE:</b> Leave empty if you want store subtitle in episode path.</span>
 	          	                	</label>
                         		</div>
 	                            <div class="field-pair">
-	                            	<label class="nocheck">
+	                            	<label>
 	                                	<span class="component-title">Subtitle Find Frequency</span>
 	                                    <input type="number" name="subtitles_finder_frequency" value="$sickbeard.SUBTITLES_FINDER_FREQUENCY" hours="1" class="form-control input-sm input75" />
-	                                </label>
-	                                <label class="nocheck">
-	                                	<span class="component-title">&nbsp;</span>
-	                                    <span class="component-desc">Time in hours between scans (hours. 1)</span>
+										<span class="component-desc">time in hours between scans (default: 1)</span>
 	                                </label>
 	                            </div>
 		                        <div class="field-pair">
-		                            <input type="checkbox" name="subtitles_history" id="subtitles_history" #if $sickbeard.SUBTITLES_HISTORY then " checked=\"checked\"" else ""#/>
 		                            <label class="clearfix" for="subtitles_history">
 		                                <span class="component-title">Subtitles History</span>
-		                                <span class="component-desc">Log downloaded Subtitle on History page?</span>
+		                                <span class="component-desc">
+											<input type="checkbox" name="subtitles_history" id="subtitles_history" #if $sickbeard.SUBTITLES_HISTORY then " checked=\"checked\"" else ""#/>
+											<p>Log downloaded Subtitle on History page?</p>
+										</span>
 		                            </label>
 		                        </div>                        		
 		                        <div class="field-pair">
-		                            <input type="checkbox" name="subtitles_multi" id="subtitles_multi" #if $sickbeard.SUBTITLES_MULTI then " checked=\"checked\"" else ""#/>
 		                            <label class="clearfix" for="subtitles_multi">
 		                                <span class="component-title">Subtitles Multi-Language</span>
-		                                <span class="component-desc">Append language codes to subtitle filenames?</span>
+		                                <span class="component-desc">
+											<input type="checkbox" name="subtitles_multi" id="subtitles_multi" #if $sickbeard.SUBTITLES_MULTI then " checked=\"checked\"" else ""#/>
+											<p>Append language codes to subtitle filenames?</p>
+										</span>
 		                            </label>
 		                        </div>
+								<div class="field-pair">
+									<label class="clearfix" for="embedded_subtitles_all">
+										<span class="component-title">Embedded Subtitles</span>
+										<span class="component-desc">
+											<input type="checkbox" name="embedded_subtitles_all" id="embedded_subtitles_all" #if $sickbeard.EMBEDDED_SUBTITLES_ALL then " checked=\"checked\"" else ""#/>
+											<p>Ignore subtitles embedded inside video file?</p>
+											<p><b>Warning: </b>this will ignore <u>all</u> embedded subtitles for every video file!</p>
+										</span>
+									</label>
+								</div>   
 	                    <br/><input type="submit" class="btn config_submitter" value="Save Changes" /><br/>
                         </div>
                     </fieldset>

--- a/lib/subliminal/services/addic7ed.py
+++ b/lib/subliminal/services/addic7ed.py
@@ -39,7 +39,7 @@ class Addic7ed(ServiceBase):
     api_based = False
     #TODO: Complete this
     languages = language_set(['ar', 'ca', 'de', 'el', 'en', 'es', 'eu', 'fr', 'ga', 'gl', 'he', 'hr', 'hu',
-                              'it', 'pl', 'pt', 'ro', 'ru', 'se', 'pb'])
+                              'it', 'nl', 'pl', 'pt', 'ro', 'ru', 'se', 'pb'])
     language_map = {'Portuguese (Brazilian)': Language('pob'), 'Greek': Language('gre'),
                     'Spanish (Latin America)': Language('spa'), 'Galego': Language('glg'),
                     u'Català': Language('cat')}

--- a/lib/subliminal/videos.py
+++ b/lib/subliminal/videos.py
@@ -136,14 +136,15 @@ class Video(object):
             return []
         basepath = os.path.splitext(self.path)[0]
         results = []
-        video_infos = None
-        try:
-            video_infos = enzyme.parse(self.path)
-            logger.debug(u'Succeeded parsing %s with enzyme: %r' % (self.path, video_infos)) if sys.platform != 'win32' else logger.debug('Log line suppressed on windows')
-        except:
-            logger.debug(u'Failed parsing %s with enzyme' % self.path) if sys.platform != 'win32' else logger.debug('Log line suppressed on windows')
-        if isinstance(video_infos, enzyme.core.AVContainer):
-            results.extend([subtitles.EmbeddedSubtitle.from_enzyme(self.path, s) for s in video_infos.subtitles])
+        if not sickbeard.EMBEDDED_SUBTITLES_ALL:
+            video_infos = None
+            try:
+                video_infos = enzyme.parse(self.path)
+                logger.debug(u'Succeeded parsing %s with enzyme: %r' % (self.path, video_infos)) if sys.platform != 'win32' else logger.debug('Log line suppressed on windows')
+            except:
+                logger.debug(u'Failed parsing %s with enzyme' % self.path) if sys.platform != 'win32' else logger.debug('Log line suppressed on windows')
+            if isinstance(video_infos, enzyme.core.AVContainer):
+                results.extend([subtitles.EmbeddedSubtitle.from_enzyme(self.path, s) for s in video_infos.subtitles])
         # cannot use glob here because it chokes if there are any square
         # brackets inside the filename, so we have to use basic string
         # startswith/endswith comparisons

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -490,6 +490,7 @@ SUBTITLES_DIR = ''
 SUBTITLES_SERVICES_LIST = []
 SUBTITLES_SERVICES_ENABLED = []
 SUBTITLES_HISTORY = False
+EMBEDDED_SUBTITLES_ALL = False
 SUBTITLES_FINDER_FREQUENCY = 1
 SUBTITLES_MULTI = False
 
@@ -557,7 +558,7 @@ def initialize(consoleLogging=True):
             GUI_NAME, HOME_LAYOUT, HISTORY_LAYOUT, DISPLAY_SHOW_SPECIALS, COMING_EPS_LAYOUT, COMING_EPS_SORT, COMING_EPS_DISPLAY_PAUSED, COMING_EPS_MISSED_RANGE, DISPLAY_FILESIZE, FUZZY_DATING, TRIM_ZERO, DATE_PRESET, TIME_PRESET, TIME_PRESET_W_SECONDS, THEME_NAME, \
             POSTER_SORTBY, POSTER_SORTDIR, \
             METADATA_WDTV, METADATA_TIVO, METADATA_MEDE8ER, IGNORE_WORDS, REQUIRE_WORDS, CALENDAR_UNPROTECTED, NO_RESTART, CREATE_MISSING_SHOW_DIRS, \
-            ADD_SHOWS_WO_DIR, USE_SUBTITLES, SUBTITLES_LANGUAGES, SUBTITLES_DIR, SUBTITLES_SERVICES_LIST, SUBTITLES_SERVICES_ENABLED, SUBTITLES_HISTORY, SUBTITLES_FINDER_FREQUENCY, SUBTITLES_MULTI, subtitlesFinderScheduler, \
+            ADD_SHOWS_WO_DIR, USE_SUBTITLES, SUBTITLES_LANGUAGES, SUBTITLES_DIR, SUBTITLES_SERVICES_LIST, SUBTITLES_SERVICES_ENABLED, SUBTITLES_HISTORY, SUBTITLES_FINDER_FREQUENCY, SUBTITLES_MULTI, EMBEDDED_SUBTITLES_ALL, subtitlesFinderScheduler, \
             USE_FAILED_DOWNLOADS, DELETE_FAILED, ANON_REDIRECT, LOCALHOST_IP, TMDB_API_KEY, DEBUG, PROXY_SETTING, PROXY_INDEXERS, \
             AUTOPOSTPROCESSER_FREQUENCY, SHOWUPDATE_HOUR, DEFAULT_AUTOPOSTPROCESSER_FREQUENCY, MIN_AUTOPOSTPROCESSER_FREQUENCY, \
             ANIME_DEFAULT, NAMING_ANIME, ANIMESUPPORT, USE_ANIDB, ANIDB_USERNAME, ANIDB_PASSWORD, ANIDB_USE_MYLIST, \
@@ -1054,6 +1055,7 @@ def initialize(consoleLogging=True):
                                       if x]
         SUBTITLES_DEFAULT = bool(check_setting_int(CFG, 'Subtitles', 'subtitles_default', 0))
         SUBTITLES_HISTORY = bool(check_setting_int(CFG, 'Subtitles', 'subtitles_history', 0))
+        EMBEDDED_SUBTITLES_ALL = bool(check_setting_int(CFG, 'Subtitles', 'embedded_subtitles_all', 0))
         SUBTITLES_FINDER_FREQUENCY = check_setting_int(CFG, 'Subtitles', 'subtitles_finder_frequency', 1)
         SUBTITLES_MULTI = bool(check_setting_int(CFG, 'Subtitles', 'subtitles_multi', 1))
 
@@ -1979,6 +1981,7 @@ def save_config():
     new_config['Subtitles']['subtitles_dir'] = SUBTITLES_DIR
     new_config['Subtitles']['subtitles_default'] = int(SUBTITLES_DEFAULT)
     new_config['Subtitles']['subtitles_history'] = int(SUBTITLES_HISTORY)
+    new_config['Subtitles']['embedded_subtitles_all'] = int(EMBEDDED_SUBTITLES_ALL)
     new_config['Subtitles']['subtitles_finder_frequency'] = int(SUBTITLES_FINDER_FREQUENCY)
     new_config['Subtitles']['subtitles_multi'] = int(SUBTITLES_MULTI)
 

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -4794,7 +4794,7 @@ class ConfigSubtitles(Config):
 
     def saveSubtitles(self, use_subtitles=None, subtitles_plugins=None, subtitles_languages=None, subtitles_dir=None,
                       service_order=None, subtitles_history=None, subtitles_finder_frequency=None,
-                      subtitles_multi=None):
+                      subtitles_multi=None, embedded_subtitles_all=None):
 
         results = []
 
@@ -4820,6 +4820,7 @@ class ConfigSubtitles(Config):
             subtitles_languages.replace(' ', '').split(','))] if subtitles_languages != '' else ''
         sickbeard.SUBTITLES_DIR = subtitles_dir
         sickbeard.SUBTITLES_HISTORY = config.checkbox_to_value(subtitles_history)
+        sickbeard.EMBEDDED_SUBTITLES_ALL = config.checkbox_to_value(embedded_subtitles_all)
         sickbeard.SUBTITLES_FINDER_FREQUENCY = config.to_int(subtitles_finder_frequency, default=1)
         sickbeard.SUBTITLES_MULTI = config.checkbox_to_value(subtitles_multi)
 


### PR DESCRIPTION
Embedded subtitles are not always of good quality. This adds the ability to ignore embedded subtitles so new subtitles are downloaded. Also added NL in the addic7ed provider.

Note: it would be better to make this function a show setting, but this would need database changes..