### PR TITLE
Move "Coming episodes" logic into a dedicated class

### DIFF
--- a/gui/slick/views/comingEpisodes.mako
+++ b/gui/slick/views/comingEpisodes.mako
@@ -202,7 +202,7 @@ window.setInterval('location.reload(true)', 600000); // Refresh every 10 minutes
 
     <tbody style="text-shadow:none;">
 
-% for cur_result in sql_results:
+% for cur_result in results:
 <%
     cur_indexer = int(cur_result['indexer'])
     run_time = cur_result['runtime']
@@ -297,7 +297,7 @@ window.setInterval('location.reload(true)', 600000); // Refresh every 10 minutes
     <br /><br />
 % endif
 
-% for cur_result in sql_results:
+% for cur_result in results:
 <%
     cur_indexer = int(cur_result['indexer'])
 
@@ -472,7 +472,7 @@ window.setInterval('location.reload(true)', 600000); // Refresh every 10 minutes
         <thead><tr><th>${day.strftime('%A').decode(sickbeard.SYS_ENCODING).capitalize()}</th></tr></thead>
         <tbody>
         <% day_has_show = False %>
-        % for cur_result in sql_results:
+        % for cur_result in results:
             % if int(cur_result['paused']) and not sickbeard.COMING_EPS_DISPLAY_PAUSED:
                 <% continue %>
             % endif

--- a/gui/slick/views/status.mako
+++ b/gui/slick/views/status.mako
@@ -3,6 +3,7 @@
     import sickbeard
     from sickbeard import helpers
     from sickbeard.show_queue import ShowQueueActions
+    from sickrage.helper.common import dateTimeFormat
 %>
 <%block name="scripts">
 <script type="text/javascript">
@@ -111,7 +112,7 @@
                % else:
                <td></td>
                % endif
-               <td>${service.lastRun.strftime("%Y-%m-%d %H:%M:%S")}</td>
+               <td>${service.lastRun.strftime(dateTimeFormat)}</td>
                <td>${service.silent}</td>
            </tr>
            <% del service %>
@@ -159,7 +160,7 @@
                     % else:
                         <td>sickbeard.showQueueScheduler.action.currentItem.priority</td>
                     % endif
-                    <td>${sickbeard.showQueueScheduler.action.currentItem.added.strftime("%Y-%m-%d %H:%M:%S")}</td>
+                    <td>${sickbeard.showQueueScheduler.action.currentItem.added.strftime(dateTimeFormat)}</td>
                     <td>${ShowQueueActions.names[sickbeard.showQueueScheduler.action.currentItem.action_id]}</td>
                 </tr>
             % endif
@@ -191,7 +192,7 @@
                     % else:
                         <td>${item.priority}</td>
                     % endif
-                    <td>${item.added.strftime("%Y-%m-%d %H:%M:%S")}</td>
+                    <td>${item.added.strftime(dateTimeFormat)}</td>
                     <td>${ShowQueueActions.names[item.action_id]}</td>
                 </tr>
             % endfor

--- a/sickbeard/classes.py
+++ b/sickbeard/classes.py
@@ -60,11 +60,11 @@ class AuthURLOpener(SickBeardURLopener):
         # if this is the first try then provide a username/password
         if self.numTries == 0:
             self.numTries = 1
-            return (self.username, self.password)
+            return self.username, self.password
 
         # if we've tried before then return blank which cancels the request
         else:
-            return ('', '')
+            return '', ''
 
     # this is pretty much just a hack for convenience
     def openit(self, url):
@@ -189,7 +189,7 @@ class AllShowsListUI:
                         if searchterm.lower() in name.lower():
                             if 'firstaired' not in curShow:
                                 curShow['firstaired'] = str(datetime.date.fromordinal(1))
-                                curShow['firstaired'] = re.sub("([-]0{2}){1,}", "", curShow['firstaired'])
+                                curShow['firstaired'] = re.sub("([-]0{2})+", "", curShow['firstaired'])
                                 fixDate = parser.parse(curShow['firstaired'], fuzzy=True).date()
                                 curShow['firstaired'] = fixDate.strftime(dateFormat)
 
@@ -203,7 +203,7 @@ class ShowListUI:
     """
     This class is for tvdb-api. Instead of prompting with a UI to pick the
     desired result out of a list of shows it tries to be smart about it
-    based on what shows are in SB.
+    based on what shows are in SickRage.
     """
 
     def __init__(self, config, log=None):
@@ -246,7 +246,7 @@ class Proper:
             self.indexerid) + " from " + str(sickbeard.indexerApi(self.indexer).name)
 
 
-class ErrorViewer():
+class ErrorViewer:
     """
     Keeps a static list of UIErrors to be displayed on the UI and allows
     the list to be cleared.

--- a/sickbeard/classes.py
+++ b/sickbeard/classes.py
@@ -25,6 +25,7 @@ import datetime
 from dateutil import parser
 
 from common import USER_AGENT, Quality
+from sickrage.helper.common import dateFormat, dateTimeFormat
 
 
 class SickBeardURLopener(urllib.FancyURLopener):
@@ -35,7 +36,7 @@ class AuthURLOpener(SickBeardURLopener):
     """
     URLOpener class that supports http auth without needing interactive password entry.
     If the provided username/password don't work it simply fails.
-    
+
     user: username to use for HTTP auth
     pw: password to use for HTTP auth
     """
@@ -190,7 +191,7 @@ class AllShowsListUI:
                                 curShow['firstaired'] = str(datetime.date.fromordinal(1))
                                 curShow['firstaired'] = re.sub("([-]0{2}){1,}", "", curShow['firstaired'])
                                 fixDate = parser.parse(curShow['firstaired'], fuzzy=True).date()
-                                curShow['firstaired'] = fixDate.strftime("%Y-%m-%d")
+                                curShow['firstaired'] = fixDate.strftime(dateFormat)
 
                             if curShow not in searchResults:
                                 searchResults += [curShow]
@@ -202,7 +203,7 @@ class ShowListUI:
     """
     This class is for tvdb-api. Instead of prompting with a UI to pick the
     desired result out of a list of shows it tries to be smart about it
-    based on what shows are in SB. 
+    based on what shows are in SB.
     """
 
     def __init__(self, config, log=None):
@@ -269,7 +270,7 @@ class ErrorViewer():
         return ErrorViewer.errors
 
 
-class UIError():
+class UIError:
     """
     Represents an error to be displayed in the web UI.
     """
@@ -277,4 +278,4 @@ class UIError():
     def __init__(self, message):
         self.title = sys.exc_info()[-2] or message
         self.message = message
-        self.time = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+        self.time = datetime.datetime.now().strftime(dateTimeFormat)

--- a/sickbeard/databases/mainDB.py
+++ b/sickbeard/databases/mainDB.py
@@ -25,11 +25,13 @@ from sickbeard import db, common, helpers, logger
 
 from sickbeard import encodingKludge as ek
 from sickbeard.name_parser.parser import NameParser, InvalidNameException, InvalidShowException
+from sickrage.helper.common import dateTimeFormat
 
 from babelfish import language_converters
 
 MIN_DB_VERSION = 9  # oldest db version we support migrating from
 MAX_DB_VERSION = 42
+
 
 class MainSanityCheck(db.DBSanityCheck):
     def check(self):
@@ -237,7 +239,7 @@ class MainSanityCheck(db.DBSanityCheck):
 
         sqlResults = self.connection.select(
             "SELECT subtitles, episode_id FROM tv_episodes WHERE subtitles != '' AND subtitles_lastsearch < ?;",
-                [datetime.datetime(2015, 7, 15, 17, 20, 44, 326380).strftime("%Y-%m-%d %H:%M:%S")])
+                [datetime.datetime(2015, 7, 15, 17, 20, 44, 326380).strftime(dateTimeFormat)])
 
         if not sqlResults:
             return
@@ -257,10 +259,11 @@ class MainSanityCheck(db.DBSanityCheck):
                 langs.append(subcode)
 
             self.connection.action("UPDATE tv_episodes SET subtitles = ?, subtitles_lastsearch = ? WHERE episode_id = ?;",
-                [','.join(langs), datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"), sqlResult['episode_id']])
+                [','.join(langs), datetime.datetime.now().strftime(dateTimeFormat), sqlResult['episode_id']])
 
     def fix_show_nfo_lang(self):
         self.connection.action("UPDATE tv_shows SET lang = '' WHERE lang = 0 or lang = '0'")
+
 
 def backupDatabase(version):
     logger.log(u"Backing up database before upgrade")

--- a/sickbeard/logger.py
+++ b/sickbeard/logger.py
@@ -28,6 +28,7 @@ import locale
 
 import sickbeard
 from sickbeard import classes, encodingKludge as ek
+from sickrage.helper.common import dateTimeFormat
 from github import Github, InputFileContent
 import codecs
 
@@ -118,16 +119,16 @@ class Logger(object):
         # rotating log file handler
         if self.fileLogging:
             rfh = logging.handlers.RotatingFileHandler(self.logFile, maxBytes=sickbeard.LOG_SIZE, backupCount=sickbeard.LOG_NR, encoding='utf-8')
-            rfh.setFormatter(CensoredFormatter(u'%(asctime)s %(levelname)-8s %(message)s', '%Y-%m-%d %H:%M:%S'))
+            rfh.setFormatter(CensoredFormatter(u'%(asctime)s %(levelname)-8s %(message)s', dateTimeFormat))
             rfh.setLevel(DEBUG)
 
             for logger in self.loggers:
                 logger.addHandler(rfh)
-                
+
     def shutdown(self):
-        
+
         logging.shutdown()
-        
+
     def log(self, msg, level=INFO, *args, **kwargs):
         meThread = threading.currentThread().getName()
         message = meThread + u" :: " + msg
@@ -155,7 +156,7 @@ class Logger(object):
         if not (sickbeard.GIT_USERNAME and sickbeard.GIT_PASSWORD and sickbeard.DEBUG and len(classes.ErrorViewer.errors) > 0):
             self.log('Please set your GitHub username and password in the config and enable debug. Unable to submit issue ticket to GitHub!')
             return
-          
+
         try:
             from versionChecker import CheckVersion
             checkversion = CheckVersion()
@@ -167,7 +168,7 @@ class Logger(object):
 
         if commits_behind is None or commits_behind > 0:
             self.log('Please update SickRage, unable to submit issue ticket to GitHub with an outdated version!')
-            return          
+            return
 
         if self.submitter_running:
             return 'RUNNING'
@@ -186,7 +187,7 @@ class Logger(object):
             if os.path.isfile(self.logFile):
                 with ek.ek(codecs.open, *[self.logFile, 'r', 'utf-8']) as f:
                     log_data = f.readlines()
-                    
+
             for i in range (1 , int(sickbeard.LOG_NR)):
                 if os.path.isfile(self.logFile + "." + str(i)) and (len(log_data) <= 500):
                     with ek.ek(codecs.open, *[self.logFile + "." + str(i), 'r', 'utf-8']) as f:
@@ -230,7 +231,7 @@ class Logger(object):
                     try:
                         message += u"Locale: " + locale.getdefaultlocale()[1] + "\n"
                     except:
-                        message += u"Locale: unknown" + "\n"                        
+                        message += u"Locale: unknown" + "\n"
                 message += u"Branch: **" + sickbeard.BRANCH + "**\n"
                 message += u"Commit: SiCKRAGETV/SickRage@" + sickbeard.CUR_COMMIT_HASH + "\n"
                 if gist and gist != 'No ERROR found':

--- a/sickbeard/metadata/kodi_12plus.py
+++ b/sickbeard/metadata/kodi_12plus.py
@@ -22,6 +22,7 @@ import sickbeard
 
 from sickbeard import logger, exceptions, helpers
 from sickbeard.exceptions import ex
+from sickrage.helper.common import dateFormat
 
 import xml.etree.cElementTree as etree
 
@@ -141,7 +142,7 @@ class KODI_12PlusMetadata(generic.GenericMetadata):
         year = etree.SubElement(tv_node, "year")
         if getattr(myShow, 'firstaired', None) is not None:
             try:
-                year_text = str(datetime.datetime.strptime(myShow["firstaired"], '%Y-%m-%d').year)
+                year_text = str(datetime.datetime.strptime(myShow["firstaired"], dateFormat).year)
                 if year_text:
                     year.text = year_text
             except:

--- a/sickbeard/metadata/mede8er.py
+++ b/sickbeard/metadata/mede8er.py
@@ -26,6 +26,7 @@ import mediabrowser
 from sickbeard import logger, exceptions, helpers
 from sickbeard.exceptions import ex
 from sickbeard import encodingKludge as ek
+from sickrage.helper.common import dateFormat
 
 try:
     import xml.etree.cElementTree as etree
@@ -142,7 +143,7 @@ class Mede8erMetadata(mediabrowser.MediaBrowserMetadata):
 
         SeriesName = etree.SubElement(tv_node, "title")
         SeriesName.text = myShow['seriesname']
-        
+
         Genres = etree.SubElement(tv_node, "genres")
         if getattr(myShow, "genre", None) != None:
             for genre in myShow['genre'].split('|'):
@@ -157,7 +158,7 @@ class Mede8erMetadata(mediabrowser.MediaBrowserMetadata):
         year = etree.SubElement(tv_node, "year")
         if getattr(myShow, "firstaired", None) != None:
             try:
-                year_text = str(datetime.datetime.strptime(myShow["firstaired"], '%Y-%m-%d').year)
+                year_text = str(datetime.datetime.strptime(myShow["firstaired"], dateFormat).year)
                 if year_text:
                     year.text = year_text
             except:
@@ -286,7 +287,7 @@ class Mede8erMetadata(mediabrowser.MediaBrowserMetadata):
                 year = etree.SubElement(episode, "year")
                 if getattr(myShow, "firstaired", None) != None:
                     try:
-                        year_text = str(datetime.datetime.strptime(myShow["firstaired"], '%Y-%m-%d').year)
+                        year_text = str(datetime.datetime.strptime(myShow["firstaired"], dateFormat).year)
                         if year_text:
                             year.text = year_text
                     except:
@@ -399,7 +400,7 @@ class Mede8erMetadata(mediabrowser.MediaBrowserMetadata):
             return False
 
         return True
-    
+
     def write_ep_file(self, ep_obj):
         """
         Generates and writes ep_obj's metadata under the given path with the

--- a/sickbeard/metadata/mediabrowser.py
+++ b/sickbeard/metadata/mediabrowser.py
@@ -28,6 +28,7 @@ from sickbeard import logger, exceptions, helpers
 from sickbeard import encodingKludge as ek
 
 from sickbeard.exceptions import ex
+from sickrage.helper.common import dateFormat
 
 import xml.etree.cElementTree as etree
 
@@ -316,7 +317,7 @@ class MediaBrowserMetadata(generic.GenericMetadata):
         ProductionYear = etree.SubElement(tv_node, "ProductionYear")
         if getattr(myShow, 'firstaired', None) is not None:
             try:
-                year_text = str(datetime.datetime.strptime(myShow['firstaired'], '%Y-%m-%d').year)
+                year_text = str(datetime.datetime.strptime(myShow['firstaired'], dateFormat).year)
                 if year_text:
                     ProductionYear.text = year_text
             except:

--- a/sickbeard/metadata/wdtv.py
+++ b/sickbeard/metadata/wdtv.py
@@ -28,6 +28,7 @@ from sickbeard import logger, exceptions, helpers
 from sickbeard import encodingKludge as ek
 
 from sickbeard.exceptions import ex
+from sickrage.helper.common import dateFormat
 
 import xml.etree.cElementTree as etree
 
@@ -252,7 +253,7 @@ class WDTVMetadata(generic.GenericMetadata):
             year = etree.SubElement(episode, "year")
             if getattr(myShow, 'firstaired', None) is not None:
                 try:
-                    year_text = str(datetime.datetime.strptime(myShow["firstaired"], '%Y-%m-%d').year)
+                    year_text = str(datetime.datetime.strptime(myShow["firstaired"], dateFormat).year)
                     if year_text:
                         year.text = year_text
                 except:

--- a/sickbeard/subtitles.py
+++ b/sickbeard/subtitles.py
@@ -23,6 +23,7 @@ from sickbeard.exceptions import ex
 from sickbeard import logger
 from sickbeard import encodingKludge as ek
 from sickbeard import db
+from sickrage.helper.common import dateTimeFormat
 import subliminal
 import babelfish
 import subprocess
@@ -171,9 +172,9 @@ class SubtitlesFinder():
 
             # Old shows rule
             throwaway = datetime.datetime.strptime('20110101', '%Y%m%d')
-            if ((epToSub['airdate_daydiff'] > 7 and epToSub['searchcount'] < 2 and now - datetime.datetime.strptime(epToSub['lastsearch'], '%Y-%m-%d %H:%M:%S') > datetime.timedelta(hours=rules['old'][epToSub['searchcount']])) or
+            if ((epToSub['airdate_daydiff'] > 7 and epToSub['searchcount'] < 2 and now - datetime.datetime.strptime(epToSub['lastsearch'], dateTimeFormat) > datetime.timedelta(hours=rules['old'][epToSub['searchcount']])) or
                 # Recent shows rule
-                (epToSub['airdate_daydiff'] <= 7 and epToSub['searchcount'] < 7 and now - datetime.datetime.strptime(epToSub['lastsearch'], '%Y-%m-%d %H:%M:%S') > datetime.timedelta(hours=rules['new'][epToSub['searchcount']]))):
+                (epToSub['airdate_daydiff'] <= 7 and epToSub['searchcount'] < 7 and now - datetime.datetime.strptime(epToSub['lastsearch'], dateTimeFormat) > datetime.timedelta(hours=rules['new'][epToSub['searchcount']]))):
                 logger.log('Downloading subtitles for episode %dx%d of show %s' % (epToSub['season'], epToSub['episode'], epToSub['show_name']), logger.DEBUG)
 
                 showObj = sickbeard.helpers.findCertainShow(sickbeard.showList, int(epToSub['showid']))

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -52,6 +52,7 @@ from sickbeard.blackandwhitelist import BlackAndWhiteList
 from sickbeard import sbdatetime
 from sickbeard import network_timezones
 from sickbeard.indexers.indexer_config import INDEXER_TVRAGE
+from sickrage.helper.common import dateTimeFormat
 from dateutil.tz import *
 
 from sickbeard import encodingKludge as ek
@@ -1506,7 +1507,7 @@ class TVEpisode(object):
         self.refreshSubtitles()
 
         self.subtitles_searchcount += 1 if self.subtitles_searchcount else 1
-        self.subtitles_lastsearch = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        self.subtitles_lastsearch = datetime.datetime.now().strftime(dateTimeFormat)
         self.saveToDB()
 
         newSubtitles = frozenset(self.subtitles).difference(previous_subtitles)

--- a/sickbeard/webapi.py
+++ b/sickbeard/webapi.py
@@ -27,10 +27,13 @@ import re
 import traceback
 
 import sickbeard
+from sickrage.helper.common import dateFormat, dateTimeFormat, timeFormat
+from sickrage.helper.quality import get_quality_string
 from sickrage.media.ShowFanArt import ShowFanArt
 from sickrage.media.ShowNetworkLogo import ShowNetworkLogo
 from sickrage.media.ShowPoster import ShowPoster
 from sickrage.media.ShowBanner import ShowBanner
+from sickrage.show.ComingEpisodes import ComingEpisodes
 from sickrage.show.History import History
 from sickrage.system.Restart import Restart
 from sickrage.system.Shutdown import Shutdown
@@ -55,7 +58,6 @@ from sickbeard.common import SNATCHED_PROPER
 from sickbeard.common import UNAIRED
 from sickbeard.common import UNKNOWN
 from sickbeard.common import WANTED
-from sickbeard.common import qualityPresetStrings
 from sickbeard.common import statusStrings
 import codecs
 
@@ -68,10 +70,6 @@ except ImportError:
 from tornado.web import RequestHandler
 
 indexer_ids = ["indexerid", "tvdbid"]
-
-dateFormat = "%Y-%m-%d"
-dateTimeFormat = "%Y-%m-%d %H:%M"
-timeFormat = '%A %I:%M %p'
 
 RESULT_SUCCESS = 10  # only use inside the run methods
 RESULT_FAILURE = 20  # only use inside the run methods
@@ -517,15 +515,6 @@ def _responds(result_type, data=None, msg=""):
             "data": data}
 
 
-def _get_quality_string(q):
-    qualityString = "Custom"
-    if q in qualityPresetStrings:
-        qualityString = qualityPresetStrings[q]
-    elif q in Quality.qualityStrings:
-        qualityString = Quality.qualityStrings[q]
-    return qualityString
-
-
 def _get_status_Strings(s):
     return statusStrings[s]
 
@@ -622,12 +611,15 @@ def _getRootDirs():
 
 
 class ApiError(Exception):
-    "Generic API error"
+    """
+    Generic API error
+    """
 
 
 class IntParseError(Exception):
-    "A value could not be parsed into a int. But should be parsable to a int "
-
+    """
+    A value could not be parsed into an int, but should be parsable to an int
+    """
 
 # -------------------------------------------------------------------------------------#
 
@@ -655,126 +647,53 @@ class CMD_Help(ApiCall):
 
 
 class CMD_ComingEpisodes(ApiCall):
-    _help = {"desc": "display the coming episodes",
-             "optionalParameters": {"sort": {"desc": "change the sort order"},
-                                    "type": {"desc": "one or more of allowedValues separated by |"},
-                                    "paused": {
-                                        "desc": "0 to exclude paused shows, 1 to include them, or omitted to use the SR default"},
-             }
+    _help = {
+        "desc": "Display the coming episodes",
+        "optionalParameters": {
+            "sort": {"desc": "Change the sort order"},
+            "type": {"desc": "One or more of allowedValues separated by |"},
+            "paused": {
+                "desc": "0 to exclude paused shows, 1 to include them, or omitted to use SickRage default value"
+            },
+        }
     }
 
     def __init__(self, args, kwargs):
         # required
         # optional
-        self.sort, args = self.check_params(args, kwargs, "sort", "date", False, "string",
-                                            ["date", "show", "network"])
-        self.type, args = self.check_params(args, kwargs, "type", "today|missed|soon|later", False,
-                                            "list",
-                                            ["missed", "later", "today", "soon"])
-        self.paused, args = self.check_params(args, kwargs, "paused", sickbeard.COMING_EPS_DISPLAY_PAUSED,
-                                              False, "int",
+        self.sort, args = self.check_params(args, kwargs, "sort", "date", False, "string", ComingEpisodes.sorts.keys())
+        self.type, args = self.check_params(args, kwargs, "type", '|'.join(ComingEpisodes.categories), False, "list",
+                                            ComingEpisodes.categories)
+        self.paused, args = self.check_params(args, kwargs, "paused", sickbeard.COMING_EPS_DISPLAY_PAUSED, False, "int",
                                               [0, 1])
         # super, missing, help
         ApiCall.__init__(self, args, kwargs)
 
     def run(self):
-        """ display the coming episodes """
-        today = datetime.date.today().toordinal()
-        next_week = (datetime.date.today() + datetime.timedelta(days=7)).toordinal()
-        recently = (datetime.date.today() - datetime.timedelta(days=sickbeard.COMING_EPS_MISSED_RANGE)).toordinal()
+        """ Display the coming episodes """
+        grouped_coming_episodes = ComingEpisodes.get_coming_episodes(self.type, self.sort, self.paused)
+        data = {section: [] for section in grouped_coming_episodes.keys()}
 
-        done_show_list = []
-        qualList = Quality.DOWNLOADED + Quality.SNATCHED + Quality.ARCHIVED + [IGNORED]
+        for section, coming_episodes in grouped_coming_episodes.iteritems():
+            for coming_episode in coming_episodes:
+                data[section].append({
+                    'airdate': coming_episode['airdate'],
+                    'airs': coming_episode['airs'],
+                    'ep_name': coming_episode['name'],
+                    'ep_plot': coming_episode['description'],
+                    'episode': coming_episode['episode'],
+                    'indexerid': coming_episode['indexer_id'],
+                    'network': coming_episode['network'],
+                    'paused': coming_episode['paused'],
+                    'quality': coming_episode['quality'],
+                    'season': coming_episode['season'],
+                    'show_name': coming_episode['show_name'],
+                    'show_status': coming_episode['status'],
+                    'tvdbid': coming_episode['tvdbid'],
+                    'weekday': coming_episode['weekday']
+                })
 
-        myDB = db.DBConnection(row_type="dict")
-        sql_results = myDB.select(
-            "SELECT airdate, airs, episode, name AS 'ep_name', description AS 'ep_plot', network, season, showid AS 'indexerid', show_name, tv_shows.quality AS quality, tv_shows.status AS 'show_status', tv_shows.paused AS 'paused' FROM tv_episodes, tv_shows WHERE season != 0 AND airdate >= ? AND airdate < ? AND tv_shows.indexer_id = tv_episodes.showid AND tv_episodes.status NOT IN (" + ','.join(
-                ['?'] * len(qualList)) + ")", [today, next_week] + qualList)
-        for cur_result in sql_results:
-            done_show_list.append(int(cur_result["indexerid"]))
-
-        more_sql_results = myDB.select(
-            "SELECT airdate, airs, episode, name AS 'ep_name', description AS 'ep_plot', network, season, showid AS 'indexerid', show_name, tv_shows.quality AS quality, tv_shows.status AS 'show_status', tv_shows.paused AS 'paused' FROM tv_episodes outer_eps, tv_shows WHERE season != 0 AND showid NOT IN (" + ','.join(
-                ['?'] * len(
-                    done_show_list)) + ") AND tv_shows.indexer_id = outer_eps.showid AND airdate = (SELECT airdate FROM tv_episodes inner_eps WHERE inner_eps.season != 0 AND inner_eps.showid = outer_eps.showid AND inner_eps.airdate >= ? ORDER BY inner_eps.airdate ASC LIMIT 1) AND outer_eps.status NOT IN (" + ','.join(
-                ['?'] * len(Quality.DOWNLOADED + Quality.SNATCHED)) + ")",
-            done_show_list + [next_week] + Quality.DOWNLOADED + Quality.SNATCHED)
-        sql_results += more_sql_results
-
-        more_sql_results = myDB.select(
-            "SELECT airdate, airs, episode, name AS 'ep_name', description AS 'ep_plot', network, season, showid AS 'indexerid', show_name, tv_shows.quality AS quality, tv_shows.status AS 'show_status', tv_shows.paused AS 'paused' FROM tv_episodes, tv_shows WHERE season != 0 AND tv_shows.indexer_id = tv_episodes.showid AND airdate < ? AND airdate >= ? AND tv_episodes.status = ? AND tv_episodes.status NOT IN (" + ','.join(
-                ['?'] * len(qualList)) + ")", [today, recently, WANTED] + qualList)
-        sql_results += more_sql_results
-
-        # sort by air date
-        sorts = {
-            'date': (lambda x, y: cmp(int(x["airdate"]), int(y["airdate"]))),
-            'show': (lambda a, b: cmp(a["show_name"], b["show_name"])),
-            'network': (lambda a, b: cmp(a["network"], b["network"])),
-        }
-
-        sql_results.sort(sorts[self.sort])
-        finalEpResults = {}
-
-        # add all requested types or all
-        for curType in self.type:
-            finalEpResults[curType] = []
-
-        # Safety Measure to convert rows in sql_results to dict.
-        # This should not be required as the DB connections should only be returning dict results not sqlite3.row_type
-        dict_results = [dict(row) for row in sql_results]
-
-        for ep in dict_results:
-            """
-                Missed:   yesterday... (less than 1week)
-                Today:    today
-                Soon:     tomorrow till next week
-                Later:    later than next week
-            """
-
-            if ep["paused"] and not self.paused:
-                continue
-
-            ep['airs'] = str(ep['airs']).replace('am', ' AM').replace('pm', ' PM').replace('  ', ' ')
-            dtEpisodeAirs = sbdatetime.sbdatetime.convert_to_setting(
-                network_timezones.parse_date_time(int(ep['airdate']), ep['airs'], ep['network']))
-            ep['airdate'] = dtEpisodeAirs.toordinal()
-
-            status = "soon"
-            if ep["airdate"] < today:
-                status = "missed"
-            elif ep["airdate"] >= next_week:
-                status = "later"
-            elif ep["airdate"] >= today and ep["airdate"] < next_week:
-                if ep["airdate"] == today:
-                    status = "today"
-                else:
-                    status = "soon"
-
-            # skip unwanted
-            if self.type is not None and not status in self.type:
-                continue
-
-            if not ep["network"]:
-                ep["network"] = ""
-
-            ep["quality"] = _get_quality_string(ep["quality"])
-            # clean up tvdb horrible airs field
-            ep['airs'] = sbdatetime.sbdatetime.sbftime(dtEpisodeAirs, t_preset=timeFormat).lstrip('0').replace(' 0',
-                                                                                                               ' ')
-            # start day of the week on 1 (monday)
-            ep['weekday'] = 1 + datetime.date.fromordinal(dtEpisodeAirs.toordinal()).weekday()
-            # Add tvdbid for backward compability
-            ep["tvdbid"] = ep['indexerid']
-            ep['airdate'] = sbdatetime.sbdatetime.sbfdate(dtEpisodeAirs, d_preset=dateFormat)
-
-            # TODO: check if this obsolete
-            if not status in finalEpResults:
-                finalEpResults[status] = []
-
-            finalEpResults[status].append(ep)
-
-        return _responds(RESULT_SUCCESS, finalEpResults)
+        return _responds(RESULT_SUCCESS, data)
 
 
 class CMD_Episode(ApiCall):
@@ -836,7 +755,7 @@ class CMD_Episode(ApiCall):
                                                            d_preset=dateFormat)
         status, quality = Quality.splitCompositeStatus(int(episode["status"]))
         episode["status"] = _get_status_Strings(status)
-        episode["quality"] = _get_quality_string(quality)
+        episode["quality"] = get_quality_string(quality)
         episode["file_size_human"] = _sizeof_fmt(episode["file_size"])
 
         return _responds(RESULT_SUCCESS, episode)
@@ -886,8 +805,8 @@ class CMD_EpisodeSearch(ApiCall):
         if ep_queue_item.success:
             status, quality = Quality.splitCompositeStatus(epObj.status)  # @UnusedVariable
             # TODO: split quality and status?
-            return _responds(RESULT_SUCCESS, {"quality": _get_quality_string(quality)},
-                             "Snatched (" + _get_quality_string(quality) + ")")
+            return _responds(RESULT_SUCCESS, {"quality": get_quality_string(quality)},
+                             "Snatched (" + get_quality_string(quality) + ")")
 
         return _responds(RESULT_FAILURE, msg='Unable to find episode')
 
@@ -1143,7 +1062,7 @@ class CMD_History(ApiCall):
                 continue
 
             row["status"] = status
-            row["quality"] = _get_quality_string(quality)
+            row["quality"] = get_quality_string(quality)
             row["date"] = _historyDate_to_dateTimeForm(str(row["date"]))
 
             del row["action"]
@@ -1917,7 +1836,7 @@ class CMD_Show(ApiCall):
                     genreList.append(genre)
 
         showDict["genre"] = genreList
-        showDict["quality"] = _get_quality_string(showObj.quality)
+        showDict["quality"] = get_quality_string(showObj.quality)
 
         anyQualities, bestQualities = _mapQuality(showObj.quality)
         showDict["quality_details"] = {"initial": anyQualities, "archive": bestQualities}
@@ -2583,7 +2502,7 @@ class CMD_ShowSeasons(ApiCall):
             for row in sqlResults:
                 status, quality = Quality.splitCompositeStatus(int(row["status"]))
                 row["status"] = _get_status_Strings(status)
-                row["quality"] = _get_quality_string(quality)
+                row["quality"] = get_quality_string(quality)
                 dtEpisodeAirs = sbdatetime.sbdatetime.convert_to_setting(
                     network_timezones.parse_date_time(row['airdate'], showObj.airs, showObj.network))
                 row['airdate'] = sbdatetime.sbdatetime.sbfdate(dtEpisodeAirs, d_preset=dateFormat)
@@ -2607,7 +2526,7 @@ class CMD_ShowSeasons(ApiCall):
                 del row["episode"]
                 status, quality = Quality.splitCompositeStatus(int(row["status"]))
                 row["status"] = _get_status_Strings(status)
-                row["quality"] = _get_quality_string(quality)
+                row["quality"] = get_quality_string(quality)
                 dtEpisodeAirs = sbdatetime.sbdatetime.convert_to_setting(
                     network_timezones.parse_date_time(row['airdate'], showObj.airs, showObj.network))
                 row['airdate'] = sbdatetime.sbdatetime.sbfdate(dtEpisodeAirs, d_preset=dateFormat)
@@ -2683,7 +2602,7 @@ class CMD_ShowSetQuality(ApiCall):
         showObj.quality = newQuality
 
         return _responds(RESULT_SUCCESS,
-                         msg=showObj.name + " quality has been changed to " + _get_quality_string(showObj.quality))
+                         msg=showObj.name + " quality has been changed to " + get_quality_string(showObj.quality))
 
 
 class CMD_ShowStats(ApiCall):
@@ -2853,7 +2772,7 @@ class CMD_Shows(ApiCall):
 
             showDict = {
                 "paused": curShow.paused,
-                "quality": _get_quality_string(curShow.quality),
+                "quality": get_quality_string(curShow.quality),
                 "language": curShow.lang,
                 "air_by_date": curShow.air_by_date,
                 "sports": curShow.sports,

--- a/sickbeard/webapi.py
+++ b/sickbeard/webapi.py
@@ -671,7 +671,7 @@ class CMD_ComingEpisodes(ApiCall):
 
     def run(self):
         """ Display the coming episodes """
-        grouped_coming_episodes = ComingEpisodes.get_coming_episodes(self.type, self.sort, self.paused)
+        grouped_coming_episodes = ComingEpisodes.get_coming_episodes(self.type, self.sort, True, self.paused)
         data = {section: [] for section in grouped_coming_episodes.keys()}
 
         for section, coming_episodes in grouped_coming_episodes.iteritems():

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -58,6 +58,7 @@ from sickrage.media.ShowBanner import ShowBanner
 from sickrage.media.ShowFanArt import ShowFanArt
 from sickrage.media.ShowNetworkLogo import ShowNetworkLogo
 from sickrage.media.ShowPoster import ShowPoster
+from sickrage.show.ComingEpisodes import ComingEpisodes
 from sickrage.show.History import History as HistoryTool
 from sickrage.system.Restart import Restart
 from sickrage.system.Shutdown import Shutdown
@@ -498,13 +499,6 @@ class WebRoot(WebHandler):
                 ['?'] * len(qualList)) + ")", [today, recently, WANTED] + qualList)
         sql_results += more_sql_results
 
-        # sort by localtime
-        sorts = {
-            'date': (lambda x, y: cmp(x["localtime"], y["localtime"])),
-            'show': (lambda a, b: cmp((a["show_name"], a["localtime"]), (b["show_name"], b["localtime"]))),
-            'network': (lambda a, b: cmp((a["network"], a["localtime"]), (b["network"], b["localtime"]))),
-        }
-
         # make a dict out of the sql results
         sql_results = [dict(row) for row in sql_results]
 
@@ -514,7 +508,7 @@ class WebRoot(WebHandler):
                 network_timezones.parse_date_time(item['airdate'],
                                                   item['airs'], item['network']))
 
-        sql_results.sort(sorts[sickbeard.COMING_EPS_SORT])
+        sql_results.sort(ComingEpisodes.sorts[sickbeard.COMING_EPS_SORT])
 
         t = PageTemplate(rh=self, file="comingEpisodes.mako")
         # paused_item = { 'title': '', 'path': 'toggleComingEpsDisplayPaused' }
@@ -547,7 +541,7 @@ class WebRoot(WebHandler):
             layout = sickbeard.COMING_EPS_LAYOUT
 
         return t.render(submenu=submenu, next_week=next_week, today=today, sql_results=sql_results, layout=layout,
-                title='Coming Episodes', header='Coming Episodes', topmenu='comingEpisodes')
+                        title='Coming Episodes', header='Coming Episodes', topmenu='comingEpisodes')
 
 
 class CalendarHandler(BaseHandler):

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -35,7 +35,6 @@ from sickbeard import search_queue
 from sickbeard import naming
 from sickbeard import subtitles
 from sickbeard import network_timezones
-from sickbeard import sbdatetime
 from sickbeard.providers import newznab, rsstorrent
 from sickbeard.common import Quality, Overview, statusStrings, qualityPresetStrings, cpu_presets
 from sickbeard.common import SNATCHED, UNAIRED, IGNORED, ARCHIVED, WANTED, FAILED, SKIPPED
@@ -467,72 +466,39 @@ class WebRoot(WebHandler):
 
         return self.redirect("/comingEpisodes/")
 
-    def comingEpisodes(self, layout="None"):
-
-        today1 = datetime.date.today()
-        today = today1.toordinal()
-        next_week1 = (datetime.date.today() + datetime.timedelta(days=7))
-        next_week = next_week1.toordinal()
-        recently = (datetime.date.today() - datetime.timedelta(days=sickbeard.COMING_EPS_MISSED_RANGE)).toordinal()
-
-        done_show_list = []
-        qualList = Quality.DOWNLOADED + Quality.SNATCHED + [ARCHIVED, IGNORED]
-
-        myDB = db.DBConnection()
-        sql_results = myDB.select(
-            "SELECT *, tv_shows.status AS show_status FROM tv_episodes, tv_shows WHERE season != 0 AND airdate >= ? AND airdate < ? AND tv_shows.indexer_id = tv_episodes.showid AND tv_episodes.status NOT IN (" + ','.join(
-                ['?'] * len(qualList)) + ")", [today, next_week] + qualList)
-
-        for cur_result in sql_results:
-            done_show_list.append(int(cur_result["showid"]))
-
-        more_sql_results = myDB.select(
-            "SELECT *, tv_shows.status AS show_status FROM tv_episodes outer_eps, tv_shows WHERE season != 0 AND showid NOT IN (" + ','.join(
-                ['?'] * len(
-                    done_show_list)) + ") AND tv_shows.indexer_id = outer_eps.showid AND airdate = (SELECT airdate FROM tv_episodes inner_eps WHERE inner_eps.season != 0 AND inner_eps.showid = outer_eps.showid AND inner_eps.airdate >= ? ORDER BY inner_eps.airdate ASC LIMIT 1) AND outer_eps.status NOT IN (" + ','.join(
-                ['?'] * len(Quality.DOWNLOADED + Quality.SNATCHED)) + ")",
-            done_show_list + [next_week] + Quality.DOWNLOADED + Quality.SNATCHED)
-        sql_results += more_sql_results
-
-        more_sql_results = myDB.select(
-            "SELECT *, tv_shows.status AS show_status FROM tv_episodes, tv_shows WHERE season != 0 AND tv_shows.indexer_id = tv_episodes.showid AND airdate < ? AND airdate >= ? AND tv_episodes.status = ? AND tv_episodes.status NOT IN (" + ','.join(
-                ['?'] * len(qualList)) + ")", [today, recently, WANTED] + qualList)
-        sql_results += more_sql_results
-
-        # make a dict out of the sql results
-        sql_results = [dict(row) for row in sql_results]
-
-        # add localtime to the dict
-        for index, item in enumerate(sql_results):
-            sql_results[index]['localtime'] = sbdatetime.sbdatetime.convert_to_setting(
-                network_timezones.parse_date_time(item['airdate'],
-                                                  item['airs'], item['network']))
-
-        sql_results.sort(ComingEpisodes.sorts[sickbeard.COMING_EPS_SORT])
-
-        t = PageTemplate(rh=self, file="comingEpisodes.mako")
-        # paused_item = { 'title': '', 'path': 'toggleComingEpsDisplayPaused' }
-        # paused_item['title'] = 'Hide Paused' if sickbeard.COMING_EPS_DISPLAY_PAUSED else 'Show Paused'
-        paused_item = {'title': 'View Paused:', 'path': {'': ''}}
-        paused_item['path'] = {'Hide': 'toggleComingEpsDisplayPaused'} if sickbeard.COMING_EPS_DISPLAY_PAUSED else {
-            'Show': 'toggleComingEpsDisplayPaused'}
-        submenu = [
-            {'title': 'Sort by:', 'path': {'Date': 'setComingEpsSort/?sort=date',
-                                           'Show': 'setComingEpsSort/?sort=show',
-                                           'Network': 'setComingEpsSort/?sort=network',
-            }},
-
-            {'title': 'Layout:', 'path': {'Banner': 'setComingEpsLayout/?layout=banner',
-                                          'Poster': 'setComingEpsLayout/?layout=poster',
-                                          'List': 'setComingEpsLayout/?layout=list',
-                                          'Calendar': 'setComingEpsLayout/?layout=calendar',
-            }},
-            paused_item,
-        ]
-
-        next_week = datetime.datetime.combine(next_week1, datetime.time(tzinfo=network_timezones.sb_timezone))
+    def comingEpisodes(self, layout=None):
+        next_week = datetime.date.today() + datetime.timedelta(days=7)
+        next_week1 = datetime.datetime.combine(next_week, datetime.time(tzinfo=network_timezones.sb_timezone))
+        results = ComingEpisodes.get_coming_episodes(ComingEpisodes.categories, sickbeard.COMING_EPS_SORT, False)
         today = datetime.datetime.now().replace(tzinfo=network_timezones.sb_timezone)
-        sql_results = sql_results
+
+        submenu = [
+            {
+                'title': 'Sort by:',
+                'path': {
+                    'Date': 'setComingEpsSort/?sort=date',
+                    'Show': 'setComingEpsSort/?sort=show',
+                    'Network': 'setComingEpsSort/?sort=network',
+                }
+            },
+            {
+                'title': 'Layout:',
+                'path': {
+                    'Banner': 'setComingEpsLayout/?layout=banner',
+                    'Poster': 'setComingEpsLayout/?layout=poster',
+                    'List': 'setComingEpsLayout/?layout=list',
+                    'Calendar': 'setComingEpsLayout/?layout=calendar',
+                }
+            },
+            {
+                'title': 'View Paused:',
+                'path': {
+                    'Hide': 'toggleComingEpsDisplayPaused'
+                } if sickbeard.COMING_EPS_DISPLAY_PAUSED else {
+                    'Show': 'toggleComingEpsDisplayPaused'
+                }
+            },
+        ]
 
         # Allow local overriding of layout parameter
         if layout and layout in ('poster', 'banner', 'list', 'calendar'):
@@ -540,7 +506,8 @@ class WebRoot(WebHandler):
         else:
             layout = sickbeard.COMING_EPS_LAYOUT
 
-        return t.render(submenu=submenu, next_week=next_week, today=today, sql_results=sql_results, layout=layout,
+        t = PageTemplate(rh=self, file='comingEpisodes.mako')
+        return t.render(submenu=submenu, next_week=next_week1, today=today, results=results, layout=layout,
                         title='Coming Episodes', header='Coming Episodes', topmenu='comingEpisodes')
 
 

--- a/sickrage/helper/common.py
+++ b/sickrage/helper/common.py
@@ -1,0 +1,3 @@
+dateFormat = '%Y-%m-%d'
+dateTimeFormat = '%Y-%m-%d %H:%M:%S'
+timeFormat = '%A %I:%M %p'

--- a/sickrage/helper/quality.py
+++ b/sickrage/helper/quality.py
@@ -1,0 +1,11 @@
+from sickbeard.common import Quality, qualityPresetStrings
+
+
+def get_quality_string(q):
+    if q in qualityPresetStrings:
+        return qualityPresetStrings[q]
+
+    if q in Quality.qualityStrings:
+        return Quality.qualityStrings[q]
+
+    return 'Custom'

--- a/sickrage/helper/quality.py
+++ b/sickrage/helper/quality.py
@@ -1,11 +1,16 @@
 from sickbeard.common import Quality, qualityPresetStrings
 
 
-def get_quality_string(q):
-    if q in qualityPresetStrings:
-        return qualityPresetStrings[q]
+def get_quality_string(quality):
+    """
+    :param quality: The quality to convert into a string
+    :return: The string representation of the provided quality
+    """
 
-    if q in Quality.qualityStrings:
-        return Quality.qualityStrings[q]
+    if quality in qualityPresetStrings:
+        return qualityPresetStrings[quality]
+
+    if quality in Quality.qualityStrings:
+        return Quality.qualityStrings[quality]
 
     return 'Custom'

--- a/sickrage/show/ComingEpisodes.py
+++ b/sickrage/show/ComingEpisodes.py
@@ -1,0 +1,122 @@
+import sickbeard
+
+from datetime import date, timedelta
+from sickbeard.common import IGNORED, Quality, WANTED
+from sickbeard.db import DBConnection
+from sickbeard.network_timezones import parse_date_time
+from sickbeard.sbdatetime import sbdatetime
+from sickrage.helper.common import dateFormat, timeFormat
+from sickrage.helper.quality import get_quality_string
+
+
+class ComingEpisodes:
+    categories = ['later', 'missed', 'soon', 'today']
+    sorts = {
+        'date': (lambda a, b: cmp(a['localtime'], b['localtime'])),
+        'network': (lambda a, b: cmp((a['network'], a['localtime']), (b['network'], b['localtime']))),
+        'show': (lambda a, b: cmp((a['show_name'], a['localtime']), (b['show_name'], b['localtime']))),
+    }
+
+    def __init__(self):
+        pass
+
+    @staticmethod
+    def get_coming_episodes(categories, sort, paused=sickbeard.COMING_EPS_DISPLAY_PAUSED):
+        if not isinstance(categories, list):
+            categories = categories.split('|')
+
+        if sort not in ComingEpisodes.sorts.keys():
+            sort = 'date'
+
+        today = date.today().toordinal()
+        next_week = (date.today() + timedelta(days=7)).toordinal()
+        recently = (date.today() - timedelta(days=sickbeard.COMING_EPS_MISSED_RANGE)).toordinal()
+        qualities_list = Quality.DOWNLOADED + Quality.SNATCHED + Quality.ARCHIVED + [IGNORED]
+
+        fields_to_select = ', '.join(
+            ['airdate', 'airs', 'description', 'episode', 'indexer_id', 'name', 'network', 'paused', 'quality',
+             'season', 'show_name', 'showid', 's.status']
+        )
+        db = DBConnection(row_type='dict')
+        results = db.select(
+            'SELECT %s ' % fields_to_select +
+            'FROM tv_episodes e, tv_shows s '
+            'WHERE season != 0 '
+            'AND airdate >= ? '
+            'AND airdate < ? '
+            'AND s.indexer_id = e.showid '
+            'AND e.status NOT IN (' + ','.join(['?'] * len(qualities_list)) + ')',
+            [today, next_week] + qualities_list
+        )
+
+        done_shows_list = [int(result['showid']) for result in results]
+        placeholder = ','.join(['?'] * len(done_shows_list))
+        placeholder2 = ','.join(['?'] * len(Quality.DOWNLOADED + Quality.SNATCHED))
+
+        results += db.select(
+            'SELECT %s ' % fields_to_select +
+            'FROM tv_episodes e, tv_shows s '
+            'WHERE season != 0 '
+            'AND showid NOT IN (' + placeholder + ') '
+                                                  'AND s.indexer_id = e.showid '
+                                                  'AND airdate = (SELECT airdate '
+                                                  'FROM tv_episodes inner_e '
+                                                  'WHERE inner_e.season != 0 '
+                                                  'AND inner_e.showid = e.showid '
+                                                  'AND inner_e.airdate >= ? '
+                                                  'ORDER BY inner_e.airdate ASC LIMIT 1) '
+                                                  'AND e.status NOT IN (' + placeholder2 + ')',
+            done_shows_list + [next_week] + Quality.DOWNLOADED + Quality.SNATCHED
+        )
+
+        results += db.select(
+            'SELECT %s ' % fields_to_select +
+            'FROM tv_episodes e, tv_shows s '
+            'WHERE season != 0 '
+            'AND s.indexer_id = e.showid '
+            'AND airdate < ? AND airdate >= ? '
+            'AND e.status = ? '
+            'AND e.status NOT IN (' + ','.join(['?'] * len(qualities_list)) + ')',
+            [today, recently, WANTED] + qualities_list
+        )
+
+        for index, item in enumerate(results):
+            results[index]['localtime'] = sbdatetime.convert_to_setting(
+                parse_date_time(int(item['airdate']), item['airs'], item['network']))
+
+        results.sort(ComingEpisodes.sorts[sort])
+
+        grouped_results = {category: [] for category in categories}
+
+        for result in results:
+            if result['paused'] and not paused:
+                continue
+
+            result['airs'] = str(result['airs']).replace('am', ' AM').replace('pm', ' PM').replace('  ', ' ')
+            result['airdate'] = result['localtime'].toordinal()
+
+            if result['airdate'] < today:
+                category = 'missed'
+            elif result['airdate'] >= next_week:
+                category = 'later'
+            elif result['airdate'] == today:
+                category = 'today'
+            else:
+                category = 'soon'
+
+            if len(categories) > 0 and category not in categories:
+                continue
+
+            if not result['network']:
+                result['network'] = ''
+
+            result['quality'] = get_quality_string(result['quality'])
+            result['airs'] = sbdatetime.sbftime(result['localtime'], t_preset=timeFormat).lstrip('0').replace(' 0', ' ')
+            result['weekday'] = 1 + date.fromordinal(result['airdate']).weekday()
+            result['tvdbid'] = result['indexer_id']
+            result['airdate'] = sbdatetime.sbfdate(result['localtime'], d_preset=dateFormat)
+            result['localtime'] = result['localtime'].toordinal()
+
+            grouped_results[category].append(result)
+
+        return grouped_results

--- a/sickrage/show/__init__.py
+++ b/sickrage/show/__init__.py
@@ -1,1 +1,1 @@
-__all__ = ['History']
+__all__ = ['ComingEpisodes', 'History']


### PR DESCRIPTION
I am still working on this PR. But as I found a couple of differences between the API and the web UI, I decided to open this PR to track the changes and see which version is the best and validate the choices.

- Qualities definition:
 - API ([source](https://github.com/SiCKRAGETV/SickRage/blob/v4.0.55/sickbeard/webapi.py#L736)): `qualList = Quality.DOWNLOADED + Quality.SNATCHED + [ARCHIVED, IGNORED]`
 - Web UI ([source](https://github.com/SiCKRAGETV/SickRage/blob/v4.0.55/sickbeard/webserve.py#L499)): `qualList = Quality.DOWNLOADED + Quality.SNATCHED + [ARCHIVED, IGNORED]`
 - Solution: @miigotu confirmed that `Quality.ARCHIVED` should be used (https://github.com/SiCKRAGETV/sickrage-issues/issues/2567#issuecomment-138367874)
- Sorting methods:
 - API ([source](https://github.com/SiCKRAGETV/SickRage/blob/v4.0.55/sickbeard/webapi.py#L759)): only sort by the required field
 - Web UI ([source](https://github.com/SiCKRAGETV/SickRage/blob/v4.0.55/sickbeard/webserve.py#L523)): sort by the required field and then by time
 - Solution: I chose the web UI option. However the `date` sort might need to use `airdate` rather than `localtime`. What do you think?
- Date time format:
 - API: `%Y-%m-%d %H:%M` (for `future` and `show` commands)
 - Web UI: `%Y-%m-%d %H:%M:%S`
 - Solution: Use the Web UI format (`%Y-%m-%d %H:%M:%S`) everywhere (https://github.com/SiCKRAGETV/SickRage/pull/2438#issuecomment-139912848)

The rest of the logic looks similar, except in the SQL queries. The API only select what is needed (at least it looks like it does), while the web UI selects **everything**. I will try to improve that to select only what we need.

https://github.com/SiCKRAGETV/sickrage-issues/issues/2567