### PR TITLE
Add API methods to check for update and perform update

### DIFF
--- a/gui/slick/interfaces/default/apiBuilder.tmpl
+++ b/gui/slick/interfaces/default/apiBuilder.tmpl
@@ -32,6 +32,7 @@ addListGroup("api", "Command");
 
 addOption("Command", "SickRage", "?cmd=sb", 1); //make default
 addList("Command", "SickRage.AddRootDir", "?cmd=sb.addrootdir", "sb.addrootdir", "", "", "action");
+addOption("Command", "SickRage.CheckVersion", "?cmd=sb.checkversion", "", "", "action");
 addOption("Command", "SickRage.CheckScheduler", "?cmd=sb.checkscheduler", "", "", "action");
 addList("Command", "SickRage.DeleteRootDir", "?cmd=sb.deleterootdir", "sb.deleterootdir", "", "", "action");
 addOption("Command", "SickRage.ForceSearch", "?cmd=sb.forcesearch", "", "", "action");
@@ -44,6 +45,7 @@ addOption("Command", "SickRage.Restart", "?cmd=sb.restart", "", "", "action");
 addList("Command", "SickRage.searchindexers", "?cmd=sb.searchindexers", "sb.searchindexers", "", "", "action");
 addList("Command", "SickRage.SetDefaults", "?cmd=sb.setdefaults", "sb.setdefaults", "", "", "action");
 addOption("Command", "SickRage.Shutdown", "?cmd=sb.shutdown", "", "", "action");
+addOption("Command", "SickRage.Update", "?cmd=sb.update", "", "", "action");
 addList("Command", "Coming Episodes", "?cmd=future", "future");
 addList("Command", "Episode", "?cmd=episode", "episode");
 addList("Command", "Episode.Search", "?cmd=episode.search", "episode.search", "", "", "action");

--- a/sickbeard/versionChecker.py
+++ b/sickbeard/versionChecker.py
@@ -68,7 +68,7 @@ class CheckVersion():
                 if sickbeard.AUTO_UPDATE:
                     logger.log(u"New update found for SickRage, starting auto-updater ...")
                     ui.notifications.message('New update found for SickRage, starting auto-updater')
-                    if self.safe_to_update() == True and self._runbackup() == True:
+                    if self.run_backup_if_safe() is True:
                         if sickbeard.versionCheckScheduler.action.update():
                             logger.log(u"Update was successful!")
                             ui.notifications.message('Update was successful')
@@ -76,6 +76,9 @@ class CheckVersion():
                         else:
                             logger.log(u"Update failed!")
                             ui.notifications.message('Update failed!')
+
+    def run_backup_if_safe(self):
+        return self.safe_to_update() is True and self._runbackup() is True
 
     def _runbackup(self):
         # Do a system backup before update
@@ -301,6 +304,21 @@ class GitUpdateManager(UpdateManager):
         self._newest_commit_hash = None
         self._num_commits_behind = 0
         self._num_commits_ahead = 0
+
+    def get_cur_commit_hash(self):
+        return self._cur_commit_hash
+
+    def get_newest_commit_hash(self):
+        return self._newest_commit_hash
+
+    def get_cur_version(self):
+        return self._run_git(self._git_path, "describe --abbrev=0 " + self._cur_commit_hash)[0]
+
+    def get_newest_version(self):
+        return self._run_git(self._git_path, "describe --abbrev=0 " + self._newest_commit_hash)[0]
+
+    def get_num_commits_behind(self):
+        return self._num_commits_behind
 
     def _git_error(self):
         error_message = 'Unable to find your git executable - Shutdown SickRage and EITHER set git_path in your config.ini OR delete your .git folder and run from source to enable updates.'
@@ -613,7 +631,22 @@ class SourceUpdateManager(UpdateManager):
             return "master"
         else:
             return sickbeard.CUR_COMMIT_BRANCH
-        
+
+    def get_cur_commit_hash(self):
+        return self._cur_commit_hash
+
+    def get_newest_commit_hash(self):
+        return self._newest_commit_hash
+
+    def get_cur_version(self):
+        return ""
+
+    def get_newest_version(self):
+        return ""
+
+    def get_num_commits_behind(self):
+        return self._num_commits_behind
+
     def need_update(self):
         # need this to run first to set self._newest_commit_hash
         try:

--- a/sickbeard/webapi.py
+++ b/sickbeard/webapi.py
@@ -28,6 +28,7 @@ import traceback
 
 import sickbeard
 
+from versionChecker import CheckVersion
 from sickbeard import db, logger, exceptions, history, ui, helpers
 from sickbeard import encodingKludge as ek
 from sickbeard import search_queue
@@ -752,7 +753,7 @@ class CMD_ComingEpisodes(ApiCall):
         # Safety Measure to convert rows in sql_results to dict.
         # This should not be required as the DB connections should only be returning dict results not sqlite3.row_type
         dict_results = [dict(row) for row in sql_results]
-        
+
         for ep in dict_results:
             """
                 Missed:   yesterday... (less than 1week)
@@ -1482,6 +1483,35 @@ class CMD_SickBeardAddRootDir(ApiCall):
         sickbeard.ROOT_DIRS = root_dirs_new
         return _responds(RESULT_SUCCESS, _getRootDirs(), msg="Root directories updated")
 
+class CMD_SickBeardCheckVersion(ApiCall):
+    _help = {"desc": "check if a new version of SickRage is available"}
+
+    def __init__(self, args, kwargs):
+        # required
+        # optional
+        # super, missing, help
+        ApiCall.__init__(self, args, kwargs)
+
+    def run(self):
+        checkversion = CheckVersion()
+        needs_update = checkversion.check_for_new_version()
+
+        data = {
+            "current_version": {
+                "branch": checkversion.get_branch(),
+                "commit": checkversion.updater.get_cur_commit_hash(),
+                "version": checkversion.updater.get_cur_version(),
+            },
+            "latest_version": {
+                "branch": checkversion.get_branch(),
+                "commit": checkversion.updater.get_newest_commit_hash(),
+                "version": checkversion.updater.get_newest_version(),
+            },
+            "commits_offset": checkversion.updater.get_num_commits_behind(),
+            "needs_update": needs_update,
+        }
+
+        return _responds(RESULT_SUCCESS, data)
 
 class CMD_SickBeardCheckScheduler(ApiCall):
     _help = {"desc": "query the scheduler"}
@@ -1868,6 +1898,27 @@ class CMD_SickBeardShutdown(ApiCall):
         sickbeard.events.put(sickbeard.events.SystemEvent.SHUTDOWN)
         return _responds(RESULT_SUCCESS, msg="SickRage is shutting down...")
 
+class CMD_SickBeardUpdate(ApiCall):
+    _help = {"desc": "update SickRage to the latest version available"}
+
+    def __init__(self, args, kwargs):
+        # required
+        # optional
+        # super, missing, help
+        ApiCall.__init__(self, args, kwargs)
+
+    def run(self):
+        checkversion = CheckVersion()
+
+        if checkversion.check_for_new_version():
+            if checkversion.run_backup_if_safe():
+                checkversion.update()
+
+                return _responds(RESULT_SUCCESS, msg="SickRage is updating ...")
+
+            return _responds(RESULT_FAILURE, msg="SickRage could not backup config ...")
+
+        return _responds(RESULT_FAILURE, msg="SickRage is already up to date")
 
 class CMD_Show(ApiCall):
     _help = {"desc": "display information for a given show",
@@ -2867,6 +2918,7 @@ _functionMaper = {"help": CMD_Help,
                   "sb": CMD_SickBeard,
                   "postprocess": CMD_PostProcess,
                   "sb.addrootdir": CMD_SickBeardAddRootDir,
+                  "sb.checkversion": CMD_SickBeardCheckVersion,
                   "sb.checkscheduler": CMD_SickBeardCheckScheduler,
                   "sb.deleterootdir": CMD_SickBeardDeleteRootDir,
                   "sb.getdefaults": CMD_SickBeardGetDefaults,
@@ -2879,6 +2931,7 @@ _functionMaper = {"help": CMD_Help,
                   "sb.searchtvdb": CMD_SickBeardSearchTVDB,
                   "sb.searchtvrage": CMD_SickBeardSearchTVRAGE,
                   "sb.setdefaults": CMD_SickBeardSetDefaults,
+                  "sb.update": CMD_SickBeardUpdate,
                   "sb.shutdown": CMD_SickBeardShutdown,
                   "show": CMD_Show,
                   "show.addexisting": CMD_ShowAddExisting,


### PR DESCRIPTION
I added the two following methods to SickRage's API:
- `sb.checkversion`:
 - Get information about the current version
 - Get information about the latest version
 - Check if an update is required
 - Get the number of commits between the current version and the latest version
- `sb.update`: update SickRage if necessary

## Usage

### `sb.checkversion`

Request:

```
GET /?cmd=sb.checkversion
```

Response:

```json
{
    "data": {
        "commits_offset": 0, 
        "current_version": {
            "branch": "develop", 
            "commit": "ddc0fca21d9030612a5c810ecc24463a7f64112b", 
            "version": "v4.0.24"
        }, 
        "latest_version": {
            "branch": "develop", 
            "commit": "3565ec70dc924d8117f506983fc18a9351f487e4", 
            "version": "v4.0.24"
        }, 
        "needs_update": false
    }, 
    "message": "", 
    "result": "success"
}
```

### `sb.update`

Request:

```
GET /?cmd=sb.update
```

Response:

```json
// If no update is necessary
{
    "data": {}, 
    "message": "SickRage is already up to date", 
    "result": "failure"
}

// If the config could not be backed up
{
    "data": {}, 
    "message": "SickRage could not backup config ...", 
    "result": "failure"
}

// If an update was started
{
    "data": {}, 
    "message": "SickRage is updating ...", 
    "result": "success"
}
```

I'm not an expert in Python, but I think that my changes in `sickbeard/versionChecker.py` can be improved.

Reference issue: SiCKRAGETV/sickrage-issues#1780