### PR TITLE
Fix Title of None for Errors submitted through UI

### DIFF
--- a/sickbeard/classes.py
+++ b/sickbeard/classes.py
@@ -276,6 +276,6 @@ class UIError():
     """
 
     def __init__(self, message):
-        self.title = sys.exc_info()[-2]
+        self.title = sys.exc_info()[-2] or message
         self.message = message
         self.time = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')


### PR DESCRIPTION
- Changes the title assignment to use the message if there is no
Exception that generated the error. Should fix submitting errors that
were handled by SR itself, rather than an exception like configuration
errors or the like.

fixes https://github.com/SiCKRAGETV/sickrage-issues/issues/1282