### PR TITLE
More specific quality pills

### DIFF
--- a/gui/slick/css/style.css
+++ b/gui/slick/css/style.css
@@ -1301,6 +1301,11 @@ td.col-status {
 	text-align: center;
 }
 
+th.col-quality,
+td.col-quality {
+	width: 110px;
+}
+
 th.col-legend,
 td.col-legend {
 	width: 80px;
@@ -1892,6 +1897,17 @@ span.quality {
 	-webkit-border-radius: 4px;
 	-moz-border-radius: 4px;
 	border-radius: 4px;
+}
+
+span.any-hd {
+	background-color: #2672b6;
+	background: repeating-linear-gradient(
+		-45deg,
+		#2672b6,
+		#2672b6 10px,
+		#5b990d 10px,
+		#5b990d 20px
+	);
 }
 
 span.Custom {

--- a/gui/slick/interfaces/default/comingEpisodes.mako
+++ b/gui/slick/interfaces/default/comingEpisodes.mako
@@ -2,7 +2,6 @@
     import sickbeard
     from sickbeard.helpers import anon_url
     from sickbeard import sbdatetime
-    from sickbeard.common import qualityPresets, qualityPresetStrings
     import datetime
     import time
     import re
@@ -10,6 +9,7 @@
 <%
     sort = sickbeard.COMING_EPS_SORT
 %>
+<%namespace file="/inc_defs.mako" import="renderQualityPill"/>
 <%include file="/inc_top.mako"/>
 <script type="text/javascript" src="${sbRoot}/js/ajaxEpSearch.js?${sbPID}"></script>
 <h1 class="header">${header}</h1>
@@ -221,11 +221,7 @@ $(document).ready(function(){
             </td>
 
             <td align="center">
-% if int(cur_result['quality']) in qualityPresets:
-                <span class="quality ${qualityPresetStrings[int(cur_result['quality'])]}">${qualityPresetStrings[int(cur_result['quality'])]}</span>
-% else:
-                <span class="quality Custom">Custom</span>
-% endif
+	        ${renderQualityPill(cur_result['quality'])}
             </td>
 
             <td align="center" style="vertical-align: middle;">
@@ -428,11 +424,7 @@ $(document).ready(function(){
 
                 <div class="clearfix">
                     <span class="title">Quality:</span>
-                    % if int(cur_result['quality']) in qualityPresets:
-                        <span class="quality ${qualityPresetStrings[int(cur_result['quality'])]}">${qualityPresetStrings[int(cur_result['quality'])]}</span>
-                    % else:
-                        <span class="quality Custom">Custom</span>
-                    % endif
+	            ${renderQualityPill(cur_result['quality'])}
                 </div>
             </td>
         </tr>

--- a/gui/slick/interfaces/default/displayShow.mako
+++ b/gui/slick/interfaces/default/displayShow.mako
@@ -7,11 +7,11 @@
     import sickbeard.helpers
 
     from sickbeard.common import SKIPPED, WANTED, UNAIRED, ARCHIVED, IGNORED, SNATCHED, SNATCHED_PROPER, SNATCHED_BEST, FAILED
-    from sickbeard.common import Quality, qualityPresets, qualityPresetStrings, statusStrings, Overview
+    from sickbeard.common import Quality, qualityPresets, statusStrings, Overview
 
     from sickbeard.helpers import anon_url
 %>
-
+<%namespace file="/inc_defs.mako" import="renderQualityPill"/>
 <%include file="/inc_top.mako"/>
 <script type="text/javascript" src="${sbRoot}/js/lib/jquery.bookmarkscroll.js?${sbPID}"></script>
 
@@ -204,13 +204,13 @@ $(document).ready(function(){
                 <% anyQualities, bestQualities = Quality.splitQuality(int(show.quality)) %>
                     <tr><td class="showLegend">Quality: </td><td>
                 % if show.quality in qualityPresets:
-                    <span class="quality ${qualityPresetStrings[show.quality]}">${qualityPresetStrings[show.quality]}</span>
+                    ${renderQualityPill(show.quality)}
                 % else:
                 % if anyQualities:
-                    <i>Initial:</i> ${", ".join([Quality.qualityStrings[x] for x in sorted(anyQualities)])}${("", "</br>")[bool(bestQualities)]}
+                    <i>Initial:</i> ${", ".join([capture(renderQualityPill, x) for x in sorted(anyQualities)])}${("", "</br>")[bool(bestQualities)]}
                 % endif
                 % if bestQualities:
-                    <i>Replace with:</i> ${", ".join([Quality.qualityStrings[x] for x in sorted(bestQualities)])}
+                    <i>Replace with:</i> ${", ".join([capture(renderQualityPill, x) for x in sorted(bestQualities)])}
                 % endif
                 % endif
 
@@ -559,7 +559,7 @@ $(document).ready(function(){
             </td>
                 <% curStatus, curQuality = Quality.splitCompositeStatus(int(epResult["status"])) %>
                 % if curQuality != Quality.NONE:
-                    <td class="col-status">${statusStrings[curStatus]} <span class="quality ${Quality.qualityStrings[curQuality].replace("720p","HD720p").replace("1080p","HD1080p").replace("HDTV", "HD720p")}">${Quality.qualityStrings[curQuality]}</span></td>
+                    <td class="col-status">${statusStrings[curStatus]} ${renderQualityPill(curQuality)}</td>
                 % else:
                     <td class="col-status">${statusStrings[curStatus]}</td>
                 % endif

--- a/gui/slick/interfaces/default/history.mako
+++ b/gui/slick/interfaces/default/history.mako
@@ -11,12 +11,13 @@
     from sickbeard.providers import generic
 
     from sickbeard.common import SKIPPED, WANTED, UNAIRED, ARCHIVED, IGNORED, SNATCHED, SNATCHED_PROPER, SNATCHED_BEST, FAILED, DOWNLOADED, SUBTITLED
-    from sickbeard.common import Quality, qualityPresets, qualityPresetStrings, statusStrings, Overview
+    from sickbeard.common import Quality, statusStrings, Overview
 %>
 <%
     layout = sickbeard.HISTORY_LAYOUT
     history_limit = sickbeard.HISTORY_LIMIT
 %>
+<%namespace file="/inc_defs.mako" import="renderQualityPill"/>
 <%include file="/inc_top.mako"/>
 
 <style type="text/css">
@@ -155,7 +156,7 @@ $(document).ready(function(){
                 % endif
                 </td>
                 <span style="display: none;">${curQuality}</span>
-                <td align="center"><span class="quality ${Quality.qualityStrings[curQuality].replace("720p","HD720p").replace("1080p","HD1080p").replace("HDTV", "HD720p")}">${Quality.qualityStrings[curQuality]}</span></td>
+                <td align="center">${renderQualityPill(curQuality)}</td>
             </tr>
         % endfor
         </tbody>
@@ -228,7 +229,7 @@ $(document).ready(function(){
                     % endfor
                 </td>
                 % endif
-                <td align="center" width="14%" quality="${curQuality}"><span class="quality ${Quality.qualityStrings[curQuality].replace("720p","HD720p").replace("1080p","HD1080p").replace("RawHD TV", "RawHD").replace("HD TV", "HD720p")}">${Quality.qualityStrings[curQuality]}</span></td>
+                <td align="center" width="14%" quality="${curQuality}">${renderQualityPill(curQuality)}</td>
             </tr>
         % endfor
         </tbody>

--- a/gui/slick/interfaces/default/home.mako
+++ b/gui/slick/interfaces/default/home.mako
@@ -7,6 +7,7 @@
     import datetime
     import re
 %>
+<%namespace file="/inc_defs.mako" import="renderQualityPill"/>
 <%include file="/inc_top.mako"/>
 <%
     myDB = db.DBConnection()
@@ -578,11 +579,7 @@ $(document).ready(function(){
                 </td>
 
                 <td class="show-table">
-                    % if curShow.quality in qualityPresets:
-                        <span class="show-quality">${qualityPresetStrings[curShow.quality]}</span>
-                    % else:
-                        <span class="show-quality">Custom</span>
-                    % endif
+		    ${renderQualityPill(curShow.quality, overrideClass="show-quality")}
                 </td>
             </tr>
         </table>
@@ -770,11 +767,7 @@ $(document).ready(function(){
         </td>
     % endif
 
-    % if curShow.quality in qualityPresets:
-        <td align="center"><span class="quality ${qualityPresetStrings[curShow.quality]}">${qualityPresetStrings[curShow.quality]}</span></td>
-    % else:
-        <td align="center"><span class="quality Custom">Custom</span></td>
-    % endif
+        <td align="center">${renderQualityPill(curShow.quality)}</td>
 
         <td align="center">
             ## This first span is used for sorting and is never displayed to user

--- a/gui/slick/interfaces/default/inc_defs.mako
+++ b/gui/slick/interfaces/default/inc_defs.mako
@@ -1,0 +1,23 @@
+<%!
+    from sickbeard.common import Quality, qualityPresets, qualityPresetStrings
+%>
+<%def name="renderQualityPill(quality, overrideClass=None)"><%
+    if quality in qualityPresets:
+        cssClass = qualityPresetStrings[quality]
+        qualityString = qualityPresetStrings[quality]
+    elif quality in Quality.combinedQualityStrings:
+        cssClass = Quality.cssClassStrings[quality]
+        qualityString = Quality.combinedQualityStrings[quality]
+    elif quality in Quality.qualityStrings:
+        cssClass = Quality.cssClassStrings[quality]
+        qualityString = Quality.qualityStrings[quality]
+    else:
+        cssClass = "Custom"
+        qualityString = "Custom"
+
+    if overrideClass == None:
+        cssClass = "quality " + cssClass
+    else:
+        cssClass = overrideClass
+
+%><span class="${cssClass}">${qualityString}</span></%def>

--- a/gui/slick/interfaces/default/manage.mako
+++ b/gui/slick/interfaces/default/manage.mako
@@ -1,8 +1,9 @@
 <%!
     import sickbeard
     from sickbeard.common import SKIPPED, WANTED, UNAIRED, ARCHIVED, IGNORED, SNATCHED, SNATCHED_PROPER, SNATCHED_BEST, FAILED
-    from sickbeard.common import Quality, qualityPresets, qualityPresetStrings, statusStrings
+    from sickbeard.common import statusStrings
 %>
+<%namespace file="/inc_defs.mako" import="renderQualityPill"/>
 <%include file="/inc_top.mako"/>
 <script type="text/javascript" src="${sbRoot}/js/lib/bootbox.min.js?${sbPID}"></script>
 <script type="text/javascript" charset="utf-8">
@@ -81,7 +82,7 @@ $(document).ready(function()
         <tr>
             <th class="col-checkbox">Edit<br/><input type="checkbox" class="bulkCheck" id="editCheck" /></th>
             <th class="nowrap" style="text-align: left;">Show Name</th>
-            <th class="col-legend">Quality</th>
+            <th class="col-quality">Quality</th>
             <th class="col-legend">Sports</th>
             <th class="col-legend">Scene</th>
             <th class="col-legend">Anime</th>
@@ -160,11 +161,7 @@ $(document).ready(function()
         <tr>
             <td align="center"><input type="checkbox" class="editCheck" id="edit-${curShow.indexerid}" /></td>
             <td class="tvShow"><a href="${sbRoot}/home/displayShow?show=${curShow.indexerid}">${curShow.name}</a></td>
-        % if curShow.quality in qualityPresets:
-            <td align="center"><span class="quality ${qualityPresetStrings[curShow.quality]}">${qualityPresetStrings[curShow.quality]}</span></td>
-        % else:
-            <td align="center"><span class="quality Custom">Custom</span></td>
-        % endif
+            <td align="center">${renderQualityPill(curShow.quality)}</td>
             <td align="center"><img src="${sbRoot}/images/${('no16.png" alt="N"', 'yes16.png" alt="Y"')[int(curShow.is_sports) == 1]} width="16" height="16" /></td>
             <td align="center"><img src="${sbRoot}/images/${('no16.png" alt="N"', 'yes16.png" alt="Y"')[int(curShow.is_scene) == 1]} width="16" height="16" /></td>
             <td align="center"><img src="${sbRoot}/images/${('no16.png" alt="N"', 'yes16.png" alt="Y"')[int(curShow.is_anime) == 1]} width="16" height="16" /></td>

--- a/sickbeard/common.py
+++ b/sickbeard/common.py
@@ -118,6 +118,9 @@ class Quality:
     FULLHDWEBDL = 1 << 6  # 64 -- 1080p web-dl
     HDBLURAY = 1 << 7  # 128
     FULLHDBLURAY = 1 << 8  # 256
+    ANYHDTV = HDTV | FULLHDTV  # 20
+    ANYWEBDL = HDWEBDL | FULLHDWEBDL  # 96
+    ANYBLURAY = HDBLURAY | FULLHDBLURAY  # 384
 
     # put these bits at the other end of the spectrum, far enough out that they shouldn't interfere
     UNKNOWN = 1 << 15  # 32768
@@ -126,13 +129,32 @@ class Quality:
                       UNKNOWN: "Unknown",
                       SDTV: "SDTV",
                       SDDVD: "SD DVD",
-                      HDTV: "HDTV",
+                      HDTV: "720p HDTV",
                       RAWHDTV: "RawHD",
                       FULLHDTV: "1080p HDTV",
                       HDWEBDL: "720p WEB-DL",
                       FULLHDWEBDL: "1080p WEB-DL",
                       HDBLURAY: "720p BluRay",
                       FULLHDBLURAY: "1080p BluRay"}
+
+    combinedQualityStrings = {ANYHDTV: "HDTV",
+                              ANYWEBDL: "WEB-DL",
+                              ANYBLURAY: "BluRay"}
+
+    cssClassStrings = {NONE: "Unknown",
+                       UNKNOWN: "Unknown",
+                       SDTV: "SDTV",
+                       SDDVD: "SD",
+                       HDTV: "HD720p",
+                       RAWHDTV: "RawHD",
+                       FULLHDTV: "HD1080p",
+                       HDWEBDL: "HD720p",
+                       FULLHDWEBDL: "HD1080p",
+                       HDBLURAY: "HD720p",
+                       FULLHDBLURAY: "HD1080p",
+                       ANYHDTV: "any-hd",
+                       ANYWEBDL: "any-hd",
+                       ANYBLURAY: "any-hd"}
 
     statusPrefixes = {DOWNLOADED: "Downloaded",
                       SNATCHED: "Snatched",


### PR DESCRIPTION
I'm guessing most users aren't as particular as I am about their quality settings, but I like to select the specific quality I like/want for each show. The downside of this is that everything shows up as "Custom" everywhere, which is kind of annoying. This PR shows the specific custom quality that is selected, or if both resolutions of a type (HDTV, WEB-DL, BluRay) are selected, it will display a combined quality pill. For anything more complex, it reverts back to displaying "Custom".

I added a Mako %def to display these pills and tried to use it in all places where quality is displayed to reduce the amount of duplicated code.

It also renames "HDTV" to "720p HDTV" which I think makes more sense since we now have 1080p HDTV, but feel free to rip that out. :)

Thoughts/suggestions?