### PR TITLE
Fix travis reporting failed builds as successful

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,10 @@ before_script:
  - chmod +x ./tests/all_tests.py
 
 script:
-  - ./tests/all_tests.py || cat ./Logs/sickrage.log
+  - ./tests/all_tests.py
+
+after_failure:
+  - cat ./Logs/sickrage.log
 
 notifications:
   irc: "irc.freenode.net#sickrage-updates"


### PR DESCRIPTION
Oops, adding || cat sickrage.log makes travis think we have a successful build, since cat returns 0.