### PR TITLE
Fixed invalid syntax error when starting sickrage

### DIFF
--- a/lib/guessit/textutils.py
+++ b/lib/guessit/textutils.py
@@ -247,8 +247,8 @@ def find_first_level_groups(string, enclosing, blank_sep=None):
     return split_on_groups(string, groups)
 
 
-_camel_word2_set = {'is', 'to'}
-_camel_word3_set = {'the'}
+_camel_word2_set = ['is', 'to']
+_camel_word3_set = ['the']
 
 
 def _camel_split_and_lower(string, i):


### PR DESCRIPTION
_camel_word2_set is a dictionary but uses incorrect syntax, comma to
seperate elements instead of ':'. Changed the dict to a list. because I dont think a dict is needed here.