### PR TITLE
Add ranked and sorting options to RARBG settings

### DIFF
--- a/gui/slick/interfaces/default/config_providers.tmpl
+++ b/gui/slick/interfaces/default/config_providers.tmpl
@@ -420,6 +420,45 @@ var show_nzb_providers = #if $sickbeard.USE_NZBS then "true" else "false"#;
                         </div>
                         #end if
 
+                        #if $hasattr($curTorrentProvider, 'confirmed'):
+                        <div class="field-pair">
+                            <label for="${curTorrentProvider.getID()}_confirmed">
+                                <span class="component-title">Confirmed download</span>
+                                <span class="component-desc">
+                                    <input type="checkbox" name="${curTorrentProvider.getID()}_confirmed" id="${curTorrentProvider.getID()}_confirmed" #if $curTorrentProvider.confirmed then "checked=\"checked\"" else ""#/>
+                                    <p>only download torrents from trusted or verified uploaders ?</p>
+                                </span>
+                            </label>
+                        </div>
+                        #end if
+
+                        #if $hasattr($curTorrentProvider, 'ranked'):
+                        <div class="field-pair">
+                            <label for="${curTorrentProvider.getID()}_ranked">
+                                <span class="component-title">Ranked torrents</span>
+                                <span class="component-desc">
+                                    <input type="checkbox" name="${curTorrentProvider.getID()}_ranked" id="${curTorrentProvider.getID()}_ranked" #if $curTorrentProvider.ranked then "checked=\"checked\"" else ""#/>
+                                    <p>only download ranked torrents (internal releases)</p>
+                                </span>
+                            </label>
+                        </div>
+                        #end if
+                        
+                        #if $hasattr($curTorrentProvider, 'sorting'):
+                        <div class="field-pair">
+                            <label for="${curTorrentProvider.getID()}_sorting">
+                                <span class="component-title">Sorting results by</span>
+                                <span class="component-desc">
+                                    <select name="${curTorrentProvider.getID()}_sorting" id="${curTorrentProvider.getID()}_sorting" class="form-control input-sm">
+#for $curAction in ('last', 'seeders', 'leechers'):
+    <option value="$curAction" #if $curAction == $curTorrentProvider.sorting then ' selected="selected"' else ''#>$curAction</option>
+#end for
+                                    </select>
+                                </span>
+                            </label>
+                        </div>
+                        #end if
+
                         #if $hasattr($curTorrentProvider, 'proxy'):
                         <div class="field-pair">
                             <label for="${curTorrentProvider.getID()}_proxy">
@@ -445,18 +484,6 @@ var show_nzb_providers = #if $sickbeard.USE_NZBS then "true" else "false"#;
                             </label>
                         </div>
                         #end if
-                        #end if
-
-                        #if $hasattr($curTorrentProvider, 'confirmed'):
-                        <div class="field-pair">
-                            <label for="${curTorrentProvider.getID()}_confirmed">
-                                <span class="component-title">Confirmed download</span>
-                                <span class="component-desc">
-                                    <input type="checkbox" name="${curTorrentProvider.getID()}_confirmed" id="${curTorrentProvider.getID()}_confirmed" #if $curTorrentProvider.confirmed then "checked=\"checked\"" else ""#/>
-                                    <p>only download torrents from trusted or verified uploaders ?</p>
-                                </span>
-                            </label>
-                        </div>
                         #end if
 
                         #if $hasattr($curTorrentProvider, 'freeleech'):

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -1191,6 +1191,12 @@ def initialize(consoleLogging=True):
             if hasattr(curTorrentProvider, 'confirmed'):
                 curTorrentProvider.confirmed = bool(check_setting_int(CFG, curTorrentProvider.getID().upper(),
                                                                       curTorrentProvider.getID() + '_confirmed', 0))
+            if hasattr(curTorrentProvider, 'ranked'):
+                curTorrentProvider.ranked = bool(check_setting_int(CFG, curTorrentProvider.getID().upper(),
+                                                                      curTorrentProvider.getID() + '_ranked', 0))
+            if hasattr(curTorrentProvider, 'sorting'):
+                curTorrentProvider.sorting = check_setting_str(CFG, curTorrentProvider.getID().upper(),
+                                                                   curTorrentProvider.getID() + '_sorting','seeders')
             if hasattr(curTorrentProvider, 'options'):
                 curTorrentProvider.options = check_setting_str(CFG, curTorrentProvider.getID().upper(),
                                                                curTorrentProvider.getID() + '_options', '')
@@ -1759,6 +1765,11 @@ def save_config():
         if hasattr(curTorrentProvider, 'confirmed'):
             new_config[curTorrentProvider.getID().upper()][curTorrentProvider.getID() + '_confirmed'] = int(
                 curTorrentProvider.confirmed)
+        if hasattr(curTorrentProvider, 'ranked'):
+            new_config[curTorrentProvider.getID().upper()][curTorrentProvider.getID() + '_ranked'] = int(
+                curTorrentProvider.ranked)
+        if hasattr(curTorrentProvider, 'sorting'):
+            new_config[curTorrentProvider.getID().upper()][curTorrentProvider.getID() + '_sorting'] = curTorrentProvider.sorting
         if hasattr(curTorrentProvider, 'ratio'):
             new_config[curTorrentProvider.getID().upper()][
                 curTorrentProvider.getID() + '_ratio'] = curTorrentProvider.ratio

--- a/sickbeard/providers/rarbg.py
+++ b/sickbeard/providers/rarbg.py
@@ -58,6 +58,8 @@ class RarbgProvider(generic.TorrentProvider):
         self.supportsBacklog = True
         self.ratio = None
         self.minseed = None
+        self.ranked = None
+        self.sorting = None
         self.minleech = None
         self.token = None
         self.tokenExpireDate = None
@@ -84,10 +86,8 @@ class RarbgProvider(generic.TorrentProvider):
         }
         
         self.defaultOptions = self.urlOptions['categories'].format(categories='18;41') + \
-                                self.urlOptions['sorting'].format(sorting='seeders') + \
                                 self.urlOptions['limit'].format(limit='100') + \
-                                self.urlOptions['format'].format(format='json') + \
-                                self.urlOptions['ranked'].format(ranked='0')
+                                self.urlOptions['format'].format(format='json')
 
         self.next_request = datetime.datetime.now()
 
@@ -226,6 +226,12 @@ class RarbgProvider(generic.TorrentProvider):
 
                 if self.minseed:
                     searchURL += self.urlOptions['seeders'].format(min_seeders=int(self.minseed))
+                    
+                if self.sorting:
+                    searchURL += self.urlOptions['sorting'].format(sorting=self.sorting)
+
+                if self.ranked:
+                    searchURL += self.urlOptions['ranked'].format(ranked=int(self.ranked))
 
                 logger.log(u'{name} search page URL: {url}'.format(name=self.name, url=searchURL), logger.DEBUG)
 

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -4478,6 +4478,19 @@ class ConfigProviders(Config):
                 except:
                     curTorrentProvider.confirmed = 0
 
+            if hasattr(curTorrentProvider, 'ranked'):
+                try:
+                    curTorrentProvider.ranked = config.checkbox_to_value(
+                        kwargs[curTorrentProvider.getID() + '_ranked'])
+                except:
+                    curTorrentProvider.ranked = 0
+
+            if hasattr(curTorrentProvider, 'sorting'):
+                try:
+                    curTorrentProvider.sorting = str(kwargs[curTorrentProvider.getID() + '_sorting']).strip()
+                except:
+                     curTorrentProvider.sorting = 'seeders'
+
             if hasattr(curTorrentProvider, 'proxy'):
                 try:
                     curTorrentProvider.proxy.enabled = config.checkbox_to_value(


### PR DESCRIPTION
Ranked: If checked will only return rartv, ettv, and scene releases released internally on rarbg. Otherwise returns all results from rarbg site.
Sorting: By seeders, leechers, or newest first