### PR TITLE
HotFix for: local variable 'subtitles' referenced before assignment

### DIFF
--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -1440,6 +1440,7 @@ class TVEpisode(object):
                         helpers.chmodAsParent(subtitle.path)
         except ServiceError as e:
             logger.log("Service is unavailable: {0}".format(str(e)), logger.INFO)
+            return
         except Exception as e:
             logger.log("Error occurred when downloading subtitles: " + str(e), logger.ERROR)
             return


### PR DESCRIPTION
https://github.com/SiCKRAGETV/SickRage/pull/1796 adds a check for
Exception ServiceError, but doesn't return on the exception. For every
other exception the function is returned from.

Fixes https://github.com/SiCKRAGETV/sickrage-issues/issues/1359