### PR TITLE
Paused Shows are Showing in webapi Backlog Query

### DIFF
--- a/sickbeard/webapi.py
+++ b/sickbeard/webapi.py
@@ -1302,7 +1302,7 @@ class CMD_Backlog(ApiCall):
             showEps = []
 
             sqlResults = myDB.select(
-                "SELECT * FROM tv_episodes WHERE showid = ? ORDER BY season DESC, episode DESC",
+                "SELECT tv_episodes.*, tv_shows.paused FROM tv_episodes INNER JOIN tv_shows ON tv_episodes.showid = tv_shows.indexer_id WHERE showid = ? and paused = 0 ORDER BY season DESC, episode DESC",
                 [curShow.indexerid])
 
             for curResult in sqlResults:


### PR DESCRIPTION
Updating the SQL query to include paused value from tv_shows table, allows for filtering of non-paused shows only.  
Currently paused shows are being included in webapi backlog query.  
Please see me full explanation in my comment dated today in issue #2267.  
https://github.com/SiCKRAGETV/sickrage-issues/issues/2267