### PR TITLE
Added Quality check even if SR itself downloaded the episode

### DIFF
--- a/sickbeard/postProcessor.py
+++ b/sickbeard/postProcessor.py
@@ -762,13 +762,23 @@ class PostProcessor(object):
         if self.is_priority:
             return True
 
-        # if SB downloaded this on purpose then this is a priority download
-        if self.in_history or ep_obj.status in common.Quality.SNATCHED + common.Quality.SNATCHED_PROPER + common.Quality.SNATCHED_BEST:
-            self._log(u"SB snatched this episode so I'm marking it as priority", logger.DEBUG)
-            return True
-
         old_ep_status, old_ep_quality = common.Quality.splitCompositeStatus(ep_obj.status)
 
+        # if SB downloaded this on purpose we likely have a priority download
+        if self.in_history or ep_obj.status in common.Quality.SNATCHED + common.Quality.SNATCHED_PROPER + common.Quality.SNATCHED_BEST:
+            # if the episode is still in a snatched status, then we can assume we want this
+            if ep_obj.status in common.Quality.SNATCHED + common.Quality.SNATCHED_PROPER + common.Quality.SNATCHED_BEST:
+                self._log(u"SB snatched this episode and it is not processed before", logger.DEBUG)
+                return True
+            # if it's not snatched, we only want it if the new quality is higher or if it's a proper of equal or higher quality
+            if new_ep_quality > old_ep_quality and new_ep_quality != common.Quality.UNKNOWN:
+                self._log(u"SB snatched this episode and it is a higher quality so I'm marking it as priority", logger.DEBUG)
+                return True
+            if self.is_proper and new_ep_quality >= old_ep_quality and new_ep_quality != common.Quality.UNKNOWN:
+                self._log(u"SB snatched this episode and it is a proper of equal or higher quality so I'm marking it as priority", logger.DEBUG)
+                return True
+            return False
+            
         # if the user downloaded it manually and it's higher quality than the existing episode then it's priority
         if new_ep_quality > old_ep_quality and new_ep_quality != common.Quality.UNKNOWN:
             self._log(


### PR DESCRIPTION
- Adds check for quality even if SR initiated the download

is_priority will now return False if the episode status is not snatched
and the new quality is lower than the old quality (or lower or equal if
its a proper)

https://github.com/SiCKRAGETV/sickrage-issues/issues/1023 for more info