### PR TITLE
Small visual improvement in server status

### DIFF
--- a/gui/slick/interfaces/default/status.tmpl
+++ b/gui/slick/interfaces/default/status.tmpl
@@ -62,11 +62,11 @@
 			#for $schedulerName, $scheduler in $schedulerList.iteritems()
 				#set service = getattr($sickbeard, $scheduler)
 			<tr>
-				<td>#echo $schedulerName #</td>
+				<td>$schedulerName</td>
 				#if $service.isAlive()
-				<td style="background-color:green">#echo $service.isAlive() #</td>
+				<td style="background-color:green">$service.isAlive()</td>
 				#else
-				<td style="background-color:red">#echo $service.isAlive() #</td>
+				<td style="background-color:red">$service.isAlive()</td>
 				#end if
 				#if $scheduler == 'backlogSearchScheduler'
 					#set searchQueue = getattr($sickbeard, 'searchQueueScheduler')
@@ -75,10 +75,10 @@
 					#if $BLSpaused
 				<td>Paused</td>
 					#else
-				<td>#echo $service.enable #</td>
+				<td>$service.enable</td>
 					#end if
 				#else
-				<td>#echo $service.enable #</td>
+				<td>$service.enable</td>
 				#end if
 				#if $scheduler == 'backlogSearchScheduler'
 					#set searchQueue = getattr($sickbeard, 'searchQueueScheduler')
@@ -89,7 +89,7 @@
 					#else
 						#try
 						#set amActive = $service.action.amActive
-				<td>#echo $amActive #</td>
+				<td>$amActive</td>
 						#except Exception
 				<td>N/A</td>
 						#end try
@@ -97,22 +97,22 @@
 				#else
 					#try
 					#set amActive = $service.action.amActive
-				<td>#echo $amActive #</td>
+				<td>$amActive</td>
 					#except Exception
 				<td>N/A</td>
 					#end try
 				#end if
-				<td>#echo $service.start_time #</td>
+				<td align="right">$service.start_time</td>
 				#set $cycleTime = ($service.cycleTime.microseconds + ($service.cycleTime.seconds + $service.cycleTime.days * 24 * 3600) * 10**6) / 10**6
-				<td>#echo $helpers.pretty_time_delta($cycleTime) #</td>
+				<td align="right">$helpers.pretty_time_delta($cycleTime)</td>
 				#if $service.enable
 					#set $timeLeft = ($service.timeLeft().microseconds + ($service.timeLeft().seconds + $service.timeLeft().days * 24 * 3600) * 10**6) / 10**6
-				<td>#echo $helpers.pretty_time_delta($timeLeft) #</td>
+				<td align="right">$helpers.pretty_time_delta($timeLeft)</td>
 				#else
 				<td></td>
 				#end if
-				<td>#echo $service.lastRun.strftime("%Y-%m-%d %H:%M:%S") #</td>
-				<td>#echo $service.silent #</td>
+				<td>$service.lastRun.strftime("%Y-%m-%d %H:%M:%S")</td>
+				<td>$service.silent</td>
 			</tr>
 			#del service
 			#end for

--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -150,7 +150,7 @@ def remove_non_release_groups(name):
 
 
 def replaceExtension(filename, newExt):
-    '''
+    """
     >>> replaceExtension('foo.avi', 'mkv')
     'foo.mkv'
     >>> replaceExtension('.vimrc', 'arglebargle')
@@ -161,7 +161,7 @@ def replaceExtension(filename, newExt):
     ''
     >>> replaceExtension('foo.bar', '')
     'foo.'
-    '''
+    """
     sepFile = filename.rpartition(".")
     if sepFile[0] == "":
         return filename
@@ -221,7 +221,7 @@ def isBeingWritten(filepath):
 
 
 def sanitizeFileName(name):
-    '''
+    """
     >>> sanitizeFileName('a/b/c')
     'a-b-c'
     >>> sanitizeFileName('abc')
@@ -230,7 +230,7 @@ def sanitizeFileName(name):
     'ab'
     >>> sanitizeFileName('.a.b..')
     'a.b'
-    '''
+    """
 
     # remove bad chars from the filename
     name = re.sub(r'[\\/\*]', '-', name)
@@ -356,7 +356,7 @@ def searchIndexerForShowID(regShowName, indexer=None, indexer_id=None, ui=None):
 
 
 def sizeof_fmt(num):
-    '''
+    """
     >>> sizeof_fmt(2)
     '2.0 bytes'
     >>> sizeof_fmt(1024)
@@ -367,7 +367,7 @@ def sizeof_fmt(num):
     '1.0 MB'
     >>> sizeof_fmt(1234567)
     '1.2 MB'
-    '''
+    """
     for x in ['bytes', 'KB', 'MB', 'GB', 'TB']:
         if num < 1024.0:
             return "%3.1f %s" % (num, x)
@@ -1589,15 +1589,19 @@ def pretty_time_delta(seconds):
     days, seconds = divmod(seconds, 86400)
     hours, seconds = divmod(seconds, 3600)
     minutes, seconds = divmod(seconds, 60)
+    time_delta = sign_string
+
     if days > 0:
-        return '%s%dd%02dh%02dm%02ds' % (sign_string, days, hours, minutes, seconds)
-    elif hours > 0:
-        return '%s%02dh%02dm%02ds' % (sign_string, hours, minutes, seconds)
-    elif minutes > 0:
-        return '%s%02dm%02ds' % (sign_string, minutes, seconds)
-    else:
-        return '%s%02ds' % (sign_string, seconds)
-    
+        time_delta += ' %dd' % days
+    if hours > 0:
+        time_delta += ' %dh' % hours
+    if minutes > 0:
+        time_delta += ' %dm' % minutes
+    if seconds > 0:
+        time_delta += ' %ds' % seconds
+
+    return time_delta
+
 def isFileLocked(file, writeLockCheck=False):
     '''
     Checks to see if a file is locked. Performs three checks


### PR DESCRIPTION
This change the formatting of the the *Start time*, *Cycle time* and *Next run* columns in the *Scheduler* table.

Before:
<img width="1010" alt="Before" src="https://cloud.githubusercontent.com/assets/1009664/8638632/805f5fea-28c1-11e5-994f-64a17010c1cc.png">

After:
<img width="1006" alt="After" src="https://cloud.githubusercontent.com/assets/1009664/8638634/85abe3e2-28c1-11e5-8dcb-16671bd2daf7.png">
