### PR TITLE
Dont allow forcing daily/backlog search on startup

### DIFF
--- a/gui/slick/interfaces/default/config_search.mako
+++ b/gui/slick/interfaces/default/config_search.mako
@@ -132,26 +132,6 @@
                             </label>
                         </div>
 
-                        <div class="field-pair">
-                            <label for="dailysearch_startup">
-                                <span class="component-title">Daily search on startup</span>
-                                <span class="component-desc">
-                                    <input type="checkbox" name="dailysearch_startup" id="dailysearch_startup" ${('', 'checked="checked"')[bool(sickbeard.DAILYSEARCH_STARTUP)]}/>
-                                    <p>start daily search on startup of SickRage</p>
-                                </span>
-                            </label>
-                        </div>
-
-                        <div class="field-pair">
-                            <label for="backlog_startup">
-                                <span class="component-title">Run backlog on startup</span>
-                                <span class="component-desc">
-                                    <input type="checkbox" name="backlog_startup" id="backlog_startup" ${('', 'checked="checked"')[bool(sickbeard.BACKLOG_STARTUP)]}/>
-                                    <p>start processing backlogged episodes on startup of SickRage</p>
-                                </span>
-                            </label>
-                        </div>
-
                          <div class="field-pair">
                              <input id="use_failed_downloads" type="checkbox" class="enabler" name="use_failed_downloads" ${('', 'checked="checked"')[bool(sickbeard.USE_FAILED_DOWNLOADS)]} />
                              <label for="use_failed_downloads">

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -3949,8 +3949,8 @@ class ConfigSearch(Config):
                    nzbget_host=None, nzbget_use_https=None, backlog_frequency=None,
                    dailysearch_frequency=None, nzb_method=None, torrent_method=None, usenet_retention=None,
                    download_propers=None, check_propers_interval=None, allow_high_priority=None, sab_forced=None,
-                   randomize_providers=None, backlog_startup=None, use_failed_downloads=None, delete_failed=None,
-                   dailysearch_startup=None, torrent_dir=None, torrent_username=None, torrent_password=None, torrent_host=None,
+                   randomize_providers=None, use_failed_downloads=None, delete_failed=None,
+                   torrent_dir=None, torrent_username=None, torrent_password=None, torrent_host=None,
                    torrent_label=None, torrent_label_anime=None, torrent_path=None, torrent_verify_cert=None,
                    torrent_seed_time=None, torrent_paused=None, torrent_high_bandwidth=None,
                    torrent_rpcurl=None, torrent_auth_type = None, ignore_words=None, require_words=None):
@@ -3985,8 +3985,6 @@ class ConfigSearch(Config):
 
         sickbeard.ALLOW_HIGH_PRIORITY = config.checkbox_to_value(allow_high_priority)
 
-        sickbeard.DAILYSEARCH_STARTUP = config.checkbox_to_value(dailysearch_startup)
-        sickbeard.BACKLOG_STARTUP = config.checkbox_to_value(backlog_startup)
         sickbeard.USE_FAILED_DOWNLOADS = config.checkbox_to_value(use_failed_downloads)
         sickbeard.DELETE_FAILED = config.checkbox_to_value(delete_failed)
 


### PR DESCRIPTION
forcing searches on startup is no good, and defeats the purpose of a timer between searches. We must set the interval in relation to last daily/backlog time set in the database instead.