### PR TITLE
webapi CMD_ShowPause doesn't update database

### DIFF
--- a/sickbeard/webapi.py
+++ b/sickbeard/webapi.py
@@ -2388,9 +2388,11 @@ class CMD_ShowPause(ApiCall):
 
         if self.pause:
             showObj.paused = 1
+            showObj.saveToDB()
             return _responds(RESULT_SUCCESS, msg=str(showObj.name) + " has been paused")
         else:
             showObj.paused = 0
+            showObj.saveToDB()
             return _responds(RESULT_SUCCESS, msg=str(showObj.name) + " has been unpaused")
 
 class CMD_ShowRefresh(ApiCall):


### PR DESCRIPTION
webapi does not update the database for the "show.pause" command till SickRage restarts. This causes the SickRage web interface to not show the "Coming Episodes" paused or not accurately. And any addons retrieving the pause data will not be correct after a webapi "show.pause" command till after a restart.

Added
showObj.saveToDB()
to lines 2391 and 2395