### PR TITLE
Show skipped files in log INFO, not DEBUG

### DIFF
--- a/sickbeard/nzbSplitter.py
+++ b/sickbeard/nzbSplitter.py
@@ -159,7 +159,7 @@ def splitResult(result):
         for epNo in parse_result.episode_numbers:
             if not result.extraInfo[0].wantEpisode(season, epNo, result.quality):
                 logger.log(u"Ignoring result " + newNZB + " because we don't want an episode that is " +
-                           Quality.qualityStrings[result.quality], logger.DEBUG)
+                           Quality.qualityStrings[result.quality], logger.INFO)
                 wantEp = False
                 break
         if not wantEp:

--- a/sickbeard/providers/btn.py
+++ b/sickbeard/providers/btn.py
@@ -454,7 +454,7 @@ class BTNProvider(generic.TorrentProvider):
                 logger.log(
                     u"Ignoring result " + title + " because we don't want an episode that is " +
                     Quality.qualityStrings[
-                        quality], logger.DEBUG)
+                        quality], logger.INFO)
 
                 continue
 

--- a/sickbeard/providers/generic.py
+++ b/sickbeard/providers/generic.py
@@ -488,7 +488,7 @@ class GenericProvider:
                 logger.log(
                     u"Ignoring result " + title + " because we don't want an episode that is " +
                     Quality.qualityStrings[
-                        quality], logger.DEBUG)
+                        quality], logger.INFO)
 
                 continue
 

--- a/sickbeard/providers/iptorrents.py
+++ b/sickbeard/providers/iptorrents.py
@@ -287,7 +287,7 @@ class IPTorrentsProvider(generic.TorrentProvider):
                 logger.log(
                     u"Ignoring result " + title + " because we don't want an episode that is " +
                     Quality.qualityStrings[
-                        quality], logger.DEBUG)
+                        quality], logger.INFO)
 
                 continue
 

--- a/sickbeard/tvcache.py
+++ b/sickbeard/tvcache.py
@@ -364,7 +364,7 @@ class TVCache():
             # if the show says we want that episode then add it to the list
             if not showObj.wantEpisode(curSeason, curEp, curQuality, manualSearch, downCurQuality):
                 logger.log(u"Skipping " + curResult["name"] + " because we don't want an episode that's " +
-                           Quality.qualityStrings[curQuality], logger.DEBUG)
+                           Quality.qualityStrings[curQuality], logger.INFO)
                 continue
 
             epObj = showObj.getEpisode(curSeason, curEp)


### PR DESCRIPTION
User's can easily check why files was skipped without need to see DEBUG logs. 