### PR TITLE
Remove failed status if feature not enabled

### DIFF
--- a/gui/slick/interfaces/default/displayShow.mako
+++ b/gui/slick/interfaces/default/displayShow.mako
@@ -279,7 +279,11 @@ $(document).ready(function(){
     <div class="pull-left" >
         Change selected episodes to:</br>
         <select id="statusSelect" class="form-control form-control-inline input-sm">
-        % for curStatus in [WANTED, SKIPPED, ARCHIVED, IGNORED, FAILED] + sorted(Quality.DOWNLOADED):
+        <% availableStatus = [WANTED, SKIPPED, ARCHIVED, IGNORED, FAILED] %>
+        % if not sickbeard.USE_FAILED_DOWNLOADS:
+        <% availableStatus.remove(FAILED) %>
+        % endif      
+        % for curStatus in availableStatus + sorted(Quality.DOWNLOADED):
             % if curStatus != DOWNLOADED:
             <option value="${curStatus}">${statusStrings[curStatus]}</option>
             % endif

--- a/gui/slick/interfaces/default/displayShow.mako
+++ b/gui/slick/interfaces/default/displayShow.mako
@@ -279,7 +279,7 @@ $(document).ready(function(){
     <div class="pull-left" >
         Change selected episodes to:</br>
         <select id="statusSelect" class="form-control form-control-inline input-sm">
-        <% availableStatus = [WANTED, SKIPPED, ARCHIVED, IGNORED, FAILED] %>
+        <% availableStatus = [WANTED, SKIPPED, IGNORED, FAILED] %>
         % if not sickbeard.USE_FAILED_DOWNLOADS:
         <% availableStatus.remove(FAILED) %>
         % endif      


### PR DESCRIPTION
we should remove the FAILED status from API in "Episodes.SetStatus' but this function it's nor working! I can't select the second listbox. it's empty

![image](https://cloud.githubusercontent.com/assets/2620870/9647937/00c07096-51b9-11e5-908a-55f00ba98ceb.png)

@MGaetan89  can you confirm please?