### PR TITLE
FIX#1292 Masking NZB API Keys in logs

### DIFF
--- a/sickbeard/logger.py
+++ b/sickbeard/logger.py
@@ -62,7 +62,7 @@ class CensoredFormatter(logging.Formatter, object):
             if v and len(v) > 0 and v in msg:
                 msg = msg.replace(v, len(v) * '*')
         # Needed because Newznab apikey isn't stored as key=value in a section.
-        msg = re.sub('apikey\=[^\&]*\&','apikey\=**********\&', msg)
+        msg = re.sub(r'(r|apikey|api_key)=[^&]*([&\w]?)',r'\1=**********\2', msg)
         return msg
 
 


### PR DESCRIPTION
* Modified Regex substitution to account for 3 possible keys that the
API can be attached to
* Modified Regex to account for API Key being at the end of the string
or followed by an & or a space
* Used capture groups to only mask out the API Key, matched prefix and
ending are kept