### PR TITLE
Display episodes list of collapsed season when select all is checked

### DIFF
--- a/gui/slick/js/displayShow.js
+++ b/gui/slick/js/displayShow.js
@@ -47,6 +47,7 @@ $(document).ready(function () {
         var seasCheck = this;
         var seasNo = $(seasCheck).attr('id');
 
+        $('#collapseSeason-' + seasNo).collapse('show');
         $('.epCheck:visible').each(function () {
             var epParts = $(this).attr('id').split('x');
 


### PR DESCRIPTION
Fix for SiCKRAGETV/sickrage-issues#2592

This does not collapse back the season if the checkbox is unchecked. It only expand the season if it is collapsed.