### PR TITLE
HOTFIX: convert the bool to int for default web_use_gzip config

### DIFF
--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -1615,7 +1615,7 @@ def save_config():
     new_config['General']['web_username'] = WEB_USERNAME
     new_config['General']['web_password'] = helpers.encrypt(WEB_PASSWORD, ENCRYPTION_VERSION)
     new_config['General']['web_cookie_secret'] = WEB_COOKIE_SECRET
-    new_config['General']['web_use_gzip'] = WEB_USE_GZIP
+    new_config['General']['web_use_gzip'] = int(WEB_USE_GZIP)
     new_config['General']['download_url'] = DOWNLOAD_URL
     new_config['General']['localhost_ip'] = LOCALHOST_IP
     new_config['General']['cpu_preset'] = CPU_PRESET


### PR DESCRIPTION
SiCKRAGETV/sickrage-issues/issues/1156#issuecomment-96308300
SiCKRAGETV/sickrage-issues/issues/1156

Need to save the default setting as int, to avoid confusing users. "False" as a setting does not work, 0 will.