### PR TITLE
Fix default argument when not provided.

### DIFF
--- a/sickbeard/webapi.py
+++ b/sickbeard/webapi.py
@@ -2161,7 +2161,7 @@ class CMD_ShowAddNew(ApiCall):
         self.flatten_folders, args = self.check_params(args, kwargs, "flatten_folders",
                                                        str(sickbeard.FLATTEN_FOLDERS_DEFAULT), False,
                                                        "bool", [])
-        self.status, args = self.check_params(args, kwargs, "status", sickbeard.STATUS_DEFAULT, False, "string",
+        self.status, args = self.check_params(args, kwargs, "status", None, False, "string",
                                               ["wanted", "skipped", "archived", "ignored"])
         self.lang, args = self.check_params(args, kwargs, "lang", sickbeard.INDEXER_DEFAULT_LANGUAGE, False, "string",
                                             self.valid_languages.keys())
@@ -2174,7 +2174,7 @@ class CMD_ShowAddNew(ApiCall):
         self.scene, args = self.check_params(args, kwargs, "scene", int(sickbeard.SCENE_DEFAULT), False,
                                              "int",
             [])
-        self.future_status, args = self.check_params(args, kwargs, "future_status", sickbeard.STATUS_DEFAULT_AFTER, False, "string",
+        self.future_status, args = self.check_params(args, kwargs, "future_status", None, False, "string",
                                               ["wanted", "skipped", "archived", "ignored"])
 
         # super, missing, help


### PR DESCRIPTION
@MGaetan89
@miigotu

This fixes the error issue when no URI parameters are provided for "status" or "future_status".  Basically reverting to the original code for checking URI provided arguments, which I believe is/was correct based on how the webapi.py was written.  The actual default values are set later in the code if not provided by the URI parameters.  It's the same format used throughout the webapi. 

The default value "None" represents no URI provided argument, for doing the comparison to the string list of possible input.  The system integer default values "STATUS_DEFAULT" and "STATUS_DEFAULT_AFTER" are used later in the function if no argument was supplied.

Thanks.