### PR TITLE
Fixup regex for issue submitter, Dont allow dupe app submitted issues. More

### DIFF
--- a/sickbeard/logger.py
+++ b/sickbeard/logger.py
@@ -177,12 +177,13 @@ class Logger(object):
             # parse and submit errors to issue tracker
             for curError in sorted(classes.ErrorViewer.errors, key=lambda error: error.time, reverse=True)[:500]:
                 try:
-                    if len(str(curError.title)) > 1024:
-                        title_Error = str(curError.title)[0:1024]
-                    else:
-                        title_Error = str(curError.title)
+                    title_Error = str(curError.title)
+                    if not len(title_Error) or title_Error == 'None':
+                        title_Error = re.match("^[A-Z0-9\-\[\] :]+::\s*(.*)$", ek.ss(str(curError.message))).group(1)
+                    if len(title_Error) > 1024:
+                        title_Error = title_Error[0:1024]
                 except Exception as e:
-                    title_Error = u"Unable to extract title from error"
+                    self.log("Unable to get error title : " + sickbeard.exceptions.ex(e), ERROR)
 
                 gist = None
                 regex = "^(%s)\s+([A-Z]+)\s+([0-9A-Z\-]+)\s*(.*)$" % curError.time

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -5066,8 +5066,8 @@ class ErrorLogs(WebRoot):
             ui.notifications.error("Missing information", "Please set your GitHub username and password in the config.")
             logger.log(u'Please set your GitHub username and password in the config, unable to submit issue ticket to GitHub!')
         else:
-            issue = logger.submit_errors()
-            if issue:
-                ui.notifications.message('Your issue ticket #%s was submitted successfully!' % issue.number)
+            issue_id = logger.submit_errors()
+            if issue_id:
+                ui.notifications.message('Your issue ticket #%s was submitted successfully!' % issue_id)
 
         return self.redirect("/errorlogs/")

--- a/tests/issue_submitter_tests.py
+++ b/tests/issue_submitter_tests.py
@@ -37,9 +37,11 @@ def error():
         sickbeard.logger.submit_errors()
         raise
 
+
 class IssueSubmitterBasicTests(unittest.TestCase):
     def test_submitter(self):
         self.assertRaises(Exception, error)
+
 
 if __name__ == "__main__":
     print "=================="
@@ -47,3 +49,4 @@ if __name__ == "__main__":
     print "=================="
     print "######################################################################"
     suite = unittest.TestLoader().loadTestsFromTestCase(IssueSubmitterBasicTests)
+    unittest.TextTestRunner(verbosity=2).run(suite)

--- a/tests/name_parser_tests.py
+++ b/tests/name_parser_tests.py
@@ -348,6 +348,7 @@ class BasicTests(test.SickbeardTestDBCase):
 if __name__ == '__main__':
     if len(sys.argv) > 1:
         suite = unittest.TestLoader().loadTestsFromName('name_parser_tests.BasicTests.test_'+sys.argv[1])
+        unittest.TextTestRunner(verbosity=2).run(suite)
     else:
         suite = unittest.TestLoader().loadTestsFromTestCase(BasicTests)
     unittest.TextTestRunner(verbosity=2).run(suite)

--- a/tests/torrent_tests.py
+++ b/tests/torrent_tests.py
@@ -76,3 +76,4 @@ if __name__ == "__main__":
     print "=================="
     print "######################################################################"
     suite = unittest.TestLoader().loadTestsFromTestCase(TorrentBasicTests)
+    unittest.TextTestRunner(verbosity=2).run(suite)

--- a/tests/xem_tests.py
+++ b/tests/xem_tests.py
@@ -85,3 +85,4 @@ if __name__ == "__main__":
     print "=================="
     print "######################################################################"
     suite = unittest.TestLoader().loadTestsFromTestCase(XEMBasicTests)
+    unittest.TextTestRunner(verbosity=2).run(suite)


### PR DESCRIPTION
Duplicate submitted issues are now comments to the original instead of
duplicating. ***DO NOT CHANGE APP SUBMITTED ISSUE TITLES FOR NOW**
Maybe later we can move to parsing issue comments to match errors and
make it ok to change APP SUBMITTED issue titles, but currently I have it using
the issue title to search for originals.

Fix some unit tests not running some or all of their tests when ran standalone.

See how it just adds a comment instead of a  new issue in SiCKRAGETV/sickrage-issues/issues/1392

Also, the gists it pasts are just the error it finds, not the entire log, which was the original writer's intent.
