### PR TITLE
178.73.198.210 torrent caching website

### DIFF
--- a/sickbeard/providers/generic.py
+++ b/sickbeard/providers/generic.py
@@ -76,6 +76,7 @@ class GenericProvider:
         self.btCacheURLS = [
                 'http://torcache.net/torrent/{torrent_hash}.torrent',
                 'http://torrage.com/torrent/{torrent_hash}.torrent',
+                'http://178.73.198.210/torrent/{torrent_hash}.torrent',
                 #'http://itorrents.org/torrent/{torrent_hash}.torrent',
             ]
 


### PR DESCRIPTION
a torrent caching website running the torrage os project afaik, to fill the void of zoink.ch