### PR TITLE
Add RSS to EZTV provider and save magnet link as fallback

### DIFF
--- a/sickbeard/providers/eztv.py
+++ b/sickbeard/providers/eztv.py
@@ -16,13 +16,13 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with Sick Beard.  If not, see <http://www.gnu.org/licenses/>.
-
 import traceback
 import re, datetime
 
 import generic
 from sickbeard import logger, tvcache, db
 from sickbeard.common import Quality
+from sickbeard.bs4_parser import BS4Parser
 
 class EZTVProvider(generic.TorrentProvider):
 
@@ -36,8 +36,9 @@ class EZTVProvider(generic.TorrentProvider):
         self.cache = EZTVCache(self)
 
         self.urls = {
-            'base_url': 'http://eztvapi.re/',
-            'show': 'http://eztvapi.re/show/%s',
+            'base_url': 'https://eztv.ch/',
+            'rss': 'https://eztv.ch/',
+            'episode': 'http://eztvapi.re/show/%s',
         }
 
         self.url = self.urls['base_url']
@@ -65,12 +66,15 @@ class EZTVProvider(generic.TorrentProvider):
         return [search_string]
 
     def getQuality(self, item, anime=False):
-        if item.get('quality') == "480p":
-            return Quality.SDTV
-        elif item.get('quality') == "720p":
-            return Quality.HDWEBDL
-        elif item.get('quality') == "1080p":
-            return Quality.FULLHDWEBDL
+        if 'quality' in item:
+            if item.get('quality') == "480p":
+                return Quality.SDTV
+            elif item.get('quality') == "720p":
+                return Quality.HDWEBDL
+            elif item.get('quality') == "1080p":
+                return Quality.FULLHDWEBDL
+            else:
+                return Quality.sceneQuality(item.get('title'), anime)
         else:
             return Quality.sceneQuality(item.get('title'), anime)
 
@@ -81,45 +85,79 @@ class EZTVProvider(generic.TorrentProvider):
 
         for mode in search_params.keys():
 
-            if mode != 'Episode':
-                logger.log(u"" + self.name + " does not accept " + mode + " mode", logger.DEBUG)
-                return results
+            if mode == 'RSS':
+                for search_string in search_params[mode]:
+                    searchURL = self.urls['rss']
+                    logger.log(u"" + self.name + " search page URL: " + searchURL, logger.DEBUG)
 
-            for search_string in search_params[mode]:
+                    HTML = self.getURL(searchURL)
+                    if not HTML:
+                        logger.log(u"" + self.name + " could not retrieve page URL:" + searchURL, logger.DEBUG)
+                        return results
 
-                searchURL = self.urls['show'] % (search_string['imdb_id'])
-                logger.log(u"" + self.name + " search page URL: " + searchURL, logger.DEBUG)
+                    try:
+                        with BS4Parser(HTML, features=["html5lib", "permissive"]) as parsedHTML:
+                            resultsTable = parsedHTML.find_all('tr', attrs={'name': 'hover', 'class': 'forum_header_border'})
 
-                parsedJSON = self.getURL(searchURL, json=True)
-                if not parsedJSON:
-                    logger.log(u"" + self.name + " could not retrieve page URL:" + searchURL, logger.DEBUG)
-                    return results
+                            if not resultsTable:
+                                logger.log(u"The Data returned from " + self.name + " do not contains any torrent",
+                                           logger.DEBUG)
+                                continue
 
-            try:
-                for episode in parsedJSON['episodes']:
-                    if int(episode.get('season')) == search_string.get('season') and \
-                       int(episode.get('episode')) == search_string.get('episode'):
+                            for entries in resultsTable:
+                                title = entries.find('a', attrs={'class': 'epinfo'}).contents[0]
+                                link = entries.find('a', attrs={'class': 'magnet'}).get('href')
 
-                        for quality in episode['torrents'].keys():
-                            link = episode['torrents'][quality]['url']
-                            title = re.search('&dn=(.*?)&', link).group(1)
+                                item = {
+                                    'title': title,
+                                    'link': link,
+                                }
 
-                            item = {
-                                'title': title,
-                                'link': link,
-                                'quality': quality
-                            }
-
-                            # re.search in case of PROPER|REPACK. In other cases
-                            # add_string is empty, so condition is met.
-                            if re.search(search_string.get('add_string'), title):
                                 items[mode].append(item)
 
-                        break
+                    except Exception, e:
+                        logger.log(u"Failed parsing " + self.name + " Traceback: " + traceback.format_exc(),
+                                    logger.ERROR)
 
-            except Exception, e:
-                logger.log(u"Failed parsing " + self.name + " Traceback: " + traceback.format_exc(),
-                            logger.ERROR)
+            elif mode == 'Episode':
+                for search_string in search_params[mode]:
+                    searchURL = self.urls['episode'] % (search_string['imdb_id'])
+                    logger.log(u"" + self.name + " search page URL: " + searchURL, logger.DEBUG)
+
+                    parsedJSON = self.getURL(searchURL, json=True)
+                    if not parsedJSON:
+                        logger.log(u"" + self.name + " could not retrieve page URL:" + searchURL, logger.DEBUG)
+                        return results
+
+                    try:
+                        for episode in parsedJSON['episodes']:
+                            if int(episode.get('season')) == search_string.get('season') and \
+                               int(episode.get('episode')) == search_string.get('episode'):
+
+                                for quality in episode['torrents'].keys():
+                                    link = episode['torrents'][quality]['url']
+                                    title = re.search('&dn=(.*?)&', link).group(1)
+
+                                    item = {
+                                        'title': title,
+                                        'link': link,
+                                        'quality': quality
+                                    }
+
+                                    # re.search in case of PROPER|REPACK. In other cases
+                                    # add_string is empty, so condition is met.
+                                    if 'add_string' in search_string and  re.search(search_string.get('add_string'), title):
+                                        items[mode].append(item)
+
+                                break
+
+                    except Exception, e:
+                        logger.log(u"Failed parsing " + self.name + " Traceback: " + traceback.format_exc(),
+                                    logger.ERROR)
+
+            else:
+                logger.log(u"" + self.name + " does not accept " + mode + " mode", logger.DEBUG)
+                return results
 
             results += items[mode]
 

--- a/sickbeard/providers/generic.py
+++ b/sickbeard/providers/generic.py
@@ -157,7 +157,6 @@ class GenericProvider:
                 urls = [
                     'http://torcache.net/torrent/' + torrent_hash + '.torrent',
                     'http://zoink.ch/torrent/' + torrent_hash + '.torrent',
-                    'http://torrage.com/torrent/' + torrent_hash.lower() + '.torrent',
                 ]
             except:
                 urls = [result.url]
@@ -183,6 +182,21 @@ class GenericProvider:
 
                 if self._verify_download(filename):
                     return True
+
+        # Fallback: if the torrent link could not be downloaded, we save the magnet link instead
+        # Softwares such as Deluge with plugin AutoAdd can automatically add it, otherwise the user
+        # can add it manually.
+        if self.providerType == GenericProvider.TORRENT:
+            filename_fallback = re.sub(r'torrent$', r'magnet', filename)
+            if filename_fallback != filename and re.match('^magnet:', result.url):
+                try:
+                    f = open(filename_fallback, 'w')
+                    f.write(result.url)
+                    f.close()
+                    logger.log(u"Saved magnet link to " + filename_fallback, logger.INFO)
+                    return True
+                except:
+                    pass
 
         logger.log(u"Failed to download result", logger.WARNING)
         return False


### PR DESCRIPTION
EZTV:
- use of https://eztv.ch as URL for RSS feed, since http://eztvapi.re does not provide RSS.

Generic:
- remove torrage, does not exists anymore
- fallback: save magnet link if torrent could not be downloaded. Some softwares can use it,
  in the worst case the user will have to add it manually.

The fallback is not a perfect solution since not all softwares will handle a ".magnet" file. However, the user does not face a dead end, and still has a possibility to get the torrent. This could be useful if, in the future, services such as zoink or torcache are closed down.