### PR TITLE
Fix upstart multi pid

### DIFF
--- a/init.upstart
+++ b/init.upstart
@@ -23,6 +23,7 @@ setgid sickbeard
 
 respawn
 respawn limit 10 5
+expect daemon
 
 script
     if [ -f /etc/default/sickbeard ]; then


### PR DESCRIPTION
Currently spawns 2 instances, and the second cannot be stopped by the service. Cannot be stopped in SR ui is service is running, and does not stop service.

PR fixes this.