### PR TITLE
Also catch BadStatusLine

### DIFF
--- a/sickbeard/notifiers/kodi.py
+++ b/sickbeard/notifiers/kodi.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage.  If not, see <http://www.gnu.org/licenses/>.
 
+import httplib
 import urllib
 import urllib2
 import socket
@@ -385,7 +386,7 @@ class KODINotifier:
 
             try:
                 response = urllib2.urlopen(req)
-            except urllib2.URLError, e:
+            except (httplib.BadStatusLine, urllib2.URLError), e:
                 logger.log(u"Error while trying to retrieve KODI API version for " + host + ": " + ex(e),
                            logger.WARNING)
                 return False


### PR DESCRIPTION
Sometimes my Kobi will return an httplib.BadStatusLine exception if it doesn't boot up. Catch this error and log it correctly.