### PR TITLE
Ignore OSError when obtaining the size of a path.

### DIFF
--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -1411,9 +1411,9 @@ def get_size(start_path='.'):
             fp = ek.ek(os.path.join, dirpath, f)
             try:
                 total_size += ek.ek(os.path.getsize, fp)
-            except OSError, e:
-                logger.log(u"Unable to get size for file " + fp + ": " + repr(e) + " / " + str(e),
-                                           logger.DEBUG)
+            except OSError as e:
+                logger.log('Unable to get size for file {filePath}. Error msg is: {errorMsg}'.format(filePath=fp, errorMsg=str(e)), logger.ERROR)
+                logger.log(traceback.format_exc(), logger.DEBUG)
     return total_size
 
 def generateApiKey():

--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -1409,7 +1409,11 @@ def get_size(start_path='.'):
     for dirpath, dirnames, filenames in ek.ek(os.walk, start_path):
         for f in filenames:
             fp = ek.ek(os.path.join, dirpath, f)
-            total_size += ek.ek(os.path.getsize, fp)
+            try:
+                total_size += ek.ek(os.path.getsize, fp)
+            except OSError, e:
+                logger.log(u"Unable to get size for file " + fp + ": " + repr(e) + " / " + str(e),
+                                           logger.DEBUG)
     return total_size
 
 def generateApiKey():


### PR DESCRIPTION
Fix bug where a broken symlink will break viewing a show.
Reference: SiCKRAGETV/sickrage-issues#1224
