### PR TITLE
Add variable in init.fedora to allow changing the Python path

### DIFF
--- a/runscripts/init.fedora
+++ b/runscripts/init.fedora
@@ -28,6 +28,7 @@ homedir=${SR_HOME-/opt/sickrage}
 datadir=${SR_DATA-/opt/sickrage}
 pidfile=${SR_PIDFILE-/var/run/sickrage/sickrage.pid}
 nice=${SR_NICE-}
+python_bin=${PYTHON_BIN-/usr/bin/python}
 ##
 
 pidpath=`dirname ${pidfile}`
@@ -47,7 +48,7 @@ fi
 start() {
         # Start daemon.
         echo -n $"Starting $prog: "
-        daemon --user=${username} --pidfile=${pidfile} ${nice} python ${homedir}/SickBeard.py ${options}
+        daemon --user=${username} --pidfile=${pidfile} ${nice} ${python_bin} ${homedir}/SickBeard.py ${options}
         RETVAL=$?
         echo
         [ $RETVAL -eq 0 ] && touch $lockfile
@@ -56,7 +57,7 @@ start() {
 
 stop() {
         echo -n $"Shutting down $prog: "
-        killproc -p ${pidfile} python
+        killproc -p ${pidfile} ${python_bin}
         RETVAL=$?
         echo
         [ $RETVAL -eq 0 ] && rm -f $lockfile


### PR DESCRIPTION
After a recent update, Python 2.6 is no longer supported. Some older OSes don't come packaged with 2.7 and you have to compile it yourself. Overriding the default Python versions on theses OSes also causes issues so is not advisable.

The current init script for Fedora (Redhat, centos, etc) doesn't allow you to set the Python path to use and just uses the system's default. I've added a variable in this init script to allow you to set PYTHON_BIN in your init config file.