### PR TITLE
Fix NoneType object has no attribute getOverview

### DIFF
--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -1954,7 +1954,11 @@ class Home(WebRoot):
         def getEpisodes(searchThread, searchstatus):
             results = []
             showObj = sickbeard.helpers.findCertainShow(sickbeard.showList, int(searchThread.show.indexerid))
-
+            
+            if not ShowObj:
+                logger.log('No Show Object found for show with indexerID: ' + searchThread.show.indexerid, logger.ERROR)
+                return results
+            
             if isinstance(searchThread, sickbeard.search_queue.ManualSearchQueueItem):
                 results.append({'show': searchThread.show.indexerid,
                                 'episode': searchThread.segment.episode,


### PR DESCRIPTION
- Fixes AttributeError: 'NoneType' object has no attribute 'getOverview'
exception in rare cases when removing a show for which a search is still
running.

Will handle the exception and log the show's indexerID to make debugging
easier.

This will not fix the root cause, which is that the search queues will
not be properly emptied when deleting a show. This will make sure we are
able to check if this is really the cause.