### PR TITLE
Fix webapi error when show search returns 0 results

### DIFF
--- a/lib/tvdb_api/tvdb_api.py
+++ b/lib/tvdb_api/tvdb_api.py
@@ -680,7 +680,11 @@ class Tvdb:
         log().debug("Searching for show %s" % series)
         self.config['params_getSeries']['seriesname'] = series
 
-        return self._getetsrc(self.config['url_getSeries'], self.config['params_getSeries']).values()[0]
+        results = self._getetsrc(self.config['url_getSeries'], self.config['params_getSeries'])
+        if not results:
+            return
+
+        return results.values()[0]
 
     def _getSeries(self, series):
         """This searches TheTVDB.com for the series name,

--- a/lib/tvrage_api/tvrage_api.py
+++ b/lib/tvrage_api/tvrage_api.py
@@ -563,7 +563,11 @@ class TVRage:
         log().debug("Searching for show %s" % series)
         self.config['params_getSeries']['show'] = series
 
-        return self._getetsrc(self.config['url_getSeries'], self.config['params_getSeries']).values()[0]
+        results = self._getetsrc(self.config['url_getSeries'], self.config['params_getSeries'])
+        if not results:
+            return
+
+        return results.values()[0]
 
     def _getSeries(self, series):
         """This searches tvrage.com for the series name,

--- a/sickbeard/webapi.py
+++ b/sickbeard/webapi.py
@@ -1703,7 +1703,7 @@ class CMD_SickBeardSearchIndexers(ApiCall):
                     apiData = t[str(self.name).encode()]
                 except (sickbeard.indexer_shownotfound, sickbeard.indexer_showincomplete, sickbeard.indexer_error):
                     logger.log(u"API :: Unable to find show with id " + str(self.indexerid), logger.WARNING)
-                    return _responds(RESULT_SUCCESS, {"results": [], "langid": lang_id})
+                    continue
 
                 for curSeries in apiData:
                     results.append({indexer_ids[_indexer]: int(curSeries['id']),


### PR DESCRIPTION
Fixes SiCKRAGETV/sickrage-issues#1491 so that an empty result set is returned rather than an internal error when no show results are found.