### PR TITLE
Remove zoink.ch

### DIFF
--- a/sickbeard/providers/generic.py
+++ b/sickbeard/providers/generic.py
@@ -75,7 +75,6 @@ class GenericProvider:
 
         self.btCacheURLS = [
                 'http://torcache.net/torrent/{torrent_hash}.torrent',
-                'http://zoink.ch/torrent/{torrent_name}.torrent',
                 'http://torrage.com/torrent/{torrent_hash}.torrent',
                 #'http://itorrents.org/torrent/{torrent_hash}.torrent',
             ]


### PR DESCRIPTION
removed zoink.ch as it appears to be hijacked by the ones running eztv ,as it is redirecting to their website