### PR TITLE
ShowUpdater: referenced before assignment curQueueItem

### DIFF
--- a/sickbeard/showUpdater.py
+++ b/sickbeard/showUpdater.py
@@ -78,16 +78,14 @@ class ShowUpdater():
                 # if should_update returns True (not 'Ended') or show is selected stale 'Ended' then update, otherwise just refresh
                 if curShow.should_update(update_date=update_date) or curShow.indexerid in stale_should_update:
                     try:
-                        curQueueItem = sickbeard.showQueueScheduler.action.updateShow(curShow, True)  # @UndefinedVariable
+                        piList.append(sickbeard.showQueueScheduler.action.updateShow(curShow, True))  # @UndefinedVariable
                     except exceptions.CantUpdateException as e:
                         logger.log("Unable to update show: {0}".format(str(e)),logger.DEBUG)
                 else:
                     logger.log(
                         u"Not updating episodes for show " + curShow.name + " because it's marked as ended and last/next episode is not within the grace period.",
                         logger.DEBUG)
-                    curQueueItem = sickbeard.showQueueScheduler.action.refreshShow(curShow, True)  # @UndefinedVariable
-
-                piList.append(curQueueItem)
+                    piList.append(sickbeard.showQueueScheduler.action.refreshShow(curShow, True))  # @UndefinedVariable
 
             except (exceptions.CantUpdateException, exceptions.CantRefreshException), e:
                 logger.log(u"Automatic update failed: " + ex(e), logger.ERROR)


### PR DESCRIPTION
A small change to fix https://github.com/SiCKRAGETV/sickrage-issues/issues/1193 : 

UnboundLocalError exception can be thrown at piList.append(curQueueItem) in cases where the CantUpdateException is thrown in the earlier try block around line 81. In this case, curQueueItem is never assigned a value and the list appending fails.

This change just skips the need for a temp holding variable "curQueueItem" and appends directly to the list the return from the updateShow/refreshShow methods.

Now if updateShow does throw a CantUpdateException, the piList.append in the try block is never attempted and so the UnboundLocalError is avoided.

Note: This is my fist github contribution, so apologies if I mess anything up.