### PR TITLE
Try to fix 'utf8' codec can't decode byte

### DIFF
--- a/sickbeard/db.py
+++ b/sickbeard/db.py
@@ -232,7 +232,7 @@ class DBConnection(object):
         try:
             return unicode(x, 'utf-8')
         except:
-            return unicode(x, sickbeard.SYS_ENCODING)
+            return unicode(x, sickbeard.SYS_ENCODING,errors="ignore")
 
     def _dict_factory(self, cursor, row):
         d = {}


### PR DESCRIPTION
while reading the DB

```
2015-05-19 11:19:18 Thread-19 :: Failed doing webui callback: Traceback (most recent call last):
  File "/home/osmc/SickRage/sickbeard/webserve.py", line 258, in async_call
    result = function(**kwargs)
  File "/home/osmc/SickRage/sickbeard/webserve.py", line 1174, in displayShow
    [showObj.indexerid]
  File "/home/osmc/SickRage/sickbeard/db.py", line 192, in select
    sqlResults = self.action(query, args, fetchall=True)
  File "/home/osmc/SickRage/sickbeard/db.py", line 170, in action
    sqlResult = self.execute(query, args, fetchall=fetchall, fetchone=fetchone)
  File "/home/osmc/SickRage/sickbeard/db.py", line 86, in execute
    return self._execute(query, args).fetchall()
  File "/home/osmc/SickRage/sickbeard/db.py", line 235, in _unicode_text_factory
    return unicode(x, sickbeard.SYS_ENCODING)
  File "/usr/lib/python2.7/encodings/utf_8.py", line 16, in decode
    return codecs.utf_8_decode(input, errors, True)
UnicodeDecodeError: 'utf8' codec can't decode byte 0x94 in position 0: invalid start byte
```