### PR TITLE
Change urls to use http github.io pages from our repos

### DIFF
--- a/sickbeard/indexers/indexer_config.py
+++ b/sickbeard/indexers/indexer_config.py
@@ -40,7 +40,7 @@ indexerConfig[INDEXER_TVRAGE] = {
 indexerConfig[INDEXER_TVDB]['trakt_id'] = 'tvdb_id'
 indexerConfig[INDEXER_TVDB]['xem_origin'] = 'tvdb'
 indexerConfig[INDEXER_TVDB]['icon'] = 'thetvdb16.png'
-indexerConfig[INDEXER_TVDB]['scene_url'] = 'http://midgetspy.github.io/sb_tvdb_scene_exceptions/exceptions.txt'
+indexerConfig[INDEXER_TVDB]['scene_url'] = 'http://sickragetv.github.io/sb_tvdb_scene_exceptions/exceptions.txt'
 indexerConfig[INDEXER_TVDB]['show_url'] = 'http://thetvdb.com/?tab=series&id='
 indexerConfig[INDEXER_TVDB]['base_url'] = 'http://thetvdb.com/api/%(apikey)s/series/' % indexerConfig[INDEXER_TVDB]['api_params']
 
@@ -48,6 +48,6 @@ indexerConfig[INDEXER_TVDB]['base_url'] = 'http://thetvdb.com/api/%(apikey)s/ser
 indexerConfig[INDEXER_TVRAGE]['trakt_id'] = 'tvrage_id'
 indexerConfig[INDEXER_TVRAGE]['xem_origin'] = 'rage'
 indexerConfig[INDEXER_TVRAGE]['icon'] = 'tvrage16.png'
-indexerConfig[INDEXER_TVRAGE]['scene_url'] = 'https://raw.githubusercontent.com/SiCKRAGETV/sr_tvrage_scene_exceptions/master/exceptions.txt'
+indexerConfig[INDEXER_TVRAGE]['scene_url'] = 'http://sickragetv.github.io/sr_tvrage_scene_exceptions/exceptions.txt'
 indexerConfig[INDEXER_TVRAGE]['show_url'] = 'http://tvrage.com/shows/id-'
 indexerConfig[INDEXER_TVRAGE]['base_url'] = 'http://tvrage.com/showinfo.php?key=%(apikey)s&sid=' % indexerConfig[INDEXER_TVRAGE]['api_params']

--- a/sickbeard/network_timezones.py
+++ b/sickbeard/network_timezones.py
@@ -73,7 +73,7 @@ def _update_zoneinfo():
     sb_timezone = tz.tzlocal()
 
     # now check if the zoneinfo needs update
-    url_zv = 'https://raw.githubusercontent.com/Prinz23/sb_network_timezones/master/zoneinfo.txt'
+    url_zv = 'http://sickragetv.github.io/sb_network_timezones/zoneinfo.txt'
 
     try:
         url_data = helpers.getURL(url_zv)
@@ -96,7 +96,7 @@ def _update_zoneinfo():
         return
 
     # now load the new zoneinfo
-    url_tar = u'https://raw.githubusercontent.com/Prinz23/sb_network_timezones/master/%s' % new_zoneinfo
+    url_tar = u'http://sickragetv.github.io/sb_network_timezones/%s' % new_zoneinfo
 
     zonefile = helpers.real_path(ek.ek(join, ek.ek(os.path.dirname, lib.dateutil.zoneinfo.__file__), new_zoneinfo))
     zonefile_tmp = re.sub(r'\.tar\.gz$', '.tmp', zonefile)
@@ -148,7 +148,7 @@ def update_network_dict():
     d = {}
 
     # network timezones are stored on github pages
-    url = 'https://raw.githubusercontent.com/Prinz23/sb_network_timezones/master/network_timezones.txt'
+    url = 'http://sickragetv.github.io/sb_network_timezones/network_timezones.txt'
 
     url_data = helpers.getURL(url)
     if url_data is None:

--- a/sickbeard/notifiers/growl.py
+++ b/sickbeard/notifiers/growl.py
@@ -25,6 +25,8 @@ from lib.growl import gntp
 
 
 class GrowlNotifier:
+    sr_logo_url = 'https://raw.githubusercontent.com/SiCKRAGETV/SickRage/master/gui/slick/images/sickrage-shark-mascot.png'
+
     def test_notify(self, host, password):
         self._sendRegistration(host, password, 'Test')
         return self._sendGrowl("Test Growl", "Testing Growl settings from SickRage", "Test", host, password,
@@ -67,8 +69,7 @@ class GrowlNotifier:
         if options['priority']:
             notice.add_header('Notification-Priority', options['priority'])
         if options['icon']:
-            notice.add_header('Notification-Icon',
-                              'https://raw.github.com/SiCKRAGETV/SickRage/master/gui/slick/images/sickrage-shark-mascot.png')
+            notice.add_header('Notification-Icon', self.sr_logo_url)
 
         if message:
             notice.add_header('Notification-Text', message)
@@ -171,8 +172,7 @@ class GrowlNotifier:
         #Send Registration
         register = gntp.GNTPRegister()
         register.add_header('Application-Name', opts['app'])
-        register.add_header('Application-Icon',
-                            'https://raw.githubusercontent.com/SiCKRAGETV/SickRage/master/gui/slick/images/sickrage-shark-mascot.png')
+        register.add_header('Application-Icon', self.sr_logo_url)
 
         register.add_notification('Test', True)
         register.add_notification(common.notifyStrings[common.NOTIFY_SNATCH], True)

--- a/sickbeard/notifiers/kodi.py
+++ b/sickbeard/notifiers/kodi.py
@@ -42,7 +42,7 @@ except ImportError:
 
 
 class KODINotifier:
-    sb_logo_url = 'https://raw.githubusercontent.com/SiCKRAGETV/SickRage/master/gui/slick/images/sickrage-shark-mascot.png'
+    sr_logo_url = 'https://raw.githubusercontent.com/SiCKRAGETV/SickRage/master/gui/slick/images/sickrage-shark-mascot.png'
 
     def _get_kodi_version(self, host, username, password):
         """Returns KODI JSON-RPC API version (odd # = dev, even # = stable)
@@ -142,7 +142,7 @@ class KODINotifier:
                 else:
                     logger.log(u"Detected KODI version >= 12, using KODI JSON API", logger.DEBUG)
                     command = '{"jsonrpc":"2.0","method":"GUI.ShowNotification","params":{"title":"%s","message":"%s", "image": "%s"},"id":1}' % (
-                        title.encode("utf-8"), message.encode("utf-8"), self.sb_logo_url)
+                        title.encode("utf-8"), message.encode("utf-8"), self.sr_logo_url)
                     notifyResult = self._send_to_kodi_json(command, curHost, username, password)
                     if notifyResult.get('result'):
                         result += curHost + ':' + notifyResult["result"].decode(sickbeard.SYS_ENCODING)


### PR DESCRIPTION
Sometime soon, sb_network_timezones should be added directly to SR source as a pre-populated submodule and we can avoid the web requests to it altogether since it rarely changes