### PR TITLE
Fix TypeError on tntvillage provider

### DIFF
--- a/sickbeard/providers/tntvillage.py
+++ b/sickbeard/providers/tntvillage.py
@@ -302,6 +302,9 @@ class TNTVillageProvider(generic.TorrentProvider):
 
         name = str(span_tag)
 
+        if not name:
+            return 0
+
         subFound=0
 
         for sub in self.sub_string:


### PR DESCRIPTION
Error log:
2015-07-08 10:50:37 ERROR    SEARCHQUEUE-BACKLOG-248835 :: [TNTVillage] :: Failed parsing TNTVillage Traceback: Traceback (most recent call last):
  File "/home/mediacenter/src/sickbeard/sickrage/sickrage/sickbeard/providers/tntvillage.py", line 436, in _doSearch
    if not self._is_italian(result) and not self.subtitle:
  File "/home/mediacenter/src/sickbeard/sickrage/sickrage/sickbeard/providers/tntvillage.py", line 309, in _is_italian
    if not re.search(sub, name, re.I):
  File "/usr/lib/python2.7/re.py", line 142, in search
    return _compile(pattern, flags).search(string)
TypeError: expected string or buffer
Traceback (most recent call last):
  File "/home/mediacenter/src/sickbeard/sickrage/sickrage/sickbeard/providers/tntvillage.py", line 436, in _doSearch
    if not self._is_italian(result) and not self.subtitle:
  File "/home/mediacenter/src/sickbeard/sickrage/sickrage/sickbeard/providers/tntvillage.py", line 309, in _is_italian
    if not re.search(sub, name, re.I):
  File "/usr/lib/python2.7/re.py", line 142, in search
    return _compile(pattern, flags).search(string)
TypeError: expected string or buffer
