### PR TITLE
Hotfix: Remove Success codes from http_error_code list

### DIFF
--- a/sickbeard/clients/__init__.py
+++ b/sickbeard/clients/__init__.py
@@ -30,19 +30,6 @@ from os import sys
 
 # Mapping error status codes to official W3C names
 http_error_code = {
-    100: 'Continue',
-    101: 'Switching Protocols',
-    102: 'Processing',
-    200: 'OK',
-    201: 'Created',
-    202: 'Accepted',
-    203: 'Non-Authoritative Information',
-    204: 'No Content',
-    205: 'Reset Content',
-    206: 'Partial Content',
-    207: 'Multi-Status',
-    208: 'Already Reported',
-    226: 'IM Used',
     300: 'Multiple Choices',
     301: 'Moved Permanently',
     302: 'Found',


### PR DESCRIPTION
Fixes erroneous error messages in download clients, causing nzb/torrent
sending to not finish succesfully and causing extra settings to not be
sent (like labels).

Effectively removes http status codes in the 100 - 299 range from the
list (those are success messages and should not be handled as errors)

https://github.com/SiCKRAGETV/sickrage-issues/issues/1331