### PR TITLE
Scene exceptions list overwite results in multiple identical search url's

### DIFF
--- a/sickbeard/providers/newznab.py
+++ b/sickbeard/providers/newznab.py
@@ -198,7 +198,7 @@ class NewznabProvider(generic.NZBProvider):
             if add_string:
                 params['q'] += ' ' + add_string
 
-            to_return.append(params)
+            to_return.append(dict(params))
 
             if ep_obj.show.anime:
                 paramsNoEp = params.copy()


### PR DESCRIPTION
All items in the list referred to the same object, so when this object was mutated all the items in the list got mutated.
This resulted in exactly the same search url multiple times when we had a list of scene exceptions.
Appended a copy of the original params dictionary object to the list, instead os the original object.
