### PR TITLE
Cat sickrage.log generated by unit testing if travis build fails.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_script:
  - chmod +x ./tests/all_tests.py
 
 script:
-  - ./tests/all_tests.py
+  - ./tests/all_tests.py || cat ./Logs/sickrage.log
 
 notifications:
   irc: "irc.freenode.net#sickrage-updates"


### PR DESCRIPTION
Will show up in the travis build log, and aid in debugging failed builds.