### PR TITLE
SCC doesn't support searching dates with pipe characters. Use '.'

### DIFF
--- a/sickbeard/providers/scc.py
+++ b/sickbeard/providers/scc.py
@@ -130,12 +130,12 @@ class SCCProvider(generic.TorrentProvider):
         if self.show.air_by_date:
             for show_name in set(show_name_helpers.allPossibleShowNames(self.show)):
                 ep_string = sanitizeSceneName(show_name) + ' ' + \
-                            str(ep_obj.airdate).replace('-', '|')
+                            str(ep_obj.airdate).replace('-', '.')
                 search_string['Episode'].append(ep_string)
         elif self.show.sports:
             for show_name in set(show_name_helpers.allPossibleShowNames(self.show)):
                 ep_string = sanitizeSceneName(show_name) + ' ' + \
-                            str(ep_obj.airdate).replace('-', '|') + '|' + \
+                            str(ep_obj.airdate).replace('-', '.') + '|' + \
                             ep_obj.airdate.strftime('%b')
                 search_string['Episode'].append(ep_string)
         elif self.show.anime:


### PR DESCRIPTION
As the commit message says, currently SickRage is attempting to search dates with the pipe character as a delimiter, which isn't supported by SCC.

E.g. 
```Jimmy.Fallon.2015|04|27``` returns no results
```Jimmy.Fallon.2015.04.27``` returns 2 results

![screen shot 2015-05-04 at 12 22 36 pm](https://cloud.githubusercontent.com/assets/88030/7448521/748d11c8-f25f-11e4-9195-69a848da94c4.png)
![screen shot 2015-05-04 at 12 22 51 pm](https://cloud.githubusercontent.com/assets/88030/7448520/748c653e-f25f-11e4-81a9-c6b07c68ea6e.png)

