### PR TITLE
Auto determine indexer when indexer tag not present in nfo

### DIFF
--- a/sickbeard/metadata/generic.py
+++ b/sickbeard/metadata/generic.py
@@ -951,11 +951,6 @@ class GenericMetadata():
 
             name = showXML.findtext('title')
 
-            try:
-                indexer = int(showXML.findtext('indexer'))
-            except:
-                indexer = None
-
             if showXML.findtext('tvdbid') != None:
                 indexer_id = int(showXML.findtext('tvdbid'))
             elif showXML.findtext('id') != None:
@@ -967,6 +962,18 @@ class GenericMetadata():
             if indexer_id is None:
                 logger.log(u"Invalid Indexer ID (" + str(indexer_id) + "), not using metadata file", logger.WARNING)
                 return empty_return
+
+            indexer = None
+            if showXML.findtext('indexer') != None:
+                indexer = int(showXML.findtext('indexer'))
+            elif showXML.find('episodeguide/url') != None:
+                epg_url = showXML.findtext('episodeguide/url').lower()
+                if str(indexer_id) in epg_url:
+                    if 'thetvdb.com' in epg_url:
+                        indexer = 1
+                    elif 'tvrage' in epg_url:
+                        indexer = 2
+
 
         except Exception, e:
             logger.log(

--- a/sickbeard/metadata/kodi_12plus.py
+++ b/sickbeard/metadata/kodi_12plus.py
@@ -153,11 +153,8 @@ class KODI_12PlusMetadata(generic.GenericMetadata):
 
         episodeguide = etree.SubElement(tv_node, "episodeguide")
         episodeguideurl = etree.SubElement(episodeguide, "url")
-        episodeguideurl2 = etree.SubElement(tv_node, "episodeguideurl")
         if getattr(myShow, 'id', None) is not None:
-            showurl = sickbeard.indexerApi(show_obj.indexer).config['base_url'] + str(myShow["id"]) + '/all/en.zip'
-            episodeguideurl.text = showurl
-            episodeguideurl2.text = showurl
+            episodeguideurl.text = sickbeard.indexerApi(show_obj.indexer).config['base_url'] + str(myShow["id"]) + '/all/en.zip'
 
         mpaa = etree.SubElement(tv_node, "mpaa")
         if getattr(myShow, 'contentrating', None) is not None:


### PR DESCRIPTION
Fixes adding existing shows automation.

Removed "episodeguideurl" tag from being created in the nfo as it is not valid and kodi doesn't even read it.

TODO: Find why indexer and id are set twice each in nfo files created by SR

Fixes https://github.com/SiCKRAGETV/sickrage-issues/issues/1205