### PR TITLE
Exit function properly on exception

### DIFF
--- a/lib/hachoir_metadata/metadata.py
+++ b/lib/hachoir_metadata/metadata.py
@@ -284,6 +284,7 @@ def extractMetadata(parser, quality=QUALITY_NORMAL):
         metadata.extract(parser)
     except HACHOIR_ERRORS, err:
         error("Error during metadata extraction: %s" % unicode(err))
+        return None
     except Exception:
         return None
     if metadata:

--- a/lib/hachoir_metadata/metadata.py
+++ b/lib/hachoir_metadata/metadata.py
@@ -284,6 +284,8 @@ def extractMetadata(parser, quality=QUALITY_NORMAL):
         metadata.extract(parser)
     except HACHOIR_ERRORS, err:
         error("Error during metadata extraction: %s" % unicode(err))
+    except Exception:
+        return None
     if metadata:
         metadata.mime_type = parser.mime_type
         metadata.endian = endian_name[parser.endian]


### PR DESCRIPTION
When "metadata.extract(parser)" raises an exception, the function exits without returning "None", which misleads the calling function that it exited with usably data, and it then interprets the result incorrectly.

The end result is that image_cache.py > fill_cache(self, show_obj) exits early on an exception when attempting to retrieve images for the cache from a meta data provider, instead of continuing to the second step of attempting to retrieve images for the cache from the indexer online.  

Without this fix the log gets the generic error message "bad descriptor" for an unknown error from "metadata.extract(parser)", and the secondary cache image retrieval attempt from the indexer is never made.