### PR TITLE
Adding a new step to make sure that develop is up to date.

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -102,6 +102,15 @@ Please follow this process; it's the best way to get your work included in the p
    # merge upstream changes
    git merge upstream/master
    ```
+   
+- Make sure that your develop branch is up to date:
+
+   ```bash
+   # Switch to the develop branch
+   git checkout develop
+   # Pull down any updates
+   git pull
+   ```
 
 - Create a new topic branch to contain your feature, change, or fix:
 


### PR DESCRIPTION
My develop was stale (pre-mako) and I followed the steps listed, after a few minutes of development I realised that my feature branch (based off develop) still have tmpl files, and no mako files.  This step might be obvious for non-noobs, but I figure it makes sense to be explicit.