### PR TITLE
Remove indexer from tvshow.nfo and series.xml

### DIFF
--- a/sickbeard/metadata/generic.py
+++ b/sickbeard/metadata/generic.py
@@ -286,14 +286,9 @@ class GenericMetadata():
                 with ek.ek(open, nfo_file_path, 'r') as xmlFileObj:
                     showXML = etree.ElementTree(file=xmlFileObj)
 
-                indexer = showXML.find('indexer')
                 indexerid = showXML.find('id')
 
                 root = showXML.getroot()
-                if indexer:
-                    indexer.text = show_obj.indexer
-                else:
-                    etree.SubElement(root, "indexer").text = str(show_obj.indexer)
 
                 if indexerid:
                     indexerid.text = show_obj.indexerid
@@ -940,11 +935,9 @@ class GenericMetadata():
 
             if showXML.findtext('title') == None \
                     or (showXML.findtext('tvdbid') == None
-                        and showXML.findtext('id') == None) \
-                            and showXML.findtext('indexer') == None:
+                        and showXML.findtext('id') == None):
                 logger.log(u"Invalid info in tvshow.nfo (missing name or id):" \
                            + str(showXML.findtext('title')) + " " \
-                           + str(showXML.findtext('indexer')) + " " \
                            + str(showXML.findtext('tvdbid')) + " " \
                            + str(showXML.findtext('id')))
                 return empty_return
@@ -964,9 +957,7 @@ class GenericMetadata():
                 return empty_return
 
             indexer = None
-            if showXML.findtext('indexer') != None:
-                indexer = int(showXML.findtext('indexer'))
-            elif showXML.find('episodeguide/url') != None:
+            if showXML.find('episodeguide/url') != None:
                 epg_url = showXML.findtext('episodeguide/url').lower()
                 if str(indexer_id) in epg_url:
                     if 'thetvdb.com' in epg_url:

--- a/sickbeard/metadata/kodi_12plus.py
+++ b/sickbeard/metadata/kodi_12plus.py
@@ -164,10 +164,6 @@ class KODI_12PlusMetadata(generic.GenericMetadata):
         if getattr(myShow, 'id', None) is not None:
             indexerid.text = str(myShow["id"])
 
-        indexer = etree.SubElement(tv_node, "indexer")
-        if show_obj.indexer is not None:
-            indexer.text = str(show_obj.indexer)
-
         genre = etree.SubElement(tv_node, "genre")
         if getattr(myShow, 'genre', None) is not None:
             if isinstance(myShow["genre"], basestring):

--- a/sickbeard/metadata/mediabrowser.py
+++ b/sickbeard/metadata/mediabrowser.py
@@ -265,9 +265,6 @@ class MediaBrowserMetadata(generic.GenericMetadata):
         if getattr(myShow, 'id', None) is not None:
             indexerid.text = str(myShow['id'])
 
-        indexer = etree.SubElement(tv_node, "indexer")
-        if show_obj.indexer != None:
-            indexer.text = str(show_obj.indexer)
 
         SeriesName = etree.SubElement(tv_node, "SeriesName")
         if getattr(myShow, 'seriesname', None) is not None:
@@ -494,9 +491,6 @@ class MediaBrowserMetadata(generic.GenericMetadata):
 
                 indexerid = etree.SubElement(episode, "id")
                 indexerid.text = str(curEpToWrite.indexerid)
-
-                indexer = etree.SubElement(episode, "indexer")
-                indexer.text = str(curEpToWrite.show.indexer)
 
                 Persons = etree.SubElement(episode, "Persons")
 


### PR DESCRIPTION
I think there is still some work to be done to make this process more proper.  I don't think that any other indexer_id should be stored in `<id>` other than tvdb, as kodi has no idea that it isn't thetvdb, and an art refresh from kodi could return the wrong show.

One problem of removing `<indexer>` (which needs to be done), is that Series.xml has no epg, or any urls at all, to check for theTVDB or TVRage and decide what indexer the `<id>` is referencing.

There should be a method to query each indexer with the provided `<id>` and compare it to the `<title>` we have, and set the indexer in SR db accordingly.  Once it is in our db, it never needs to be read again.

Finally, all of these problems exist prior to these changes, and this is a step in the right direction.