### PR TITLE
Save magnet link as fallback

### DIFF
--- a/sickbeard/providers/generic.py
+++ b/sickbeard/providers/generic.py
@@ -185,6 +185,21 @@ class GenericProvider:
                 if self._verify_download(filename):
                     return True
 
+        # Fallback: if the torrent link could not be downloaded, we save the magnet link instead
+        # Softwares such as Deluge with plugin AutoAdd can automatically add it, otherwise the user
+        # can add it manually.
+        if self.providerType == GenericProvider.TORRENT:
+            filename_fallback = re.sub(r'torrent$', r'magnet', filename)
+            if filename_fallback != filename and re.match('^magnet:', result.url):
+                try:
+                    f = open(filename_fallback, 'w')
+                    f.write(result.url)
+                    f.close()
+                    logger.log(u"Saved magnet link to " + filename_fallback, logger.INFO)
+                    return True
+                except:
+                    pass
+
         logger.log(u"Failed to download result", logger.WARNING)
         return False
 


### PR DESCRIPTION
- Save magnet link if torrent could not be downloaded. Some softwares can use it,
in the worst case the user will have to add it manually.
- Remove torrage, does not exists anymore

The fallback is not a perfect solution since not all softwares will handle a ".magnet" file. However, the user does not face a dead end, and still has a possibility to get the torrent. This could be useful if, in the future, services such as zoink or torcache are closed down.

- [ ] Send notification - if user has any enabled - about the location of the magnet link direcory