### PR TITLE
FR#1078 Update Specific Plex Sections

### DIFF
--- a/sickbeard/postProcessor.py
+++ b/sickbeard/postProcessor.py
@@ -1076,7 +1076,7 @@ class PostProcessor(object):
         notifiers.kodi_notifier.update_library(ep_obj.show.name)
 
         # do the library update for Plex
-        notifiers.plex_notifier.update_library()
+        notifiers.plex_notifier.update_library(ep_obj)
 
         # do the library update for NMJ
         # nmj_notifier kicks off its library update when the notify_download is issued (inside notifiers)


### PR DESCRIPTION
* Sends Episode Object on Post process
* If the path of the PLEX Show Section is found within the Episode
Object Location,  only that section is sent an update request.
otherwise all sections are.

Note: Functionality was introduced in the Plex Notification update,
sending Episode Object on Post Process was not included at that time.