### PR TITLE
Multiple fixes

### DIFF
--- a/gui/slick/interfaces/default/history.tmpl
+++ b/gui/slick/interfaces/default/history.tmpl
@@ -213,16 +213,10 @@
 					#for $action in sorted($hItem["actions"]):
 						#set $curStatus, $curQuality = $Quality.splitCompositeStatus(int($action["action"]))
 						#if $curStatus == DOWNLOADED:
-							#set $match = $re.search("\-(\w+)\.\w{3}\Z", $os.path.basename($action["resource"]))
-							#if $match
-								#if $match.group(1).upper() in ("X264", "720P"):
-									#set $match = $re.search("(\w+)\-.*\-"+$match.group(1)+"\.\w{3}\Z", $os.path.basename($hItem["resource"]), re.IGNORECASE)
-								#if $match
-									<span style="cursor: help;" title="$os.path.basename($action["resource"])"><i>$match.group(1).upper()</i></span>
-								#end if
-								#else:
-									<span style="cursor: help;" title="$os.path.basename($action["resource"])"><i>$match.group(1).upper()</i></span>
-								#end if
+							#if $action["provider"] != -1:
+								<span style="cursor: help;" title="$os.path.basename($action["resource"])"><i>$action["provider"]</i></span>
+							#else:
+								<span style="cursor: help;" title="$os.path.basename($action["resource"])"></span>
 							#end if
 						#end if
 					#end for

--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -137,10 +137,7 @@ def remove_non_release_groups(name):
         elif remove_type == 'searchre':
             _name = re.sub(r'(?i)' + remove_string, '', _name)
 
-    #if _name != name:
-    #    logger.log(u'Change title from {old_name} to {new_name}'.format(old_name=name, new_name=_name), logger.DEBUG)
-
-    return _name
+    return _name.strip('.- ')
 
 
 def replaceExtension(filename, newExt):

--- a/sickbeard/providers/rarbg.py
+++ b/sickbeard/providers/rarbg.py
@@ -112,7 +112,7 @@ class RarbgProvider(generic.TorrentProvider):
             response = self.session.get(self.urls['token'], timeout=30, verify=False, headers=self.headers)
             response.raise_for_status()
             resp_json = response.json()
-        except RequestException as e:
+        except (RequestException, BaseSSLError) as e:
             logger.log(u'Unable to connect to {name} provider: {error}'.format(name=self.name, error=ex(e)), logger.ERROR)
             return False
 


### PR DESCRIPTION
Fix SiCKRAGETV/sickrage-issues#1862
Fix SiCKRAGETV/sickrage-issues#1825 (Hopefully)
Fix Fix SiCKRAGETV/sickrage-issues#1858 (Might not catch it still)
Strip '. -' after removeWords.

regexes need updated but are quite complicated. failing regex is the only reason we need removeWords, and even after they are not perfect. I have a perfect working regex without removing subrls suffix but atm it breaks down if there is no release group at all in the name.
