### PR TITLE
Migrate travis to a container-based infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ python:
   - 2.6
   - 2.7
 
+sudo: false
+
 branches:
   except:
     - master


### PR DESCRIPTION
As per the documentation http://docs.travis-ci.com/user/migrating-from-legacy/

This should make the build start faster on Tavis (event if they are not taking a lot of time right now :wink:).