### PR TITLE
Added the option 25 and 50 lines to the history page.

### DIFF
--- a/gui/slick/interfaces/default/history.tmpl
+++ b/gui/slick/interfaces/default/history.tmpl
@@ -88,6 +88,8 @@
 #end if
 <div class="h2footer pull-right"><b>Limit:</b> 
     <select name="limit" id="limit" class="form-control form-control-inline input-sm">
+        <option value="25" #if $limit == "25" then "selected=\"selected\"" else ""#>25</option>	
+        <option value="50" #if $limit == "50" then "selected=\"selected\"" else ""#>50</option>	
         <option value="100" #if $limit == "100" then "selected=\"selected\"" else ""#>100</option>
         <option value="250" #if $limit == "250" then "selected=\"selected\"" else ""#>250</option>
         <option value="500" #if $limit == "500" then "selected=\"selected\"" else ""#>500</option>


### PR DESCRIPTION
This gives users the option to load less data and speed up the History page loading.