### PR TITLE
Add an API method to get a network logo

### DIFF
--- a/gui/slick/interfaces/default/apiBuilder.tmpl
+++ b/gui/slick/interfaces/default/apiBuilder.tmpl
@@ -61,6 +61,7 @@ addList("Command", "Show.AddNew", "?cmd=show.addnew", "show.addnew", "", "", "ac
 addList("Command", "Show.Cache", "?cmd=show.cache", "indexerid", "", "", "action");
 addList("Command", "Show.Delete", "?cmd=show.delete", "show.delete", "", "", "action");
 addList("Command", "Show.GetBanner", "?cmd=show.getbanner", "indexerid", "", "", "action");
+addList("Command", "Show.GetNetworkLogo", "?cmd=show.getnetworklogo", "indexerid", "", "", "action");
 addList("Command", "Show.GetPoster", "?cmd=show.getposter", "indexerid", "", "", "action");
 addList("Command", "Show.GetQuality", "?cmd=show.getquality", "indexerid", "", "", "action");
 addList("Command", "Show.Pause", "?cmd=show.pause", "show.pause", "", "", "action");

--- a/gui/slick/interfaces/default/home.tmpl
+++ b/gui/slick/interfaces/default/home.tmpl
@@ -603,7 +603,7 @@ $myShowList.sort(lambda x, y: cmp(x.name, y.name))
 				<td class="show-table">
 				    #if $layout != 'simple':	
 						#if $curShow.network:
-							<span title="$curShow.network"><img class="show-network-image" src="$sbRoot/images/network/${curShow.network.replace(u"\u00C9",'e').replace(u"\u00E9",'e').lower()}.png" alt="$curShow.network" title="$curShow.network" /></span>	
+							<span title="$curShow.network"><img class="show-network-image" src="$sbRoot/showNetworkLogo/?show=$curShow.indexerid" alt="$curShow.network" title="$curShow.network" /></span>
 						#else:
 							<span title="No Network"><img class="show-network-image" src="$sbRoot/images/network/nonetwork.png" alt="No Network" title="No Network" /></span>
 						#end if
@@ -801,7 +801,7 @@ $myShowList.sort(lambda x, y: cmp(x.name, y.name))
     #if $layout != 'simple':	
 		<td align="center">
         #if $curShow.network:
-        	<span title="$curShow.network"><img id="network" width="54" height="27" src="$sbRoot/images/network/${curShow.network.replace(u"\u00C9",'e').replace(u"\u00E9",'e').lower()}.png" alt="$curShow.network" title="$curShow.network" /></span>
+        	<span title="$curShow.network"><img id="network" width="54" height="27" src="$sbRoot/showNetworkLogo/?show=$curShow.indexerid" alt="$curShow.network" title="$curShow.network" /></span>
     	#else:
     		<span title="No Network"><img id="network" width="54" height="27" src="$sbRoot/images/network/nonetwork.png" alt="No Network" title="No Network" /></span>
 		#end if

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -174,6 +174,10 @@ class TVShow(object):
         else:
             return False
 
+    @property
+    def network_logo_name(self):
+        return self.network.replace(u'\u00C9', 'e').replace(u'\u00E9', 'e').lower()
+
     def _getLocation(self):
         # no dir check needed if missing show dirs are created during post-processing
         if sickbeard.CREATE_MISSING_SHOW_DIRS:

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -410,6 +410,18 @@ class WebRoot(WebHandler):
         static_image_path = static_image_path.replace('\\', '/')
         return self.redirect(static_image_path)
 
+    def showNetworkLogo(self, show=None):
+        show = sickbeard.helpers.findCertainShow(sickbeard.showList, int(show))
+
+        if show:
+            image_file_name = show.network_logo_name
+        else:
+            image_file_name = 'nonetwork'
+
+        static_image_path = '%s/images/network/%s.png' % (sickbeard.WEB_ROOT, image_file_name)
+
+        return self.redirect(static_image_path)
+
     def setHomeLayout(self, layout):
 
         if layout not in ('poster', 'small', 'banner', 'simple', 'coverflow'):


### PR DESCRIPTION
For SiCKRAGETV/sickrage-issues#1763.

This adds a new API method to get the network logo of a show. I also updated the web part.
I think it would be nice to merge some code between the API and the web part. Right now the code to get a show banner/poster/network logo is duplicated between those two parts.