### PR TITLE
Add flexibility when determine title from link in eztvapi.re:

### DIFF
--- a/sickbeard/providers/eztv.py
+++ b/sickbeard/providers/eztv.py
@@ -143,12 +143,27 @@ class EZTVProvider(generic.TorrentProvider):
 
                                 for quality in episode['torrents'].keys():
                                     link = episode['torrents'][quality]['url']
-                                    getTitle = re.search('&dn=(.*?)&', link)
-                                    if getTitle:
-                                        title = getTitle.group(1)
-                                    else:
+                                    if not re.match('magnet', link) and not re.match('http', link):
                                         continue
 
+                                    # Get title from link:
+                                    #     1) try magnet link
+                                    #     2) try rarbg link
+                                    #     3) try extratorrent link
+                                    #     4) try '([^/]+$)' : everything after last slash character (not accurate)
+                                    #     5) fallback, title is equal to link
+                                    if re.match('.*&dn=(.*?)&', link):
+                                        title = re.match('.*&dn=(.*?)&', link).group(1)
+                                    elif re.match('http://rarbg.to', link):
+                                        title = re.search('([^=]+$)', link).group(0)
+                                    elif re.match('http://extratorrent.cc', link):
+                                        title = re.search('([^/]+$)', link).group(0)
+                                    elif re.search('([^/]+$)', link):
+                                        title = re.search('([^/]+$)', link).group(0)
+                                    else:
+                                        title = link
+
+                                    title = title.replace('+', '.').replace('%20', '.').replace('%5B', '[').replace('%5D', ']')
                                     item = {
                                         'title': title,
                                         'link': link,


### PR DESCRIPTION
    1) try magnet link
    2) try rarbg link
    3) try extratorrent link
    4) try '([^/]+$)' : everything after last slash character (not accurate)
    5) fallback, title is equal to link
Fixes https://github.com/SiCKRAGETV/sickrage-issues/issues/1437