### PR TITLE
Add post subtitle download scripts

### DIFF
--- a/gui/slick/interfaces/default/config_subtitles.tmpl
+++ b/gui/slick/interfaces/default/config_subtitles.tmpl
@@ -124,7 +124,33 @@
 											<p><b>Warning: </b>this will ignore <u>all</u> embedded subtitles for every video file!</p>
 										</span>
 									</label>
-								</div>   
+								</div>
+								<div class="field-pair">
+        						    <label class="nocheck">
+        						        <span class="component-title">Extra Scripts</span>
+           						        <input type="text" name="subtitles_extra_scripts" value="<%='|'.join(sickbeard.SUBTITLES_EXTRA_SCRIPTS)%>" class="form-control input-sm input350" />
+        						    </label>
+        						    <label class="nocheck">
+        						        <span class="component-title">&nbsp;</span>
+        						        <span class="component-desc"><b>NOTE:</b></span>
+        						    </label>
+        						    <label class="nocheck">
+        						        <span class="component-title">&nbsp;</span>
+        								<span class="component-desc">
+        									<ul>
+            										<li>See <a href="https://github.com/SiCKRAGETV/SickRage/wiki/Subtitle%20Scripts"><font color='red'><b>Wiki</b></font></a> for a script arguments description.</li>
+            										<li>Additional scripts separated by <b>|</b>.</li>
+            										<li>Scripts are called after each episode has searched and downloaded subtitles.</li>
+										            <li>For any scripted languages, include the interpreter executable before the script. See the following example:</li>
+										            <ul>
+											            <li>For Windows: <pre>C:\Python27\pythonw.exe C:\Script\test.py</pre></li>
+											            <li>For Linux: <pre>python /Script/test.py</pre></li>
+										            </ul>
+									        </ul>
+								        </span>
+						            </label>
+						        </div>
+
 	                    <br/><input type="submit" class="btn config_submitter" value="Save Changes" /><br/>
                         </div>
                     </fieldset>

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -511,6 +511,7 @@ SUBTITLES_HISTORY = False
 EMBEDDED_SUBTITLES_ALL = False
 SUBTITLES_FINDER_FREQUENCY = 1
 SUBTITLES_MULTI = False
+SUBTITLES_EXTRA_SCRIPTS = []
 
 USE_FAILED_DOWNLOADS = False
 DELETE_FAILED = False
@@ -583,7 +584,7 @@ def initialize(consoleLogging=True):
             GUI_NAME, HOME_LAYOUT, HISTORY_LAYOUT, DISPLAY_SHOW_SPECIALS, COMING_EPS_LAYOUT, COMING_EPS_SORT, COMING_EPS_DISPLAY_PAUSED, COMING_EPS_MISSED_RANGE, DISPLAY_FILESIZE, FUZZY_DATING, TRIM_ZERO, DATE_PRESET, TIME_PRESET, TIME_PRESET_W_SECONDS, THEME_NAME, FILTER_ROW, \
             POSTER_SORTBY, POSTER_SORTDIR, \
             METADATA_WDTV, METADATA_TIVO, METADATA_MEDE8ER, IGNORE_WORDS, REQUIRE_WORDS, CALENDAR_UNPROTECTED, NO_RESTART, CREATE_MISSING_SHOW_DIRS, \
-            ADD_SHOWS_WO_DIR, USE_SUBTITLES, SUBTITLES_LANGUAGES, SUBTITLES_DIR, SUBTITLES_SERVICES_LIST, SUBTITLES_SERVICES_ENABLED, SUBTITLES_HISTORY, SUBTITLES_FINDER_FREQUENCY, SUBTITLES_MULTI, EMBEDDED_SUBTITLES_ALL, subtitlesFinderScheduler, \
+            ADD_SHOWS_WO_DIR, USE_SUBTITLES, SUBTITLES_LANGUAGES, SUBTITLES_DIR, SUBTITLES_SERVICES_LIST, SUBTITLES_SERVICES_ENABLED, SUBTITLES_HISTORY, SUBTITLES_FINDER_FREQUENCY, SUBTITLES_MULTI, EMBEDDED_SUBTITLES_ALL, SUBTITLES_EXTRA_SCRIPTS, subtitlesFinderScheduler, \
             USE_FAILED_DOWNLOADS, DELETE_FAILED, ANON_REDIRECT, LOCALHOST_IP, TMDB_API_KEY, DEBUG, PROXY_SETTING, PROXY_INDEXERS, \
             AUTOPOSTPROCESSER_FREQUENCY, SHOWUPDATE_HOUR, DEFAULT_AUTOPOSTPROCESSER_FREQUENCY, MIN_AUTOPOSTPROCESSER_FREQUENCY, \
             ANIME_DEFAULT, NAMING_ANIME, ANIMESUPPORT, USE_ANIDB, ANIDB_USERNAME, ANIDB_PASSWORD, ANIDB_USE_MYLIST, \
@@ -1100,6 +1101,9 @@ def initialize(consoleLogging=True):
         EMBEDDED_SUBTITLES_ALL = bool(check_setting_int(CFG, 'Subtitles', 'embedded_subtitles_all', 0))
         SUBTITLES_FINDER_FREQUENCY = check_setting_int(CFG, 'Subtitles', 'subtitles_finder_frequency', 1)
         SUBTITLES_MULTI = bool(check_setting_int(CFG, 'Subtitles', 'subtitles_multi', 1))
+
+        SUBTITLES_EXTRA_SCRIPTS = [x.strip() for x in check_setting_str(CFG, 'Subtitles', 'subtitles_extra_scripts', '').split('|') if
+                         x.strip()]
 
         USE_FAILED_DOWNLOADS = bool(check_setting_int(CFG, 'FailedDownloads', 'use_failed_downloads', 0))
         DELETE_FAILED = bool(check_setting_int(CFG, 'FailedDownloads', 'delete_failed', 0))
@@ -2094,6 +2098,7 @@ def save_config():
     new_config['Subtitles']['embedded_subtitles_all'] = int(EMBEDDED_SUBTITLES_ALL)
     new_config['Subtitles']['subtitles_finder_frequency'] = int(SUBTITLES_FINDER_FREQUENCY)
     new_config['Subtitles']['subtitles_multi'] = int(SUBTITLES_MULTI)
+    new_config['Subtitles']['subtitles_extra_scripts'] = '|'.join(SUBTITLES_EXTRA_SCRIPTS)
 
     new_config['FailedDownloads'] = {}
     new_config['FailedDownloads']['use_failed_downloads'] = int(USE_FAILED_DOWNLOADS)

--- a/sickbeard/logger.py
+++ b/sickbeard/logger.py
@@ -135,8 +135,6 @@ class Logger(object):
         # pass exception information if debugging enabled
 
         if level == ERROR:
-            #Replace the SSL error with a link to information about how to fix it.
-            message = re.sub(r'error \[Errno 1\] _ssl.c:\d{3}: error:\d{8}:SSL routines:SSL23_GET_SERVER_HELLO:tlsv1 alert internal error', r'See: http://git.io/vJrkM', message)
             self.logger.exception(message, *args, **kwargs)
             classes.ErrorViewer.add(classes.UIError(message))
 

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -1477,6 +1477,9 @@ class TVEpisode(object):
                     helpers.chmodAsParent(subpath)
                     helpers.fixSetGroupID(subpath)
 
+            if not sickbeard.EMBEDDED_SUBTITLES_ALL and sickbeard.SUBTITLES_EXTRA_SCRIPTS and self.location.endswith(('mkv','mp4')):
+                subtitles.run_subs_extra_scripts(self, foundSubs)
+
         except Exception as e:
             logger.log("Error occurred when downloading subtitles for: %s" % self.location)
             logger.log(traceback.format_exc(), logger.ERROR)

--- a/sickbeard/webapi.py
+++ b/sickbeard/webapi.py
@@ -1100,11 +1100,10 @@ class CMD_SubtitleSearch(ApiCall):
             return _responds(RESULT_FAILURE, msg='Unable to find subtitles')
 
         # return the correct json value
-        if previous_subtitles != epObj.subtitles:
-            status = 'New subtitles downloaded: %s' % ' '.join([
-                "<img src='" + sickbeard.WEB_ROOT + "/images/flags/" + babelfish.language.Language(
-                    x).alpha2 + ".png' alt='" + babelfish.language.Language(x).name + "'/>" for x in
-                sorted(list(set(epObj.subtitles).difference(previous_subtitles)))])
+        newSubtitles = frozenset(ep_obj.subtitles).difference(previous_subtitles)
+        if newSubtitles:
+            newLangs = [subtitles.fromietf(newSub) for newSub in newSubtitles]
+            status = 'New subtitles downloaded: %s' % ', '.join([newLang.name for newLang in newLangs])
             response = _responds(RESULT_SUCCESS, msg='New subtitles found')
         else:
             status = 'No subtitles downloaded'

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -4928,7 +4928,7 @@ class ConfigSubtitles(Config):
 
     def saveSubtitles(self, use_subtitles=None, subtitles_plugins=None, subtitles_languages=None, subtitles_dir=None,
                       service_order=None, subtitles_history=None, subtitles_finder_frequency=None,
-                      subtitles_multi=None, embedded_subtitles_all=None):
+                      subtitles_multi=None, embedded_subtitles_all=None, subtitles_extra_scripts=None):
 
         results = []
 
@@ -4940,6 +4940,7 @@ class ConfigSubtitles(Config):
         sickbeard.SUBTITLES_HISTORY = config.checkbox_to_value(subtitles_history)
         sickbeard.EMBEDDED_SUBTITLES_ALL = config.checkbox_to_value(embedded_subtitles_all)
         sickbeard.SUBTITLES_MULTI = config.checkbox_to_value(subtitles_multi)
+        sickbeard.SUBTITLES_EXTRA_SCRIPTS = [x.strip() for x in subtitles_extra_scripts.split('|') if x.strip()]
 
         # Subtitles services
         services_str_list = service_order.split()


### PR DESCRIPTION
SiCKRAGETV/sickrage-issues#1075

Argument 1 is the absolute path to the video file
Argument 2 is the absolute path to the new subtitle downloaded
Argument 3 OpenSubtitles 3 letter language code (Or should it be the full name of the language?)
Argument 4 Series name
Argument 5 Season
Argument 6 Episode
Argument 7 Episode title

Currently:
Gets called once for each subtitle downloaded for each video, so if a video downloads 10 subtitles, it is ran 10 times for that video. (I don't like this, I'd rather pass all of the subtitles at once, but we can decide that maybe after it gets some use)

Only gets called if embeded subtitles are allowed/not disabled (to prevent a race condition if your script deletes the srt after embedding it and SR keeps trying to re-download the subs)
Only gets called for mkv and mp4 (No other formats to embed subs in right?)