### PR TITLE
Fix name of attribute in providers.newsznab.NewznabCache._parseItem()

### DIFF
--- a/sickbeard/providers/newznab.py
+++ b/sickbeard/providers/newznab.py
@@ -423,7 +423,7 @@ class NewznabCache(tvcache.TVCache):
 
         tvrageid = 0
         for attr in item['newznab_attr'] if isinstance(item['newznab_attr'], list) else [item['newznab_attr']]:
-            if attr['name'] == 'tvrageid':
+            if attr['name'] == 'tvrageid' or attr['name'] == 'rageid':
                 tvrageid = int(attr['value'] or 0)
                 break
 


### PR DESCRIPTION
When I was debugging the cache yesterday, I realised that providers.newsznab.NewznabCache._parseItem() was looking for an attribute named "tvrageid" when the  name that Newsznab returns is "rageid".

This error provoqued TVCache._addCacheEntry() never added an entry was it was called from NewznabCache._parseItem()