### PR TITLE
Remove reference to readme-FailedDownloads.md, which doesnt exist.

### DIFF
--- a/gui/slick/interfaces/default/config_postProcessing.tmpl
+++ b/gui/slick/interfaces/default/config_postProcessing.tmpl
@@ -243,7 +243,6 @@
                             </label>
                             <label class="nocheck" for="use_failed_downloads">
                                 <span class="component-title">&nbsp;</span>
-                                <span class="component-desc"><b>NOTE:</b> See <i>readme-FailedDownloads.md</i> before enabling.</span>
                             </label>
                         </div>
 						

--- a/gui/slick/interfaces/default/config_search.tmpl
+++ b/gui/slick/interfaces/default/config_search.tmpl
@@ -170,7 +170,6 @@
                                                      <label class="nocheck" for="use_failed_downloads">
                                                          <span class="component-title">&nbsp;</span>
                                                          <span class="component-desc">Will only work with snatched/downloaded episodes after enabling this</span>
-                                                         <span class="component-desc"><b>NOTE:</b> See <i>readme-FailedDownloads.md</i> before enabling.</span>
                                                      </label>
                                                  </div>
 

--- a/lib/unrar2/unix.py
+++ b/lib/unrar2/unix.py
@@ -178,7 +178,7 @@ class RarFileImplementation(object):
                 data['isdir'] = 'd' in attr.lower()
                 data['datetime'] = time.strptime(fields[2]+" "+fields[3], '%d-%m-%y %H:%M')
                 data['comment'] = None
-		data['volume'] = None
+                data['volume'] = None
                 yield data
                 i += 1
                 line = source.next()

--- a/sickbeard/providers/morethantv.py
+++ b/sickbeard/providers/morethantv.py
@@ -162,7 +162,7 @@ class MoreThanTVProvider(generic.TorrentProvider):
                             sickbeard.config.naming_ep_type[2] % {'seasonnumber': ep_obj.scene_season,
                                                                   'episodenumber': ep_obj.scene_episode} + ' %s' % add_string
 
-		search_string['Episode'].append(re.sub('\.', '+', ep_string))
+                search_string['Episode'].append(re.sub('\.', '+', ep_string))
 
         return [search_string]
 


### PR DESCRIPTION
Replace two out of place tabs with spaces, identified by python -i

This reference helped confuse me about failed download handling.  Because the file doesn't exist, I opted to not even try it for worry that something bad could happen without being able to RTFM.

Closes SiCKRAGETV/sickrage-issues/issues/1430