### PR TITLE
status command should not always return 0 

### DIFF
--- a/runscripts/init.debian
+++ b/runscripts/init.debian
@@ -148,7 +148,7 @@ case "$1" in
         ;;
     status)
         status_of_proc -p "$PID_FILE" "$DAEMON" "$DESC"
-        exit 0
+        exit $?
         ;;
     *)
         N=/etc/init.d/$NAME


### PR DESCRIPTION
The status command of the init.d script should reflect the actual status based on LSB exit status code.
The function "status_of_proc" garantees that.

Modification tested on raspbian.
