### PR TITLE
Make check_setting_int understand True/False from settings

### DIFF
--- a/sickbeard/config.py
+++ b/sickbeard/config.py
@@ -442,7 +442,14 @@ def minimax(val, default, low, high):
 ################################################################################
 def check_setting_int(config, cfg_name, item_name, def_val, silent=True):
     try:
-        my_val = int(config[cfg_name][item_name])
+        my_val = config[cfg_name][item_name]
+        if str(my_val).lower() == "true":
+            my_val = 1
+        elif str(my_val).lower() == "false":
+            my_val = 0
+
+        my_val = int(my_val)
+
         if str(my_val) == str(None):
             raise
     except:


### PR DESCRIPTION
To help prevent confusing users modifying the config directly.
With this, any case variation of 'true' will work the same as 1, and 
any case variation of 'false' will work the same as 0.