### PR TITLE
Move logic to shutdown and restart SickRage into reusable classes

### DIFF
--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -59,8 +59,8 @@ from sickbeard.common import SD
 from sickbeard.common import SKIPPED
 from sickbeard.common import WANTED
 from sickbeard.databases import mainDB, cache_db, failed_db
-from sickbeard.event_queue import Events
 from sickbeard.exceptions import ex
+from sickrage.system.Shutdown import Shutdown
 
 from configobj import ConfigObj
 
@@ -1576,9 +1576,9 @@ def halt():
 
 
 def sig_handler(signum=None, frame=None):
-    if type(signum) != type(None):
+    if isinstance(signum, None):
         logger.log(u"Signal %i caught, saving and exiting..." % int(signum))
-        events.put(Events.SystemEvent.SHUTDOWN)
+        Shutdown.stop(PID)
 
 
 def saveAll():

--- a/sickbeard/webapi.py
+++ b/sickbeard/webapi.py
@@ -32,6 +32,7 @@ from sickrage.media.ShowNetworkLogo import ShowNetworkLogo
 from sickrage.media.ShowPoster import ShowPoster
 from sickrage.media.ShowBanner import ShowBanner
 from sickrage.show.History import History
+from sickrage.system.Restart import Restart
 from sickrage.system.Shutdown import Shutdown
 
 from versionChecker import CheckVersion
@@ -77,13 +78,14 @@ RESULT_FAILURE = 20  # only use inside the run methods
 RESULT_TIMEOUT = 30  # not used yet :(
 RESULT_ERROR = 40  # only use outside of the run methods !
 RESULT_FATAL = 50  # only use in Api.default() ! this is the "we encountered an internal error" error
-RESULT_DENIED = 60  # only use in Api.default() ! this is the acces denied error
-result_type_map = {RESULT_SUCCESS: "success",
-                   RESULT_FAILURE: "failure",
-                   RESULT_TIMEOUT: "timeout",
-                   RESULT_ERROR: "error",
-                   RESULT_FATAL: "fatal",
-                   RESULT_DENIED: "denied",
+RESULT_DENIED = 60  # only use in Api.default() ! this is the access denied error
+result_type_map = {
+    RESULT_SUCCESS: "success",
+    RESULT_FAILURE: "failure",
+    RESULT_TIMEOUT: "timeout",
+    RESULT_ERROR: "error",
+    RESULT_FATAL: "fatal",
+    RESULT_DENIED: "denied",
 }
 # basically everything except RESULT_SUCCESS / success is bad
 
@@ -1634,7 +1636,7 @@ class CMD_SickBeardPing(ApiCall):
 
 
 class CMD_SickBeardRestart(ApiCall):
-    _help = {"desc": "restart sickrage"}
+    _help = {"desc": "restart SickRage"}
 
     def __init__(self, args, kwargs):
         # required
@@ -1643,8 +1645,10 @@ class CMD_SickBeardRestart(ApiCall):
         ApiCall.__init__(self, args, kwargs)
 
     def run(self):
-        """ restart sickrage """
-        sickbeard.events.put(sickbeard.events.SystemEvent.RESTART)
+        """ restart SickRage """
+        if not Restart.restart(sickbeard.PID):
+            return _responds(RESULT_FAILURE, msg='SickRage can not be restarted')
+
         return _responds(RESULT_SUCCESS, msg="SickRage is restarting...")
 
 
@@ -2940,55 +2944,56 @@ class CMD_ShowsStats(ApiCall):
 # this is reserved for cmd indexes used while cmd chaining
 
 # WARNING: never define a param name that contains a "." (dot)
-# this is reserved for cmd namspaces used while cmd chaining
-_functionMaper = {"help": CMD_Help,
-                  "future": CMD_ComingEpisodes,
-                  "episode": CMD_Episode,
-                  "episode.search": CMD_EpisodeSearch,
-                  "episode.setstatus": CMD_EpisodeSetStatus,
-                  "episode.subtitlesearch": CMD_SubtitleSearch,
-                  "exceptions": CMD_Exceptions,
-                  "history": CMD_History,
-                  "history.clear": CMD_HistoryClear,
-                  "history.trim": CMD_HistoryTrim,
-                  "failed": CMD_Failed,
-                  "backlog": CMD_Backlog,
-                  "logs": CMD_Logs,
-                  "sb": CMD_SickBeard,
-                  "postprocess": CMD_PostProcess,
-                  "sb.addrootdir": CMD_SickBeardAddRootDir,
-                  "sb.checkversion": CMD_SickBeardCheckVersion,
-                  "sb.checkscheduler": CMD_SickBeardCheckScheduler,
-                  "sb.deleterootdir": CMD_SickBeardDeleteRootDir,
-                  "sb.getdefaults": CMD_SickBeardGetDefaults,
-                  "sb.getmessages": CMD_SickBeardGetMessages,
-                  "sb.getrootdirs": CMD_SickBeardGetRootDirs,
-                  "sb.pausebacklog": CMD_SickBeardPauseBacklog,
-                  "sb.ping": CMD_SickBeardPing,
-                  "sb.restart": CMD_SickBeardRestart,
-                  "sb.searchindexers": CMD_SickBeardSearchIndexers,
-                  "sb.searchtvdb": CMD_SickBeardSearchTVDB,
-                  "sb.searchtvrage": CMD_SickBeardSearchTVRAGE,
-                  "sb.setdefaults": CMD_SickBeardSetDefaults,
-                  "sb.update": CMD_SickBeardUpdate,
-                  "sb.shutdown": CMD_SickBeardShutdown,
-                  "show": CMD_Show,
-                  "show.addexisting": CMD_ShowAddExisting,
-                  "show.addnew": CMD_ShowAddNew,
-                  "show.cache": CMD_ShowCache,
-                  "show.delete": CMD_ShowDelete,
-                  "show.getquality": CMD_ShowGetQuality,
-                  "show.getposter": CMD_ShowGetPoster,
-                  "show.getbanner": CMD_ShowGetBanner,
-                  "show.getnetworklogo": CMD_ShowGetNetworkLogo,
-                  "show.getfanart": CMD_ShowGetFanArt,
-                  "show.pause": CMD_ShowPause,
-                  "show.refresh": CMD_ShowRefresh,
-                  "show.seasonlist": CMD_ShowSeasonList,
-                  "show.seasons": CMD_ShowSeasons,
-                  "show.setquality": CMD_ShowSetQuality,
-                  "show.stats": CMD_ShowStats,
-                  "show.update": CMD_ShowUpdate,
-                  "shows": CMD_Shows,
-                  "shows.stats": CMD_ShowsStats
+# this is reserved for cmd namespaces used while cmd chaining
+_functionMaper = {
+    "help": CMD_Help,
+    "future": CMD_ComingEpisodes,
+    "episode": CMD_Episode,
+    "episode.search": CMD_EpisodeSearch,
+    "episode.setstatus": CMD_EpisodeSetStatus,
+    "episode.subtitlesearch": CMD_SubtitleSearch,
+    "exceptions": CMD_Exceptions,
+    "history": CMD_History,
+    "history.clear": CMD_HistoryClear,
+    "history.trim": CMD_HistoryTrim,
+    "failed": CMD_Failed,
+    "backlog": CMD_Backlog,
+    "logs": CMD_Logs,
+    "sb": CMD_SickBeard,
+    "postprocess": CMD_PostProcess,
+    "sb.addrootdir": CMD_SickBeardAddRootDir,
+    "sb.checkversion": CMD_SickBeardCheckVersion,
+    "sb.checkscheduler": CMD_SickBeardCheckScheduler,
+    "sb.deleterootdir": CMD_SickBeardDeleteRootDir,
+    "sb.getdefaults": CMD_SickBeardGetDefaults,
+    "sb.getmessages": CMD_SickBeardGetMessages,
+    "sb.getrootdirs": CMD_SickBeardGetRootDirs,
+    "sb.pausebacklog": CMD_SickBeardPauseBacklog,
+    "sb.ping": CMD_SickBeardPing,
+    "sb.restart": CMD_SickBeardRestart,
+    "sb.searchindexers": CMD_SickBeardSearchIndexers,
+    "sb.searchtvdb": CMD_SickBeardSearchTVDB,
+    "sb.searchtvrage": CMD_SickBeardSearchTVRAGE,
+    "sb.setdefaults": CMD_SickBeardSetDefaults,
+    "sb.update": CMD_SickBeardUpdate,
+    "sb.shutdown": CMD_SickBeardShutdown,
+    "show": CMD_Show,
+    "show.addexisting": CMD_ShowAddExisting,
+    "show.addnew": CMD_ShowAddNew,
+    "show.cache": CMD_ShowCache,
+    "show.delete": CMD_ShowDelete,
+    "show.getquality": CMD_ShowGetQuality,
+    "show.getposter": CMD_ShowGetPoster,
+    "show.getbanner": CMD_ShowGetBanner,
+    "show.getnetworklogo": CMD_ShowGetNetworkLogo,
+    "show.getfanart": CMD_ShowGetFanArt,
+    "show.pause": CMD_ShowPause,
+    "show.refresh": CMD_ShowRefresh,
+    "show.seasonlist": CMD_ShowSeasonList,
+    "show.seasons": CMD_ShowSeasons,
+    "show.setquality": CMD_ShowSetQuality,
+    "show.stats": CMD_ShowStats,
+    "show.update": CMD_ShowUpdate,
+    "shows": CMD_Shows,
+    "shows.stats": CMD_ShowsStats
 }

--- a/sickbeard/webapi.py
+++ b/sickbeard/webapi.py
@@ -32,6 +32,7 @@ from sickrage.media.ShowNetworkLogo import ShowNetworkLogo
 from sickrage.media.ShowPoster import ShowPoster
 from sickrage.media.ShowBanner import ShowBanner
 from sickrage.show.History import History
+from sickrage.system.Shutdown import Shutdown
 
 from versionChecker import CheckVersion
 from sickbeard import db, logger, exceptions, ui, helpers
@@ -41,7 +42,6 @@ from sickbeard import image_cache
 from sickbeard import classes
 from sickbeard import processTV
 from sickbeard import network_timezones, sbdatetime
-from sickbeard.event_queue import Events
 from sickbeard.exceptions import ex
 from sickbeard.common import DOWNLOADED
 from sickbeard.common import FAILED
@@ -1843,7 +1843,7 @@ class CMD_SickBeardSetDefaults(ApiCall):
 
 
 class CMD_SickBeardShutdown(ApiCall):
-    _help = {"desc": "shutdown sickrage"}
+    _help = {"desc": "shutdown SickRage"}
 
     def __init__(self, args, kwargs):
         # required
@@ -1852,9 +1852,12 @@ class CMD_SickBeardShutdown(ApiCall):
         ApiCall.__init__(self, args, kwargs)
 
     def run(self):
-        """ shutdown sickrage """
-        sickbeard.events.put(Events.SystemEvent.SHUTDOWN)
+        """ shutdown SickRage """
+        if not Shutdown.stop(sickbeard.PID):
+            return _responds(RESULT_FAILURE, msg='SickRage can not be shut down')
+
         return _responds(RESULT_SUCCESS, msg="SickRage is shutting down...")
+
 
 class CMD_SickBeardUpdate(ApiCall):
     _help = {"desc": "update SickRage to the latest version available"}

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -40,7 +40,6 @@ from sickbeard.providers import newznab, rsstorrent
 from sickbeard.common import Quality, Overview, statusStrings, qualityPresetStrings, cpu_presets
 from sickbeard.common import SNATCHED, UNAIRED, IGNORED, ARCHIVED, WANTED, FAILED, SKIPPED
 from sickbeard.common import SD, HD720p, HD1080p
-from sickbeard.event_queue import Events
 from sickbeard.exceptions import ex
 from sickbeard.blackandwhitelist import BlackAndWhiteList, short_group_names
 from sickbeard.browser import foldersAtPath
@@ -60,6 +59,7 @@ from sickrage.media.ShowFanArt import ShowFanArt
 from sickrage.media.ShowNetworkLogo import ShowNetworkLogo
 from sickrage.media.ShowPoster import ShowPoster
 from sickrage.show.History import History as HistoryTool
+from sickrage.system.Restart import Restart
 from sickrage.system.Shutdown import Shutdown
 from versionChecker import CheckVersion
 
@@ -1112,13 +1112,10 @@ class Home(WebRoot):
         return self._genericMessage(title, message)
 
     def restart(self, pid=None):
-        if str(pid) != str(sickbeard.PID):
+        if not Restart.restart(pid):
             return self.redirect('/' + sickbeard.DEFAULT_PAGE + '/')
 
         t = PageTemplate(rh=self, file="restart.mako")
-
-        # restart
-        sickbeard.events.put(Events.SystemEvent.RESTART)
 
         return t.render(title="Home", header="Restarting SickRage", topmenu="system", submenu=self.HomeMenu())
 

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -60,6 +60,7 @@ from sickrage.media.ShowFanArt import ShowFanArt
 from sickrage.media.ShowNetworkLogo import ShowNetworkLogo
 from sickrage.media.ShowPoster import ShowPoster
 from sickrage.show.History import History as HistoryTool
+from sickrage.system.Shutdown import Shutdown
 from versionChecker import CheckVersion
 
 import requests
@@ -1102,10 +1103,8 @@ class Home(WebRoot):
         return t.render(title='Status', header='Status', topmenu='system', submenu=self.HomeMenu(), tvdirFree=tvdirFree, rootDir=rootDir)
 
     def shutdown(self, pid=None):
-        if str(pid) != str(sickbeard.PID):
+        if not Shutdown.stop(pid):
             return self.redirect('/' + sickbeard.DEFAULT_PAGE + '/')
-
-        sickbeard.events.put(Events.SystemEvent.SHUTDOWN)
 
         title = "Shutting down"
         message = "SickRage is shutting down..."

--- a/sickrage/system/Restart.py
+++ b/sickrage/system/Restart.py
@@ -1,0 +1,17 @@
+import sickbeard
+
+from sickbeard.event_queue import Events
+
+
+class Restart:
+    def __init__(self):
+        pass
+
+    @staticmethod
+    def restart(pid):
+        if str(pid) != str(sickbeard.PID):
+            return False
+
+        sickbeard.events.put(Events.SystemEvent.RESTART)
+
+        return True

--- a/sickrage/system/Shutdown.py
+++ b/sickrage/system/Shutdown.py
@@ -1,0 +1,17 @@
+import sickbeard
+
+from sickbeard.event_queue import Events
+
+
+class Shutdown:
+    def __init__(self):
+        pass
+
+    @staticmethod
+    def stop(pid):
+        if str(pid) != str(sickbeard.PID):
+            return False
+
+        sickbeard.events.put(Events.SystemEvent.SHUTDOWN)
+
+        return True

--- a/sickrage/system/__init__.py
+++ b/sickrage/system/__init__.py
@@ -1,1 +1,1 @@
-__all__ = ['Shutdown']
+__all__ = ['Restart', 'Shutdown']

--- a/sickrage/system/__init__.py
+++ b/sickrage/system/__init__.py
@@ -1,0 +1,1 @@
+__all__ = ['Shutdown']


### PR DESCRIPTION
I did not test the restart part, so if someone can confirm that it works, it would be great.

This PR does not change a lot, but the idea is really to have a common code base between the web UI and the API.