### PR TITLE
Only email committer if build fails in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,7 @@ after_failure:
 
 notifications:
   irc: "irc.freenode.net#sickrage-updates"
+
+  email:
+    on_success: change
+    on_failure: change


### PR DESCRIPTION
This will only send an email on the first build that fails, and then the first build that is fixed, not every single push anymore.