### PR TITLE
Workaround for openssl bug (routines:SSL23_GET_SERVER_HELLO:tlsv1 crash)

### DIFF
--- a/lib/requests/packages/urllib3/util/ssl_.py
+++ b/lib/requests/packages/urllib3/util/ssl_.py
@@ -231,6 +231,8 @@ def ssl_wrap_socket(sock, keyfile=None, certfile=None, cert_reqs=None,
         A string of ciphers we wish the client to support. This is not
         supported on Python 2.6 as the ssl module does not support it.
     """
+    ssl_version = ssl.PROTOCOL_TLSv1
+
     context = ssl_context
     if context is None:
         context = create_urllib3_context(ssl_version, cert_reqs,


### PR DESCRIPTION
JUST SAW ANOTHER FAILED REQUEST. This patch doesn't fix the problem!
Here's the complete error:

>2015-04-27 21:06:23 WARNING  SEARCHQUEUE-DAILY-SEARCH :: [OldPirateBay] :: Connection error [Errno 1] _ssl.c:492: error:14094438:SSL routines:SSL3_READ_BYTES:tlsv1 alert internal error while loading URL https://oldpiratebay.org/search?iht=8&sort=-created_at
2015-04-27 21:06:23 WARNING  SEARCHQUEUE-DAILY-SEARCH :: [ThePirateBay] :: Connection error [Errno 1] _ssl.c:492: error:14094438:SSL routines:SSL3_READ_BYTES:tlsv1 alert internal error while loading URL https://thepiratebay.se/tv/latest/
AASSLError: [Errno 1] _ssl.c:492: error:14094438:SSL routines:SSL3_READ_BYTES:tlsv1 alert internal error
AA    raise SSLError(e, request=request)
AA  File "/opt/sickbeard/lib/requests/adapters.py", line 431, in send
AA    r = adapter.send(request, **kwargs)
AA  File "/opt/sickbeard/lib/requests/sessions.py", line 573, in send
AA    resp = self.send(prep, **send_kwargs)
AA  File "/opt/sickbeard/lib/requests/sessions.py", line 461, in request
AA    return self.request('GET', url, **kwargs)
AA  File "/opt/sickbeard/lib/requests/sessions.py", line 473, in get
AA    response = self.session.get(self.urls['token'], timeout=30, verify=False, headers=self.headers)
AA  File "/opt/sickbeard/sickbeard/providers/rarbg.py", line 112, in _doLogin
AATraceback (most recent call last):
2015-04-27 21:06:22 ERROR    SEARCHQUEUE-DAILY-SEARCH :: [Rarbg] :: Unable to connect to Rarbg provider: error [Errno 1] _ssl.c:492: error:14094438:SSL routines:SSL3_READ_BYTES:tlsv1 alert internal error

I'm don't know if others had the problem, but due to a bug in openssl all https requests to rarbg (and some other sites) were crashing. The error messag contains something like this: routines:SSL23_GET_SERVER_HELLO:tlsv1

This patch forces to use TLSv1.0 (the working version) for all https connections.