### PR TITLE
Fix search indexers api

### DIFF
--- a/sickbeard/webapi.py
+++ b/sickbeard/webapi.py
@@ -1807,8 +1807,8 @@ class CMD_SickBeardSearchTVDB(CMD_SickBeardSearchIndexers):
 
 
     def __init__(self, args, kwargs):
-        self.indexerid, args = self.check_params(args, kwargs, "tvdbid", None, False, "int", [])
         CMD_SickBeardSearchIndexers.__init__(self, args, kwargs)
+        self.indexerid, args = self.check_params(args, kwargs, "tvdbid", None, False, "int", [])
 
 
 class CMD_SickBeardSearchTVRAGE(CMD_SickBeardSearchIndexers):
@@ -1820,8 +1820,8 @@ class CMD_SickBeardSearchTVRAGE(CMD_SickBeardSearchIndexers):
     }
 
     def __init__(self, args, kwargs):
-        self.indexerid, args = self.check_params(args, kwargs, "tvrageid", None, False, "int", [])
         CMD_SickBeardSearchIndexers.__init__(self, args, kwargs)
+        self.indexerid, args = self.check_params(args, kwargs, "tvrageid", None, False, "int", [])
 
 
 class CMD_SickBeardSetDefaults(ApiCall):


### PR DESCRIPTION
Currently, if you use the `sb.searchtvdb` and `sb.searchtvrage` API commands, they both returns the search results for all indexers (TVDb and TVRage).

With this PR, the behavior is as follow:
- `sb.searchindexers` returns the results for all indexers
- `sb.searchtvdb` returns the results for TVDb only
- `sb.searchtvrage` returns the results for TVRage only