### PR TITLE
Fix unicode error in verify_freespace

### DIFF
--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -1514,7 +1514,7 @@ def verify_freespace(src, dest, oldfile=None):
     
     if oldfile:
         for file in oldfile:
-            if os.path.isfile(file.location):
+            if ek.ek(os.path.isfile, file.location):
                 diskfree += ek.ek(os.path.getsize, file.location)
         
     if diskfree > neededspace:


### PR DESCRIPTION
- Fixes unicode error by using EncodingKludge for isfile check instead
of assuming it is unicode.