### PR TITLE
Fix resultType not in class Proper, use head instead of get request w…

### DIFF
--- a/sickbeard/providers/scc.py
+++ b/sickbeard/providers/scc.py
@@ -284,7 +284,7 @@ class SCCCache(tvcache.TVCache):
         self.minTime = 20
 
     def _getRSSData(self):
-        search_params = []
+        search_params = u''
         return {'entries': self.provider._doSearch(search_params)}
 
 provider = SCCProvider()


### PR DESCRIPTION
…hen validating search results

Fixes SiCKRAGETV/sickrage-issues#1889

When searching propers or torrents that were not black hole, SR was downloading the torrent content of EVERY search result to test if it was valid. All NZB, and Torrent BlackHole were not verified at all, and could fail later resulting in another search to be made (more requests)

Now we use http HEAD request for all, which does not read any content, so all links are verified when choosing from search results, and only downloaded later if the result ends up being the chosen result!