### PR TITLE
Fix broken UI labels since SiCKRAGETV/sickrage-issues#1508 (regression)

### DIFF
--- a/gui/slick/interfaces/default/displayShow.tmpl
+++ b/gui/slick/interfaces/default/displayShow.tmpl
@@ -590,7 +590,7 @@
             </td>
             #set $curStatus, $curQuality = $Quality.splitCompositeStatus(int($epResult["status"]))
                 #if $curQuality != Quality.NONE:   
-                    <td class="col-status">$statusStrings[$curStatus] <span class="quality $Quality.qualityStrings[$curQuality].replace("720p","HD720p").replace("1080p","HD1080p").replace("RawHD TV", "RawHD").replace("HD TV", "HD720p")">$Quality.qualityStrings[$curQuality]</span></td>
+                    <td class="col-status">$statusStrings[$curStatus] <span class="quality $Quality.qualityStrings[$curQuality].replace("720p","HD720p").replace("1080p","HD1080p").replace("RawHD", "RawHD").replace("HDTV", "HD720p")">$Quality.qualityStrings[$curQuality]</span></td>
                 #else:    
                     <td class="col-status">$statusStrings[$curStatus]</td>
                 #end if


### PR DESCRIPTION
The RawHD and HDTV labels in the episode overview on ```displayShow``` would not have a background color because the class name is not replaced properly.

![sickrage](https://cloud.githubusercontent.com/assets/579633/7585856/fce1933a-f8a6-11e4-8473-3de5934de523.PNG)