### PR TITLE
Change log messages to format

### DIFF
--- a/sickbeard/clients/generic.py
+++ b/sickbeard/clients/generic.py
@@ -52,20 +52,19 @@ class GenericClient(object):
             self.response = self.session.__getattribute__(method)(self.url, params=params, data=data, files=files,
                                                                   timeout=120, verify=False)
         except requests.exceptions.ConnectionError, e:
-            logger.log(self.name + u': Unable to connect ' + str(e), logger.ERROR)
+            logger.log(u'{0}: Unable to connect {1} '.format(self.name,str(e)), logger.ERROR)
             return False
         except (requests.exceptions.MissingSchema, requests.exceptions.InvalidURL):
             logger.log(self.name + u': Invalid Host', logger.ERROR)
             return False
         except requests.exceptions.HTTPError, e:
-            logger.log(self.name + u': Invalid HTTP Request ' + str(e), logger.ERROR)
+            logger.log(u'{0}: Invalid HTTP Request {1} '.format(self.name,str(e)), logger.ERROR)
             return False
         except requests.exceptions.Timeout, e:
-            logger.log(self.name + u': Connection Timeout ' + str(e), logger.WARNING)
+            logger.log(u'{0}: Connection Timeout {1}'.format(self.name,str(e)), logger.ERROR)
             return False
         except Exception, e:
-            logger.log(self.name + u': Unknown exception raised when send torrent to ' + self.name + ': ' + str(e),
-                       logger.ERROR)
+            logger.log(u'{0}: Unknown exception raised when send torrent to {0} : {1}'.format(self.name,str(e)), logger.ERROR)            
             return False
 
         if self.response.status_code == 401:
@@ -73,10 +72,10 @@ class GenericClient(object):
             return False
 
         if self.response.status_code in http_error_code.keys():
-            logger.log(self.name + u': ' + http_error_code[self.response.status_code], logger.DEBUG)
+            logger.log(u'{0}: {1}'.format(self.name,http_error_code[self.response.status_code]), logger.DEBUG)
             return False
 
-        logger.log(self.name + u': Response to ' + method.upper() + ' request is ' + self.response.text, logger.DEBUG)
+        logger.log(u'{0}: Response to {1} request is {2}'.format(self.name,method.upper(),self.response.text), logger.DEBUG)
 
         return True
 
@@ -214,7 +213,7 @@ class GenericClient(object):
 
         except Exception, e:
             logger.log(self.name + u': Failed Sending Torrent', logger.ERROR)
-            logger.log(self.name + u': Exception raised when sending torrent: ' + str(result) + u'. Error: ' + str(e), logger.DEBUG)
+            logger.log(u'{0}: Exception raised when sending torrent: {1}. Error: {2}'.format(self.name,str(result),str(e)), logger.DEBUG)
             return r_code
 
         return r_code

--- a/sickbeard/providers/alpharatio.py
+++ b/sickbeard/providers/alpharatio.py
@@ -91,7 +91,7 @@ class AlphaRatioProvider(generic.TorrentProvider):
         try:
             response = self.session.post(self.urls['login'], data=login_params, timeout=30)
         except (requests.exceptions.ConnectionError, requests.exceptions.HTTPError), e:
-            logger.log(u'Unable to connect to ' + self.name + ' provider: ' + ex(e), logger.ERROR)
+            logger.log(u'Unable to connect to {0} provider: {1}'.format(self.name,ex(e)), logger.ERROR)
             return False
 
         if re.search('Invalid Username/password', response.text) \

--- a/sickbeard/providers/bitsoup.py
+++ b/sickbeard/providers/bitsoup.py
@@ -93,7 +93,7 @@ class BitSoupProvider(generic.TorrentProvider):
         try:
             response = self.session.post(self.urls['login'], data=login_params, timeout=30)
         except (requests.exceptions.ConnectionError, requests.exceptions.HTTPError), e:
-            logger.log(u'Unable to connect to ' + self.name + ' provider: ' + ex(e), logger.ERROR)
+            logger.log(u'Unable to connect to {0} provider: {1}'.format(self.name,ex(e)), logger.ERROR)
             return False
 
         if re.search('Username or password incorrect', response.text):

--- a/sickbeard/providers/bluetigers.py
+++ b/sickbeard/providers/bluetigers.py
@@ -92,7 +92,7 @@ class BLUETIGERSProvider(generic.TorrentProvider):
         try:
             response = self.session.post(self.urls['login'], data=login_params, timeout=30)
         except (requests.exceptions.ConnectionError, requests.exceptions.HTTPError), e:
-            logger.log(u'Unable to connect to ' + self.name + ' provider: ' + ex(e), logger.ERROR)
+            logger.log(u'Unable to connect to {0} provider: {1}'.format(self.name,ex(e)), logger.ERROR)
             return False
 
         if re.search('/account-logout.php', response.text):

--- a/sickbeard/providers/fnt.py
+++ b/sickbeard/providers/fnt.py
@@ -91,7 +91,7 @@ class FNTProvider(generic.TorrentProvider):
         try:
             response = self.session.post(self.urls['login'], data=login_params, timeout=30)
         except (requests.exceptions.ConnectionError, requests.exceptions.HTTPError), e:
-            logger.log(u'Unable to connect to ' + self.name + ' provider: ' + ex(e), logger.ERROR)
+            logger.log(u'Unable to connect to {0} provider: {1}'.format(self.name,ex(e)), logger.ERROR)
             return False
 
         if re.search('/account-logout.php', response.text):

--- a/sickbeard/providers/freshontv.py
+++ b/sickbeard/providers/freshontv.py
@@ -106,7 +106,7 @@ class FreshOnTVProvider(generic.TorrentProvider):
             try:
                 response = self.session.post(self.urls['login'], data=login_params, timeout=30)
             except (requests.exceptions.ConnectionError, requests.exceptions.HTTPError) as e:
-                logger.log(u'Unable to connect to ' + self.name + ' provider: ' + ex(e), logger.ERROR)
+                logger.log(u'Unable to connect to {0} provider: {1}'.format(self.name,ex(e)), logger.ERROR)
                 return False
 
             if re.search('/logout.php', response.text):

--- a/sickbeard/providers/hdtorrents.py
+++ b/sickbeard/providers/hdtorrents.py
@@ -105,7 +105,7 @@ class HDTorrentsProvider(generic.TorrentProvider):
             try:
                 response = self.session.post(self.urls['login'], data=login_params, timeout=30)
             except (requests.exceptions.ConnectionError, requests.exceptions.HTTPError), e:
-                logger.log(u'Unable to connect to ' + self.name + ' provider: ' + ex(e), logger.ERROR)
+                logger.log(u'Unable to connect to {0} provider: {1}'.format(self.name,ex(e)), logger.ERROR)
                 return False
 
             if re.search('You need cookies enabled to log in.', response.text) \

--- a/sickbeard/providers/hounddawgs.py
+++ b/sickbeard/providers/hounddawgs.py
@@ -91,7 +91,7 @@ class HoundDawgsProvider(generic.TorrentProvider):
             self.session.get(self.urls['base_url'], timeout=30)
             response = self.session.post(self.urls['login'], data=login_params, timeout=30)
         except (requests.exceptions.ConnectionError, requests.exceptions.HTTPError), e:
-            logger.log(u'Unable to connect to ' + self.name + ' provider: ' + ex(e), logger.ERROR)
+            logger.log(u'Unable to connect to {0} provider: {1}'.format(self.name,ex(e)), logger.ERROR)
             return False
 
         if re.search('Dit brugernavn eller kodeord er forkert.', response.text) \

--- a/sickbeard/providers/iptorrents.py
+++ b/sickbeard/providers/iptorrents.py
@@ -95,7 +95,7 @@ class IPTorrentsProvider(generic.TorrentProvider):
         try:
             response = self.session.post(self.urls['login'], data=login_params, timeout=30)
         except (requests.exceptions.ConnectionError, requests.exceptions.HTTPError), e:
-            logger.log(u'Unable to connect to ' + self.name + ' provider: ' + ex(e), logger.ERROR)
+            logger.log(u'Unable to connect to {0} provider: {1}'.format(self.name,ex(e)), logger.ERROR)
             return False
 
         if re.search('tries left', response.text) \

--- a/sickbeard/providers/morethantv.py
+++ b/sickbeard/providers/morethantv.py
@@ -109,7 +109,7 @@ class MoreThanTVProvider(generic.TorrentProvider):
             try:
                 response = self.session.post(self.urls['login'], data=login_params, timeout=30)
             except (requests.exceptions.ConnectionError, requests.exceptions.HTTPError), e:
-                logger.log(u'Unable to connect to ' + self.name + ' provider: ' + ex(e), logger.ERROR)
+                logger.log(u'Unable to connect to {0} provider: {1}'.format(self.name,ex(e)), logger.ERROR)
                 return False
 
             if re.search('Your username or password was incorrect.', response.text):

--- a/sickbeard/providers/scc.py
+++ b/sickbeard/providers/scc.py
@@ -97,7 +97,7 @@ class SCCProvider(generic.TorrentProvider):
             from lib import certifi
             response = self.session.post(self.urls['login'], data=login_params, headers=self.headers, timeout=30)
         except (requests.exceptions.ConnectionError, requests.exceptions.HTTPError), e:
-            logger.log(u'Unable to connect to ' + self.name + ' provider: ' + ex(e), logger.ERROR)
+            logger.log(u'Unable to connect to {0} provider: {1}'.format(self.name,ex(e)), logger.ERROR)
             return False
 
         if re.search('Username or password incorrect', response.text) \

--- a/sickbeard/providers/scenetime.py
+++ b/sickbeard/providers/scenetime.py
@@ -89,7 +89,7 @@ class SceneTimeProvider(generic.TorrentProvider):
         try:
             response = self.session.post(self.urls['login'], data=login_params, timeout=30)
         except (requests.exceptions.ConnectionError, requests.exceptions.HTTPError), e:
-            logger.log(u'Unable to connect to ' + self.name + ' provider: ' + ex(e), logger.ERROR)
+            logger.log(u'Unable to connect to {0} provider: {1}'.format(self.name,ex(e)), logger.ERROR)
             return False
 
         if re.search('Username or password incorrect', response.text):

--- a/sickbeard/providers/speedcd.py
+++ b/sickbeard/providers/speedcd.py
@@ -87,7 +87,7 @@ class SpeedCDProvider(generic.TorrentProvider):
         try:
             response = self.session.post(self.urls['login'], data=login_params, timeout=30)
         except (requests.exceptions.ConnectionError, requests.exceptions.HTTPError), e:
-            logger.log(u'Unable to connect to ' + self.name + ' provider: ' + ex(e), logger.ERROR)
+            logger.log(u'Unable to connect to {0} provider: {1}'.format(self.name,ex(e)), logger.ERROR)
             return False
 
         if re.search('Incorrect username or Password. Please try again.', response.text) \

--- a/sickbeard/providers/t411.py
+++ b/sickbeard/providers/t411.py
@@ -90,7 +90,7 @@ class T411Provider(generic.TorrentProvider):
         try:
             response = helpers.getURL(self.urls['login_page'], post_data=login_params, timeout=30, session=self.session, json=True)
         except (requests.exceptions.ConnectionError, requests.exceptions.HTTPError), e:
-            logger.log(u'Unable to connect to ' + self.name + ' provider: ' + ex(e), logger.ERROR)
+            logger.log(u'Unable to connect to {0} provider: {1}'.format(self.name,ex(e)), logger.ERROR)
             return False
 
         if 'token' in response:

--- a/sickbeard/providers/tntvillage.py
+++ b/sickbeard/providers/tntvillage.py
@@ -155,7 +155,7 @@ class TNTVillageProvider(generic.TorrentProvider):
         try:
             response = self.session.post(self.urls['login'], data=login_params, timeout=30)
         except RequestException as e:
-            logger.log(u'Unable to connect to ' + self.name + ' provider: ' + ex(e), logger.ERROR)
+            logger.log(u'Unable to connect to {0} provider: {1}'.format(self.name,ex(e)), logger.ERROR)
             return False
 
         if re.search('Sono stati riscontrati i seguenti errori', response.text) \

--- a/sickbeard/providers/torrentbytes.py
+++ b/sickbeard/providers/torrentbytes.py
@@ -90,7 +90,7 @@ class TorrentBytesProvider(generic.TorrentProvider):
         try:
             response = self.session.post(self.urls['login'], data=login_params, timeout=30)
         except (requests.exceptions.ConnectionError, requests.exceptions.HTTPError), e:
-            logger.log(u'Unable to connect to ' + self.name + ' provider: ' + ex(e), logger.ERROR)
+            logger.log(u'Unable to connect to {0} provider: {1}'.format(self.name,ex(e)), logger.ERROR)
             return False
 
         if re.search('Username or password incorrect', response.text):

--- a/sickbeard/providers/torrentday.py
+++ b/sickbeard/providers/torrentday.py
@@ -99,7 +99,7 @@ class TorrentDayProvider(generic.TorrentProvider):
             try:
                 response = self.session.post(self.urls['login'], data=login_params, timeout=30)
             except (requests.exceptions.ConnectionError, requests.exceptions.HTTPError), e:
-                logger.log(u'Unable to connect to ' + self.name + ' provider: ' + ex(e), logger.ERROR)
+                logger.log(u'Unable to connect to {0} provider: {1}'.format(self.name,ex(e)), logger.ERROR)
                 return False
 
             if re.search('You tried too often', response.text):

--- a/sickbeard/providers/torrentleech.py
+++ b/sickbeard/providers/torrentleech.py
@@ -94,7 +94,7 @@ class TorrentLeechProvider(generic.TorrentProvider):
         try:
             response = self.session.post(self.urls['login'], data=login_params, timeout=30)
         except (requests.exceptions.ConnectionError, requests.exceptions.HTTPError), e:
-            logger.log(u'Unable to connect to ' + self.name + ' provider: ' + ex(e), logger.ERROR)
+            logger.log(u'Unable to connect to {0} provider: {1}'.format(self.name,ex(e)), logger.ERROR)
             return False
 
         if re.search('Invalid Username/password', response.text) \


### PR DESCRIPTION
@miigotu rarbg is ok but still is showing bad chars:

[Rarbg] :: Unable to connect to Rarbg provider: error ('Connection aborted.', gaierror(-2, 'Nome ou servi\xc3\xa7o desconhecido'))
https://github.com/SiCKRAGETV/SickRage/blob/master/sickbeard/providers/rarbg.py#L114

this pull was made because of rarbg but it code already uses .format