### PR TITLE
Move logic to load images (fanart/banner/poster/network logo) into reusable classes

### DIFF
--- a/sickrage/media/GenericMedia.py
+++ b/sickrage/media/GenericMedia.py
@@ -1,0 +1,86 @@
+import sickbeard
+
+from abc import abstractmethod
+from os.path import isfile, join, normpath
+from sickbeard.encodingKludge import ek
+from sickbeard.exceptions import MultipleShowObjectsException
+from sickbeard.helpers import findCertainShow
+
+
+class GenericMedia:
+    def __init__(self, indexer_id, media_format):
+        """
+        :param indexer_id: The indexer id of the show
+        :param media_format: The format of the media to get. Must be either 'normal' or 'thumb'
+        """
+
+        if media_format in ('normal', 'thumb'):
+            self.media_format = media_format
+        else:
+            self.media_format = 'normal'
+
+        try:
+            self.indexer_id = int(indexer_id)
+        except ValueError:
+            self.indexer_id = 0
+
+    @abstractmethod
+    def get_default_media_name(self):
+        """
+        :return: The name of the file to use as a fallback if the show media file is missing
+        """
+
+        return ''
+
+    def get_media(self):
+        """
+        :return: The content of the desired media file
+        """
+
+        static_media_path = self.get_static_media_path()
+
+        if ek(isfile, static_media_path):
+            with open(static_media_path, 'r') as content:
+                return content.read()
+
+        return None
+
+    @abstractmethod
+    def get_media_path(self):
+        """
+        :return: The path to the media related to self.indexer_id
+        """
+
+        return ''
+
+    def get_media_root(self):
+        """
+        :return: The root folder containing the media
+        """
+
+        return sickbeard.WEB_ROOT
+
+    def get_show(self):
+        """
+        :return: The show object associated with self.indexer_if or None
+        """
+
+        try:
+            return findCertainShow(sickbeard.showList, self.indexer_id)
+        except MultipleShowObjectsException:
+            return None
+
+    def get_static_media_path(self):
+        """
+        :return: The full path to the media
+        """
+
+        if self.get_show():
+            media_path = self.get_media_path()
+
+            if ek(isfile, media_path):
+                return normpath(media_path)
+
+        image_path = join('/images', self.get_default_media_name())
+
+        return self.get_media_root() + image_path.replace('\\', '/')

--- a/sickrage/media/ShowBanner.py
+++ b/sickrage/media/ShowBanner.py
@@ -1,0 +1,20 @@
+from sickbeard.image_cache import ImageCache
+from sickrage.media.GenericMedia import GenericMedia
+
+
+class ShowBanner(GenericMedia):
+    def __init__(self, indexer_id, media_format):
+        GenericMedia.__init__(self, indexer_id, media_format)
+
+    def get_default_media_name(self):
+        return 'banner.png'
+
+    def get_media_path(self):
+        if self.get_show():
+            if self.media_format is 'normal':
+                return ImageCache().banner_path(self.indexer_id)
+
+            if self.media_format is 'thumb':
+                return ImageCache().banner_thumb_path(self.indexer_id)
+
+        return ''

--- a/sickrage/media/ShowFanart.py
+++ b/sickrage/media/ShowFanart.py
@@ -1,0 +1,16 @@
+from sickbeard.image_cache import ImageCache
+from sickrage.media.GenericMedia import GenericMedia
+
+
+class ShowFanArt(GenericMedia):
+    def __init__(self, indexer_id, media_format):
+        GenericMedia.__init__(self, indexer_id, media_format)
+
+    def get_default_media_name(self):
+        return 'fanart.png'
+
+    def get_media_path(self):
+        if self.get_show():
+            return ImageCache().fanart_path(self.indexer_id)
+
+        return ''

--- a/sickrage/media/ShowNetworkLogo.py
+++ b/sickrage/media/ShowNetworkLogo.py
@@ -1,0 +1,22 @@
+import sickbeard
+
+from sickrage.media.GenericMedia import GenericMedia
+
+
+class ShowNetworkLogo(GenericMedia):
+    def __init__(self, indexer_id, media_format):
+        GenericMedia.__init__(self, indexer_id, media_format)
+
+    def get_default_media_name(self):
+        return 'network/nonetwork.png'
+
+    def get_media_path(self):
+        show = self.get_show()
+
+        if show:
+            return '%s/images/network/%s.png' % (self.get_media_root(), show.network_logo_name)
+
+        return ''
+
+    def get_media_root(self):
+        return sickbeard.DATA_DIR + '/gui/slick'

--- a/sickrage/media/ShowPoster.py
+++ b/sickrage/media/ShowPoster.py
@@ -1,0 +1,20 @@
+from sickbeard.image_cache import ImageCache
+from sickrage.media.GenericMedia import GenericMedia
+
+
+class ShowPoster(GenericMedia):
+    def __init__(self, indexer_id, media_format):
+        GenericMedia.__init__(self, indexer_id, media_format)
+
+    def get_default_media_name(self):
+        return 'poster.png'
+
+    def get_media_path(self):
+        if self.get_show():
+            if self.media_format is 'normal':
+                return ImageCache().poster_path(self.indexer_id)
+
+            if self.media_format is 'thumb':
+                return ImageCache().poster_thumb_path(self.indexer_id)
+
+        return ''

--- a/sickrage/media/__init__.py
+++ b/sickrage/media/__init__.py
@@ -1,0 +1,1 @@
+__all__ = ['ShowBanner', 'ShowFanArt', 'ShowNetworkLogo', 'ShowPoster']


### PR DESCRIPTION
Working on https://github.com/SiCKRAGETV/sickrage-issues/issues/2567

This PR creates reusable classes to load a show fan art, banner, poster and network logo.
I still need to implement the part about network logo, so don't merge it yet.

The goal of this PR is also to agree on the structure. It's easier to adapt things now, rather than in two month, when everything is done.

- In my opinion, SR is mature enough to move away from the `sickbeard` folder. So I created a `sickrage` folder where I put all the new files
- I use one file per class. Coming from Java, it's an obvious choice. I don't know what is the recommended way in Python
- Instead of simply doing `import somename`, I use `from somename import somename2`. I don't know how Python handles import internally, but I guess it's better to only import what is needed?
- I never really did object oriented programming in Python, so let me know if some things are wrong or could be done differently

Let me know what you think about that and if you agree with the way I try to go with this.