### PR TITLE
Fix bug preventing torrents with 0 leechers from being downloaded

### DIFF
--- a/sickbeard/providers/hdtorrents.py
+++ b/sickbeard/providers/hdtorrents.py
@@ -232,7 +232,7 @@ class HDTorrentsProvider(generic.TorrentProvider):
                 except (AttributeError, TypeError, KeyError, ValueError):
                     continue
 
-                if not title or not url or not seeders or not leechers or not size or \
+                if not title or not url or seeders == None or leechers == None or not size or \
                         seeders < self.minseed or leechers < self.minleech:
                     continue
 


### PR DESCRIPTION
Torrents that had 0 seeders or leechers would fail due to the falsey check that if not seeders is doing, preventing valid torrents from being passed through for quality checks. Changed it to explicitly look for the default value of None.

To reproduce this bug, use the HD-Torrents provider and attempt to download a TV show that is available but has 0 leechers. Review the debug logs and you will not find any "[HDTorrents] :: Found result" logs, indicating that all available torrents failed the initial checks before the quality check.