### PR TITLE
Move history logic into a reusable class

### DIFF
--- a/gui/slick/views/history.mako
+++ b/gui/slick/views/history.mako
@@ -6,13 +6,14 @@
     import re
     import time
 
-    from sickbeard import history
     from sickbeard import providers
     from sickbeard import sbdatetime
     from sickbeard.providers import generic
 
     from sickbeard.common import SKIPPED, WANTED, UNAIRED, ARCHIVED, IGNORED, SNATCHED, SNATCHED_PROPER, SNATCHED_BEST, FAILED, DOWNLOADED, SUBTITLED
     from sickbeard.common import Quality, statusStrings, Overview
+
+    from sickrage.show.History import History
 
     layout = sickbeard.HISTORY_LAYOUT
     history_limit = sickbeard.HISTORY_LIMIT
@@ -129,9 +130,9 @@ $(document).ready(function(){
         % for hItem in historyResults:
             <% curStatus, curQuality = Quality.splitCompositeStatus(int(hItem["action"])) %>
             <tr>
-                <% curdatetime = datetime.datetime.strptime(str(hItem["date"]), history.dateFormat) %>
+                <% curdatetime = datetime.datetime.strptime(str(hItem["date"]), History.date_format) %>
                 <td align="center"><div class="${fuzzydate}">${sbdatetime.sbdatetime.sbfdatetime(curdatetime, show_seconds=True)}</div><span class="sort_data">${time.mktime(curdatetime.timetuple())}</span></td>
-                <td class="tvShow" width="35%"><a href="${sbRoot}/home/displayShow?show=${hItem["showid"]}#season-${hItem["season"]}">${hItem["show_name"]} - ${"S%02i" % int(hItem["season"])}${"E%02i" % int(hItem["episode"])} ${('', '<span class="quality Proper">Proper</span>')["proper" in hItem["resource"].lower() or "repack" in hItem["resource"].lower()]}</a></td>
+                <td class="tvShow" width="35%"><a href="${sbRoot}/home/displayShow?show=${hItem["show_id"]}#season-${hItem["season"]}">${hItem["show_name"]} - ${"S%02i" % int(hItem["season"])}${"E%02i" % int(hItem["episode"])} ${('', '<span class="quality Proper">Proper</span>')["proper" in hItem["resource"].lower() or "repack" in hItem["resource"].lower()]}</a></td>
                 <td align="center" ${('', 'class="subtitles_column"')[curStatus == SUBTITLED]}>
                 % if curStatus == SUBTITLED:
                     <img width="16" height="11" style="vertical-align:middle;" src="${sbRoot}/images/subtitles/flags/${hItem['resource']}.png" onError="this.onerror=null;this.src='${sbRoot}/images/flags/unknown.png';">
@@ -189,7 +190,7 @@ $(document).ready(function(){
         <tbody>
         % for hItem in compactResults:
             <tr>
-                <% curdatetime = datetime.datetime.strptime(str(hItem["actions"][0]["time"]), history.dateFormat) %>
+                <% curdatetime = datetime.datetime.strptime(str(hItem["actions"][0]["time"]), History.date_format) %>
                 <td align="center"><div class="${fuzzydate}">${sbdatetime.sbdatetime.sbfdatetime(curdatetime, show_seconds=True)}</div><span class="sort_data">${time.mktime(curdatetime.timetuple())}</span></td>
                 <td class="tvShow" width="25%">
                     <span><a href="${sbRoot}/home/displayShow?show=${hItem["show_id"]}#season-${hItem["season"]}">${hItem["show_name"]} - ${"S%02i" % int(hItem["season"])}${"E%02i" % int(hItem["episode"])}${('', ' <span class="quality Proper">Proper</span>')['proper' in hItem["resource"].lower() or 'repack' in hItem["resource"].lower()]}</a></span>

--- a/sickbeard/failed_history.py
+++ b/sickbeard/failed_history.py
@@ -23,16 +23,17 @@ import datetime
 from sickbeard import db
 from sickbeard import logger
 from sickbeard.exceptions import ex, EpisodeNotFoundException
-from sickbeard.history import dateFormat
 from sickbeard.common import Quality
 from sickbeard.common import WANTED, FAILED
 from sickbeard import encodingKludge as ek
+from sickrage.show.History import History
+
 
 def prepareFailedName(release):
     """Standardizes release name for failed DB"""
 
     fixed = urllib.unquote(release)
-    if (fixed.endswith(".nzb")):
+    if fixed.endswith(".nzb"):
         fixed = fixed.rpartition(".")[0]
 
     fixed = re.sub("[\.\-\+\ ]", "_", fixed)
@@ -151,7 +152,7 @@ def markFailed(epObj):
 
 
 def logSnatch(searchResult):
-    logDate = datetime.datetime.today().strftime(dateFormat)
+    logDate = datetime.datetime.today().strftime(History.date_format)
     release = prepareFailedName(searchResult.name)
 
     providerClass = searchResult.provider
@@ -182,7 +183,7 @@ def deleteLoggedSnatch(release, size, provider):
 def trimHistory():
     myDB = db.DBConnection('failed.db')
     myDB.action("DELETE FROM history WHERE date < " + str(
-        (datetime.datetime.today() - datetime.timedelta(days=30)).strftime(dateFormat)))
+        (datetime.datetime.today() - datetime.timedelta(days=30)).strftime(History.date_format)))
 
 
 def findRelease(epObj):

--- a/sickbeard/history.py
+++ b/sickbeard/history.py
@@ -21,13 +21,11 @@ import datetime
 
 from sickbeard.common import SNATCHED, SUBTITLED, FAILED, Quality
 from sickbeard import encodingKludge as ek
-
-
-dateFormat = "%Y%m%d%H%M%S"
+from sickrage.show.History import History
 
 
 def _logHistoryItem(action, showid, season, episode, quality, resource, provider, version=-1):
-    logDate = datetime.datetime.today().strftime(dateFormat)
+    logDate = datetime.datetime.today().strftime(History.date_format)
     resource = ek.ss(resource)
 
     myDB = db.DBConnection()

--- a/sickbeard/properFinder.py
+++ b/sickbeard/properFinder.py
@@ -32,9 +32,9 @@ from sickbeard import exceptions
 from sickbeard.exceptions import ex
 from sickbeard import helpers, logger
 from sickbeard import search
-from sickbeard import history
 
 from sickbeard.common import DOWNLOADED, SNATCHED, SNATCHED_PROPER, Quality, cpu_presets
+from sickrage.show.History import History
 
 from name_parser.parser import NameParser, InvalidNameException, InvalidShowException
 
@@ -213,7 +213,7 @@ class ProperFinder():
                 "WHERE showid = ? AND season = ? AND episode = ? AND quality = ? AND date >= ? " +
                 "AND action IN (" + ",".join([str(x) for x in Quality.SNATCHED + Quality.DOWNLOADED]) + ")",
                 [curProper.indexerid, curProper.season, curProper.episode, curProper.quality,
-                 historyLimit.strftime(history.dateFormat)])
+                 historyLimit.strftime(History.date_format)])
 
             # if we didn't download this episode in the first place we don't know what quality to use for the proper so we can't do it
             if len(historyResults) == 0:

--- a/sickbeard/webapi.py
+++ b/sickbeard/webapi.py
@@ -31,6 +31,7 @@ from sickrage.media.ShowFanArt import ShowFanArt
 from sickrage.media.ShowNetworkLogo import ShowNetworkLogo
 from sickrage.media.ShowPoster import ShowPoster
 from sickrage.media.ShowBanner import ShowBanner
+from sickrage.show.History import History
 
 from versionChecker import CheckVersion
 from sickbeard import db, logger, exceptions, history, ui, helpers
@@ -1176,8 +1177,7 @@ class CMD_History(ApiCall):
 
 
 class CMD_HistoryClear(ApiCall):
-    _help = {"desc": "clear sickrage's history",
-    }
+    _help = {"desc": "clear SickRage's history"}
 
     def __init__(self, args, kwargs):
         # required
@@ -1186,9 +1186,8 @@ class CMD_HistoryClear(ApiCall):
         ApiCall.__init__(self, args, kwargs)
 
     def run(self):
-        """ clear sickrage's history """
-        myDB = db.DBConnection()
-        myDB.action("DELETE FROM history WHERE 1=1")
+        """ clear SickRage's history """
+        History().clear()
 
         return _responds(RESULT_SUCCESS, msg="History cleared")
 

--- a/sickbeard/webapi.py
+++ b/sickbeard/webapi.py
@@ -34,7 +34,7 @@ from sickrage.media.ShowBanner import ShowBanner
 from sickrage.show.History import History
 
 from versionChecker import CheckVersion
-from sickbeard import db, logger, exceptions, history, ui, helpers
+from sickbeard import db, logger, exceptions, ui, helpers
 from sickbeard import encodingKludge as ek
 from sickbeard import search_queue
 from sickbeard import image_cache
@@ -548,7 +548,7 @@ def _ordinal_to_dateForm(ordinal):
 
 
 def _historyDate_to_dateTimeForm(timeString):
-    date = datetime.datetime.strptime(timeString, history.dateFormat)
+    date = datetime.datetime.strptime(timeString, History.date_format)
     return date.strftime(dateTimeFormat)
 
 
@@ -1193,8 +1193,7 @@ class CMD_HistoryClear(ApiCall):
 
 
 class CMD_HistoryTrim(ApiCall):
-    _help = {"desc": "trim sickrage's history by removing entries greater than 30 days old"
-    }
+    _help = {"desc": "trim SickRage's history by removing entries greater than 30 days old"}
 
     def __init__(self, args, kwargs):
         # required
@@ -1203,12 +1202,11 @@ class CMD_HistoryTrim(ApiCall):
         ApiCall.__init__(self, args, kwargs)
 
     def run(self):
-        """ trim sickrage's history """
-        myDB = db.DBConnection()
-        myDB.action("DELETE FROM history WHERE date < " + str(
-            (datetime.datetime.today() - datetime.timedelta(days=30)).strftime(history.dateFormat)))
+        """ trim SickRage's history """
+        History().trim()
 
-        return _responds(RESULT_SUCCESS, msg="Removed history entries greater than 30 days old")
+        return _responds(RESULT_SUCCESS, msg='Removed history entries older than 30 days')
+
 
 class CMD_Failed(ApiCall):
     _help = {"desc": "display failed downloads",

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -59,6 +59,7 @@ from sickrage.media.ShowBanner import ShowBanner
 from sickrage.media.ShowFanArt import ShowFanArt
 from sickrage.media.ShowNetworkLogo import ShowNetworkLogo
 from sickrage.media.ShowPoster import ShowPoster
+from sickrage.show.History import History
 from versionChecker import CheckVersion
 
 import requests
@@ -3627,15 +3628,12 @@ class History(WebRoot):
 
         return t.render(historyResults=sqlResults, compactResults=compact, limit=limit, submenu=submenu, title='History', header='History', topmenu="history")
 
-
     def clearHistory(self):
-
-        myDB = db.DBConnection()
-        myDB.action("DELETE FROM history WHERE 1=1")
+        History().clear()
 
         ui.notifications.message('History cleared')
-        return self.redirect("/history/")
 
+        return self.redirect("/history/")
 
     def trimHistory(self):
 

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -27,7 +27,7 @@ import codecs
 import sickbeard
 from sickbeard import config, sab
 from sickbeard import clients
-from sickbeard import history, notifiers, processTV
+from sickbeard import notifiers, processTV
 from sickbeard import ui
 from sickbeard import logger, helpers, exceptions, classes, db
 from sickbeard import encodingKludge as ek
@@ -59,7 +59,7 @@ from sickrage.media.ShowBanner import ShowBanner
 from sickrage.media.ShowFanArt import ShowFanArt
 from sickrage.media.ShowNetworkLogo import ShowNetworkLogo
 from sickrage.media.ShowPoster import ShowPoster
-from sickrage.show.History import History
+from sickrage.show.History import History as HistoryTool
 from versionChecker import CheckVersion
 
 import requests
@@ -3559,6 +3559,8 @@ class History(WebRoot):
     def __init__(self, *args, **kwargs):
         super(History, self).__init__(*args, **kwargs)
 
+        self.history = HistoryTool()
+
     def index(self, limit=100):
         limit = int(limit)
         sickbeard.HISTORY_LIMIT = limit
@@ -3629,19 +3631,17 @@ class History(WebRoot):
         return t.render(historyResults=sqlResults, compactResults=compact, limit=limit, submenu=submenu, title='History', header='History', topmenu="history")
 
     def clearHistory(self):
-        History().clear()
+        self.history.clear()
 
         ui.notifications.message('History cleared')
 
         return self.redirect("/history/")
 
     def trimHistory(self):
+        self.history.trim()
 
-        myDB = db.DBConnection()
-        myDB.action("DELETE FROM history WHERE date < " + str(
-            (datetime.datetime.today() - datetime.timedelta(days=30)).strftime(history.dateFormat)))
+        ui.notifications.message('Removed history entries older than 30 days')
 
-        ui.notifications.message('Removed history entries greater than 30 days old')
         return self.redirect("/history/")
 
 

--- a/sickrage/show/History.py
+++ b/sickrage/show/History.py
@@ -1,0 +1,13 @@
+from sickbeard.db import DBConnection
+
+
+class History:
+    def __init__(self):
+        self.db = DBConnection()
+
+    def clear(self):
+        self.db.action(
+            'DELETE '
+            'FROM history '
+            'WHERE 1=1'
+        )

--- a/sickrage/show/History.py
+++ b/sickrage/show/History.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from datetime import timedelta
+from sickbeard.common import Quality
 from sickbeard.db import DBConnection
 
 
@@ -13,8 +14,55 @@ class History:
         self.db.action(
             'DELETE '
             'FROM history '
-            'WHERE 1=1'
+            'WHERE 1 = 1'
         )
+
+    def get(self, limit=100, action=None):
+        action = action.lower() if isinstance(action, str) else ''
+        limit = int(limit)
+
+        if action == 'downloaded':
+            actions = Quality.DOWNLOADED
+        elif action == 'snatched':
+            actions = Quality.SNATCHED
+        else:
+            actions = Quality.SNATCHED + Quality.DOWNLOADED
+
+        if limit == 0:
+            results = self.db.select(
+                'SELECT h.*, show_name '
+                'FROM history h, tv_shows s '
+                'WHERE h.showid = s.indexer_id '
+                'AND action in (' + ','.join(['?'] * len(actions)) + ') '
+                                                                     'ORDER BY date DESC',
+                actions
+            )
+        else:
+            results = self.db.select(
+                'SELECT h.*, show_name '
+                'FROM history h, tv_shows s '
+                'WHERE h.showid = s.indexer_id '
+                'AND action in (' + ','.join(['?'] * len(actions)) + ') '
+                                                                     'ORDER BY date DESC '
+                                                                     'LIMIT ?',
+                actions + [limit]
+            )
+
+        data = []
+        for result in results:
+            data.append({
+                'action': result['action'],
+                'date': result['date'],
+                'episode': result['episode'],
+                'provider': result['provider'],
+                'quality': result['quality'],
+                'resource': result['resource'],
+                'season': result['season'],
+                'show_id': result['showid'],
+                'show_name': result['show_name']
+            })
+
+        return data
 
     def trim(self):
         self.db.action(

--- a/sickrage/show/History.py
+++ b/sickrage/show/History.py
@@ -1,7 +1,11 @@
+from datetime import datetime
+from datetime import timedelta
 from sickbeard.db import DBConnection
 
 
 class History:
+    date_format = '%Y%m%d%H%M%S'
+
     def __init__(self):
         self.db = DBConnection()
 
@@ -10,4 +14,12 @@ class History:
             'DELETE '
             'FROM history '
             'WHERE 1=1'
+        )
+
+    def trim(self):
+        self.db.action(
+            'DELETE '
+            'FROM history '
+            'WHERE date < ?',
+            [(datetime.today() - timedelta(days=30)).strftime(History.date_format)]
         )

--- a/sickrage/show/__init__.py
+++ b/sickrage/show/__init__.py
@@ -1,0 +1,1 @@
+__all__ = ['History']


### PR DESCRIPTION
The code to get, clear and trim the history is now the same for the web UI and the API.
From what I saw, the failed history use almost the same code. So it should be easy to change that part too.