### PR TITLE
Use issues even if they are closed for issue submitter

### DIFF
--- a/sickbeard/logger.py
+++ b/sickbeard/logger.py
@@ -232,7 +232,7 @@ class Logger(object):
                 message += u"_STAFF NOTIFIED_: @SiCKRAGETV/owners @SiCKRAGETV/moderators"
 
                 title_Error = u"[APP SUBMITTED]: " + title_Error
-                reports = gh.get_organization(gh_org).get_repo(gh_repo).get_issues()
+                reports = gh.get_organization(gh_org).get_repo(gh_repo).get_issues(state="all")
 
                 issue_found = False
                 issue_id = 0


### PR DESCRIPTION
This PR will make issues submitted from inside SR always use an existing issue whether it is opened or closed, instead of creating a new issue. It will only create a new issue if one does not exit with the same title.