### PR TITLE
Fix SiCKRAGETV/sickrage-issues#2671

### DIFF
--- a/sickbeard/webapi.py
+++ b/sickbeard/webapi.py
@@ -1586,7 +1586,7 @@ class CMD_SickBeardGetMessages(ApiCall):
 
     def run(self):
         messages = []
-        for cur_notification in ui.notifications.get_notifications(self.request.remote_ip):
+        for cur_notification in ui.notifications.get_notifications(self.rh.request.remote_ip):
             messages.append({"title": cur_notification.title,
                              "message": cur_notification.message,
                              "type": cur_notification.type})


### PR DESCRIPTION
https://github.com/SiCKRAGETV/sickrage-issues/issues/2671

In my opinion, the real issue is that [`ApiCall`](https://github.com/SiCKRAGETV/SickRage/blob/develop/sickbeard/webapi.py#L270) does not call its parent constructor.
I tried to fix that, but in some case `args` is empty and the parent constructor call fails. I guess that's why `rh` is undefined sometimes (https://github.com/SiCKRAGETV/SickRage/pull/2414#issuecomment-138077018).