### PR TITLE
Better integration in Chrome for Android

### DIFF
--- a/gui/slick/interfaces/default/inc_top.tmpl
+++ b/gui/slick/interfaces/default/inc_top.tmpl
@@ -7,6 +7,13 @@
 		<meta charset="utf-8">
 		<meta http-equiv="X-UA-Compatible" content="IE=edge">
 		<meta name="viewport" content="width=device-width, initial-scale=1">
+
+		<!-- These values come from css/dark.css and css/light.css -->
+		#if $sickbeard.THEME_NAME == "dark":
+		<meta name="theme-color" content="#15528F">
+		#elif $sickbeard.THEME_NAME == "light":
+		<meta name="theme-color" content="#333333">
+		#end if
 	
 		<title>SickRage - BRANCH:[$sickbeard.BRANCH] - $title</title>
 	


### PR DESCRIPTION
This PR makes SickRage looks a bit better in Chrome for Android (don't know if it works on iOS too).

Before:
![Before](https://cloud.githubusercontent.com/assets/1009664/8637959/1003b84c-28ab-11e5-8a44-337701dae48c.png)


After:
![After (dark theme)](https://cloud.githubusercontent.com/assets/1009664/8637964/173d92cc-28ab-11e5-8417-1f8ce76a0623.png)

![After (light theme)](https://cloud.githubusercontent.com/assets/1009664/8637969/1f6c8c64-28ab-11e5-8c21-edeec7bf7f65.png)