### PR TITLE
Fix Plex notification status check

### DIFF
--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -1708,7 +1708,7 @@ class Home(WebRoot):
             return self.redirect('/home/')
 
     def updatePLEX(self):
-        if notifiers.plex_notifier.update_library():
+        if None is notifiers.plex_notifier.update_library():
             ui.notifications.message(
                 "Library update command sent to Plex Media Server host: " + sickbeard.PLEX_SERVER_HOST)
         else:


### PR DESCRIPTION
The return value of update_library() was changed from True/False to None/Error string in https://github.com/SiCKRAGETV/SickRage/commit/4c9d9185b0c25d435a6bbb20efa60b1f4337a016 but the check for the return value was never updated. This corrects that so the notification sent out correctly states that it sent a notification to the server instead of defaulting to stating it was unable to connect.

This fixes the rest of the issues described in SiCKRAGETV/sickrage-issues#1348.