### PR TITLE
Build tests

### DIFF
--- a/sickbeard/db.py
+++ b/sickbeard/db.py
@@ -46,7 +46,7 @@ def dbFilename(filename="sickbeard.db", suffix=None):
     return ek.ek(os.path.join, sickbeard.DATA_DIR, filename)
 
 class DBConnection(object):
-    def __init__(self, filename="sickbeard.db", suffix=None, row_type=None, testdb=False):
+    def __init__(self, filename="sickbeard.db", suffix=None, row_type=None):
 
         self.filename = filename
         self.suffix = suffix
@@ -59,9 +59,7 @@ class DBConnection(object):
                 self.connection = sqlite3.connect(dbFilename(self.filename, self.suffix), 20, check_same_thread=False)
                 self.connection.text_factory = self._unicode_text_factory
                 self.connection.isolation_level = None
-                if testdb:
-                    self.connection.cursor().execute('''PRAGMA journal_mode = MEMORY''')
-                    self.connection.commit()
+                self.connection.cursor().execute('''PRAGMA locking_mode = EXCLUSIVE''')
                 db_cons[self.filename] = self.connection
             else:
                 self.connection = db_cons[self.filename]

--- a/sickbeard/postProcessor.py
+++ b/sickbeard/postProcessor.py
@@ -341,7 +341,7 @@ class PostProcessor(object):
                 helpers.moveFile(cur_file_path, new_file_path)
                 helpers.chmodAsParent(new_file_path)
             except (IOError, OSError), e:
-                self._log("Unable to move file " + cur_file_path + " to " + new_file_path + ": " + str(e), logger.ERROR)
+                self._log("Unable to move file " + cur_file_path + " to " + new_file_path + ": " + ex(e), logger.ERROR)
                 raise
 
         self._combined_file_operation(file_path, new_path, new_base_name, associated_files, action=_int_move,

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -145,7 +145,7 @@ class TestDBConnection(db.DBConnection, object):
 
     def __init__(self, dbFileName=TESTDBNAME):
         dbFileName = os.path.join(TESTDIR, dbFileName)
-        super(TestDBConnection, self).__init__(dbFileName, testdb=True)
+        super(TestDBConnection, self).__init__(dbFileName)
 
 
 class TestCacheDBConnection(TestDBConnection, object):
@@ -198,26 +198,19 @@ def tearDown_test_db():
     """Deletes the test db
         although this seams not to work on my system it leaves me with an zero kb file
     """
-    # uncomment next line so leave the db intact between test and at the end
-    # return False
 
-    try:
-        if os.path.exists(os.path.join(TESTDIR, TESTDBNAME)):
-            os.remove(os.path.join(TESTDIR, TESTDBNAME))
-    except:
-        pass
+    #uncomment next line so leave the db intact between test and at the end
+    #return False
 
-    try:
-        if os.path.exists(os.path.join(TESTDIR, TESTCACHEDBNAME)):
-            os.remove(os.path.join(TESTDIR, TESTCACHEDBNAME))
-    except:
-        pass
+    for current_db in [ TESTDBNAME, TESTCACHEDBNAME, TESTFAILEDDBNAME ]:
+        for file_name in [ os.path.join(TESTDIR, current_db), os.path.join(TESTDIR, current_db + '-journal') ]:
+            if os.path.exists(file_name):
+                try:
+                    os.remove(file_name)
+                except (IOError, OSError) as e:
+                    print 'ERROR: Failed to remove ' + file_name
+                    print ex(e)
 
-    try:
-        if os.path.exists(os.path.join(TESTDIR, TESTFAILEDDBNAME)):
-            os.remove(os.path.join(TESTDIR, TESTFAILEDDBNAME))
-    except:
-        pass
 
 def setUp_test_episode_file():
     if not os.path.exists(FILEDIR):


### PR DESCRIPTION
I think its not wise to make the build tests operate on the db differently than normal operation.  It fixes the build but down the road there may be a divergence between test and run where tests succeed and run has problems.

This uses exclusive locking on the db, which is fine because we only ever have one connection to any given db at one time, and we do not want other applications touching it while we have it open anyways.  It also gives a small performance gain overall.