### PR TITLE
Fix for xml_declaration unexpected keyword in python 2.6.

### DIFF
--- a/sickbeard/metadata/mede8er.py
+++ b/sickbeard/metadata/mede8er.py
@@ -390,7 +390,7 @@ class Mede8erMetadata(mediabrowser.MediaBrowserMetadata):
 
             nfo_file = ek.ek(open, nfo_file_path, 'w')
 
-            data.write(nfo_file, encoding="utf-8", xml_declaration=True)
+            data.write(nfo_file, encoding="UTF-8")
             nfo_file.close()
             helpers.chmodAsParent(nfo_file_path)
         except IOError, e:
@@ -435,7 +435,7 @@ class Mede8erMetadata(mediabrowser.MediaBrowserMetadata):
 
             nfo_file = ek.ek(open, nfo_file_path, 'w')
 
-            data.write(nfo_file, encoding="utf-8", xml_declaration = True)
+            data.write(nfo_file, encoding="UTF-8")
             nfo_file.close()
             helpers.chmodAsParent(nfo_file_path)
         except IOError, e:


### PR DESCRIPTION
SiCKRAGETV/sickrage-issues#1166
Must be 'UTF-8' instead of 'utf-8' to get automatically written as xml and portable across python versions, as xml_declaration does not exist in 2.6.
Should work regardless of version now. Needs Tested.

Note:If this does not work as expected, method="xml" instead of xml_declaration=True should be tried.