### PR TITLE
fix xthor crash (ratio)

### DIFF
--- a/sickbeard/providers/xthor.py
+++ b/sickbeard/providers/xthor.py
@@ -57,6 +57,7 @@ class XthorProvider(generic.TorrentProvider):
         self.enabled = False
         self.username = None
         self.password = None
+        self.ratio = None
         
     def isEnabled(self):
         return self.enabled


### PR DESCRIPTION
AA. Error: XthorProvider instance has no attribute 'ratio'
AARelease Group: ADDiCTiON
AASize: -1
AAName: Dominion.S02E03.FASTSUB.VOSTFR.720p.HDTV.x264-ADDiCTiON
AAQuality: HDTV
AAEpisode: [<sickbeard.tv.TVEpisode object at 0x1ed1cb0>]
AAExtra Info:
2015-07-27 10:48:20 DEBUG    SEARCHQUEUE-DAILY-SEARCH :: Transmission: Exception raised when sending torrent: Xthor @ https://xthor.bz/download.php?torrent=14372
AAAttributeError: XthorProvider instance has no attribute 'ratio'
AA    return self.ratio
AA  File "/opt/sickrage/sickbeard/providers/xthor.py", line 208, in seedRatio
AA    result.ratio = result.provider.seedRatio()
AA  File "/opt/sickrage/sickbeard/clients/generic.py", line 183, in sendTORRENT
AATraceback (most recent call last):
2015-07-27 10:48:20 ERROR    SEARCHQUEUE-DAILY-SEARCH :: Transmission: Failed Sending Torrent