### PR TITLE
Display debug data

### DIFF
--- a/gui/slick/interfaces/default/inc_bottom.mako
+++ b/gui/slick/interfaces/default/inc_bottom.mako
@@ -3,7 +3,8 @@
     import datetime
     from sickbeard import db
     from sickbeard.common import Quality, SKIPPED, WANTED, UNAIRED, ARCHIVED, IGNORED, SNATCHED, SNATCHED_PROPER, SNATCHED_BEST
-    import re
+    from time import time
+    import re, resource
 %>
 <%
     sbRoot = sickbeard.WEB_ROOT
@@ -62,6 +63,14 @@
                 &nbsp;/&nbsp;<span class="footerhighlight">${ep_total}</span> Episodes Downloaded ${ep_percentage}
         | Daily Search: <span class="footerhighlight">${str(sickbeard.dailySearchScheduler.timeLeft()).split('.')[0]}</span>
         | Backlog Search: <span class="footerhighlight">${str(sickbeard.backlogSearchScheduler.timeLeft()).split('.')[0]}</span>
+
+        % if sickbeard.DEVELOPER:
+        <div>
+            Memory used: <span class="footerhighlight">${sickbeard.helpers.pretty_filesize(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss)}</span> |
+            Load time: <span class="footerhighlight">${"%.4f" % (time() - sbStartTime)}s</span> / Mako: <span class="footerhighlight">${"%.4f" % (time() - makoStartTime)}s</span> |
+            Branch: <span class="footerhighlight">${sickbeard.BRANCH}</span>
+        </div>
+        % endif
     </div>
         <!--
         <ul style="display: table; margin: 0 auto; font-size: 12px; list-style-type: none; padding: 0; padding-top: 10px;">


### PR DESCRIPTION
This PR adds a new line at the bottom of each page with some useful debug information. Those information are only display if the current branch is not `master`.

Currently, this line includes:
- Memory usage of the process SickRage is running in
- Overall load time of the page
- Load time for Mako

Loading times need to be improved I guess, I'm not sure it's the best way to do it.

I would also like to display the number of DB queries + time to perform them, but I'm not sure how to do that yet.

The idea behind this PR is to have data to know the impact of a specific change. If you have more ideas to include in it, feel free to suggest them.

Do no merge this PR yet, this is really a Work in progress.