### PR TITLE
Fixes progressbar sorting

### DIFF
--- a/gui/slick/interfaces/default/home.mako
+++ b/gui/slick/interfaces/default/home.mako
@@ -78,6 +78,8 @@ $.tablesorter.addParser({
         return false;
     },
     format: function(s) {
+        s = s.substring(s.length/2);
+
         match = s.match(/^(.*)/);
 
         if (match == null || match[1] == "?")

--- a/gui/slick/interfaces/default/home.mako
+++ b/gui/slick/interfaces/default/home.mako
@@ -114,7 +114,7 @@ $(document).ready(function(){
     $('.progressbar').each(function(progressbar){
         var showId = $(this).data('show-id');
         var percentage = $(this).data('progress-percentage');
-        var classToAdd = percentage > 80 ? 100 : percentage > 60 ? 80 : percentage > 40 ? 60 : percentage > 20 ? 40 : 20;
+        var classToAdd = percentage == 100 ? 100 : percentage > 80 ? 80 : percentage > 60 ? 60 : percentage > 40 ? 40 : 20;
         $(this).progressbar({ value:  percentage });
         $(this).data('progress-text') ? $(this).append('<div class="progressbarText" title="' + $(this).data('progress-tip') + '">' + $(this).data('progress-text') + '</div>') : '';
         $(this).find('.ui-progressbar-value').addClass('progress-' + classToAdd);


### PR DESCRIPTION
Since @MGaetan89 added the print view we now get back a duplicate result like `33+1 / 3733+1 / 37` instead of `33+1 / 37` so we need to split the string in half.