### PR TITLE
If file does not exist, don't allow SB quality names. If it DOES exis…

### DIFF
--- a/sickbeard/common.py
+++ b/sickbeard/common.py
@@ -182,17 +182,9 @@ class Quality:
         if quality != Quality.UNKNOWN:
             return quality
 
-        name = os.path.basename(name)
-
-        # if we have our exact text then assume we put it there
-        for x in sorted(Quality.qualityStrings.keys(), reverse=True):
-            if x == Quality.UNKNOWN or x == Quality.NONE:
-                continue
-
-            regex = '\W' + Quality.qualityStrings[x].replace(' ', '\W') + '\W'
-            regex_match = re.search(regex, name, re.I)
-            if regex_match:
-                return x
+        quality = Quality.assumeQuality(name)
+        if quality != Quality.UNKNOWN:
+            return quality
 
         return Quality.UNKNOWN
 
@@ -275,6 +267,7 @@ class Quality:
         from hachoir_parser import createParser
         from hachoir_metadata import extractMetadata
 
+        parser = None
         try:
             parser = createParser(filename)
         except Exception:
@@ -286,6 +279,7 @@ class Quality:
         if not parser:
             return Quality.UNKNOWN
 
+        metadata = None
         try:
             metadata = extractMetadata(parser)
         except Exception:

--- a/tests/common_tests.py
+++ b/tests/common_tests.py
@@ -87,17 +87,17 @@ class QualityTests(unittest.TestCase):
     def test_UNKNOWN(self):
         self.assertEqual(common.Quality.UNKNOWN, common.Quality.nameQuality("Test.Show.S01E02-SiCKBEARD"))
 
-    def test_reverse_parsing(self):
-        self.assertEqual(common.Quality.SDTV, common.Quality.nameQuality("Test Show - S01E02 - SDTV - GROUP"))
-        self.assertEqual(common.Quality.SDDVD, common.Quality.nameQuality("Test Show - S01E02 - SD DVD - GROUP"))
-        self.assertEqual(common.Quality.HDTV, common.Quality.nameQuality("Test Show - S01E02 - HDTV - GROUP"))
-        self.assertEqual(common.Quality.RAWHDTV, common.Quality.nameQuality("Test Show - S01E02 - RawHD - GROUP"))
-        self.assertEqual(common.Quality.FULLHDTV, common.Quality.nameQuality("Test Show - S01E02 - 1080p HDTV - GROUP"))
-        self.assertEqual(common.Quality.HDWEBDL, common.Quality.nameQuality("Test Show - S01E02 - 720p WEB-DL - GROUP"))
-        self.assertEqual(common.Quality.FULLHDWEBDL, common.Quality.nameQuality("Test Show - S01E02 - 1080p WEB-DL - GROUP"))
-        self.assertEqual(common.Quality.HDBLURAY, common.Quality.nameQuality("Test Show - S01E02 - 720p BluRay - GROUP"))
-        self.assertEqual(common.Quality.FULLHDBLURAY, common.Quality.nameQuality("Test Show - S01E02 - 1080p BluRay - GROUP"))
-        self.assertEqual(common.Quality.UNKNOWN, common.Quality.nameQuality("Test Show - S01E02 - Unknown - SiCKBEARD"))
+#    def test_reverse_parsing(self):
+#        self.assertEqual(common.Quality.SDTV, common.Quality.nameQuality("Test Show - S01E02 - SDTV - GROUP"))
+#        self.assertEqual(common.Quality.SDDVD, common.Quality.nameQuality("Test Show - S01E02 - SD DVD - GROUP"))
+#        self.assertEqual(common.Quality.HDTV, common.Quality.nameQuality("Test Show - S01E02 - HDTV - GROUP"))
+#        self.assertEqual(common.Quality.RAWHDTV, common.Quality.nameQuality("Test Show - S01E02 - RawHD - GROUP"))
+#        self.assertEqual(common.Quality.FULLHDTV, common.Quality.nameQuality("Test Show - S01E02 - 1080p HDTV - GROUP"))
+#        self.assertEqual(common.Quality.HDWEBDL, common.Quality.nameQuality("Test Show - S01E02 - 720p WEB-DL - GROUP"))
+#        self.assertEqual(common.Quality.FULLHDWEBDL, common.Quality.nameQuality("Test Show - S01E02 - 1080p WEB-DL - GROUP"))
+#        self.assertEqual(common.Quality.HDBLURAY, common.Quality.nameQuality("Test Show - S01E02 - 720p BluRay - GROUP"))
+#        self.assertEqual(common.Quality.FULLHDBLURAY, common.Quality.nameQuality("Test Show - S01E02 - 1080p BluRay - GROUP"))
+#        self.assertEqual(common.Quality.UNKNOWN, common.Quality.nameQuality("Test Show - S01E02 - Unknown - SiCKBEARD"))
 
 if __name__ == '__main__':
     suite = unittest.TestLoader().loadTestsFromTestCase(QualityTests)


### PR DESCRIPTION
…t, use hachoir for a real quality instead of SB incomplete quality tags. Fixes SiCKRAGETV/sickrage-issues/issues/2436