### PR TITLE
Show "Add Anime" at the bottom of the anime tables

### DIFF
--- a/gui/slick/interfaces/default/home.mako
+++ b/gui/slick/interfaces/default/home.mako
@@ -612,7 +612,7 @@ $(document).ready(function(){
 
     <tfoot class="hidden-print">
         <tr>
-            <th rowspan="1" colspan="1" align="center"><a href="${sbRoot}/home/addShows/">Add Show</a></th>
+            <th rowspan="1" colspan="1" align="center"><a href="${sbRoot}/home/addShows/">Add ${('Show', 'Anime')[curListType == 'Anime']}</a></th>
             <th>&nbsp;</th>
             <th>&nbsp;</th>
             <th>&nbsp;</th>


### PR DESCRIPTION
The last line of the shows table include a "Add Show" link. If anime are separated from the other shows, the label is still "Add Show", instead of "Add Anime". This simply changes that :)