### PR TITLE
Fix HDT removing first letter of the file

### DIFF
--- a/sickbeard/providers/hdtorrents.py
+++ b/sickbeard/providers/hdtorrents.py
@@ -218,7 +218,7 @@ class HDTorrentsProvider(generic.TorrentProvider):
                             continue
 
                         try:
-                            title = entries[22].find('a')['title'].strip('History - ').replace('Blu-ray', 'bd50')
+                            title = entries[22].find('a')['title'].replace('History - ','').replace('Blu-ray', 'bd50')
                             url = self.urls['home'] % entries[15].find('a')['href']
                             download_url = self.urls['home'] % entries[15].find('a')['href']
                             id = entries[23].find('div')['id']


### PR DESCRIPTION
```
>>> Title = "History - A"
>>> print Title.strip('History - ')
A
>>> Title = "History - B"
>>> print Title.strip('History - ')
B
>>> Title = "History - C"
>>> print Title.strip('History - ')
C
>>> Title = "History - D"
>>> print Title.strip('History - ')
D
>>> Title = "History - E"
>>> print Title.strip('History - ')
E
>>> Title = "History - F"
>>> print Title.strip('History - ')
F
>>> Title = "History - G"
>>> print Title.strip('History - ')
G
>>> Title = "History - H"
>>> print Title.strip('History - ')

>>> 