### PR TITLE
Issue 1538 dev

### DIFF
--- a/sickbeard/databases/failed_db.py
+++ b/sickbeard/databases/failed_db.py
@@ -40,11 +40,12 @@ class InitialSchema(db.SchemaUpgrade):
 
 class SizeAndProvider(InitialSchema):
     def test(self):
-        return self.hasColumn('failed', 'size') and self.hasColumn('failed', 'provider')
+        return self.hasColumn('failed', 'size') and self.hasColumn('failed', 'provider') and self.hasColumn('failed', 'url')
 
     def execute(self):
         self.addColumn('failed', 'size')
         self.addColumn('failed', 'provider', 'TEXT', '')
+        self.addColumn('failed', 'url', 'TEXT', '')
 
 
 class History(SizeAndProvider):
@@ -55,7 +56,7 @@ class History(SizeAndProvider):
 
     def execute(self):
         self.connection.action('CREATE TABLE history (date NUMERIC, ' +
-                               'size NUMERIC, release TEXT, provider TEXT);')
+                               'size NUMERIC, release TEXT, provider TEXT, url TEXT);')
 
 
 class HistoryStatus(History):

--- a/sickbeard/search.py
+++ b/sickbeard/search.py
@@ -25,7 +25,7 @@ import datetime
 import traceback
 
 import sickbeard
-
+from hashlib import sha256
 from common import SNATCHED, SNATCHED_PROPER, SNATCHED_BEST, Quality, SEASON_RESULT, MULTI_EP_RESULT
 
 from sickbeard import logger, db, show_name_helpers, exceptions, helpers
@@ -239,7 +239,7 @@ def pickBestResult(results, show, quality_list=None):
             continue
 
         if hasattr(cur_result, 'size'):
-            if sickbeard.USE_FAILED_DOWNLOADS and failed_history.hasFailed(cur_result.name, cur_result.size,
+            if sickbeard.USE_FAILED_DOWNLOADS and failed_history.hasFailed(cur_result.name, cur_result.size, sha256(cur_result.url).hexdigest(),
                                                                            cur_result.provider.name):
                 logger.log(cur_result.name + u" has previously failed, rejecting it")
                 continue
@@ -609,7 +609,7 @@ def searchProviders(show, episodes, manualSearch=False, downCurQuality=False):
 
                 logger.log(u"Seeing if we want to bother with multi-episode result " + multiResult.name, logger.DEBUG)
 
-                if sickbeard.USE_FAILED_DOWNLOADS and failed_history.hasFailed(multiResult.name, multiResult.size,
+                if sickbeard.USE_FAILED_DOWNLOADS and failed_history.hasFailed(multiResult.name, multiResult.size, sha256(multiResult.url).hexdigest(),
                                                                                multiResult.provider.name):
                     logger.log(multiResult.name + u" has previously failed, rejecting this multi-ep result")
                     continue

--- a/sickbeard/search_queue.py
+++ b/sickbeard/search_queue.py
@@ -250,7 +250,6 @@ class FailedQueueItem(generic_queue.QueueItem):
     def run(self):
         generic_queue.QueueItem.run(self)
         self.started = True
-        
         try:
             for epObj in self.segment:
             


### PR DESCRIPTION
Hi,

I improved the Failed Handler to manage with the situations like the ones I indicated here:
SiCKRAGETV/sickrage-issues#1538

Mainly, I check if the provider is returning the candidates size. If not, it uses a hash coming from the url to differentiate when a candidate is different to another with the same release name.

I add a field "url" in failed and history tables (failed.db) to store the hashes.

Please, let me know if there is something you want I change, or if there are any conflict.