### PR TITLE
Fix SeasonPack searchstrings for episode search on multiple ep search

### DIFF
--- a/sickbeard/providers/generic.py
+++ b/sickbeard/providers/generic.py
@@ -283,7 +283,7 @@ class GenericProvider:
             # mark season searched for season pack searches so we can skip later on
             searched_scene_season = epObj.scene_season
 
-            if len(episodes) > 1:
+            if len(episodes) > 1 and search_mode == 'sponly':
                 # get season search results
                 for curString in self._get_season_search_strings(epObj):
                     itemList += self._doSearch(curString, search_mode, len(episodes), epObj=epObj)

--- a/sickbeard/providers/generic.py
+++ b/sickbeard/providers/generic.py
@@ -277,7 +277,7 @@ class GenericProvider:
                 continue
 
             # skip if season already searched
-            if len(episodes) > 1 and searched_scene_season == epObj.scene_season:
+            if len(episodes) > 1 and search_mode == 'sponly' and searched_scene_season == epObj.scene_season:
                 continue
 
             # mark season searched for season pack searches so we can skip later on


### PR DESCRIPTION
Changed the _doSearch call in generic.py to only use
_get_season_search_strings when search_mode is 'sponly'

https://github.com/SiCKRAGETV/sickrage-issues/issues/1350