### PR TITLE
Temp fix for torrentday

### DIFF
--- a/sickbeard/providers/torrentday.py
+++ b/sickbeard/providers/torrentday.py
@@ -54,10 +54,10 @@ class TorrentDayProvider(generic.TorrentProvider):
 
         self.cache = TorrentDayCache(self)
 
-        self.urls = {'base_url': 'https://tdonline.org',
-                'login': 'https://tdonline.org/torrents/',
-                'search': 'https://tdonline.org/V3/API/API.php',
-                'download': 'https://tdonline.org/download.php/%s/%s'
+        self.urls = {'base_url': 'https://classic.torrentday.com',
+                'login': 'https://classic.torrentday.com/torrents/',
+                'search': 'https://classic.torrentday.com/V3/API/API.php',
+                'download': 'https://classic.torrentday.com/download.php/%s/%s'
         }
 
         self.url = self.urls['base_url']


### PR DESCRIPTION
Torrentday has a new layout and as a result sickrage is broken. This is a temporary fix as i am not nearly smart enough to create a full fix, but it works for now. might not work for users in UK and users who have to use tdonline.org