### PR TITLE
Restore support for relative, absolute and empty paths

### DIFF
--- a/sickbeard/subtitles.py
+++ b/sickbeard/subtitles.py
@@ -91,6 +91,9 @@ def subtitlesLanguages(video_path):
 
     if sickbeard.SUBTITLES_DIR and ek.ek(os.path.exists, sickbeard.SUBTITLES_DIR):
         video_path = ek.ek(os.path.join, sickbeard.SUBTITLES_DIR, ek.ek(os.path.basename, video_path))
+    # Search subtitles in the relative path
+    if sickbeard.SUBTITLES_DIR:
+        video_path = ek.ek(os.path.join, ek.ek(os.path.dirname, video_path), sickbeard.SUBTITLES_DIR, ek.ek(os.path.basename, video_path))
 
     languages = subliminal.video.scan_subtitle_languages(video_path)
 
@@ -220,6 +223,8 @@ def run_subs_extra_scripts(epObj, foundSubs):
                 subpath = subliminal.subtitle.get_subtitle_path(video.name, sub.language)
                 if sickbeard.SUBTITLES_DIR and ek.ek(os.path.exists, sickbeard.SUBTITLES_DIR):
                     subpath = ek.ek(os.path.join, sickbeard.SUBTITLES_DIR, ek.ek(os.path.basename, subpath))
+                elif sickbeard.SUBTITLES_DIR:
+                    subpath = ek.ek(os.path.join, ek.ek(os.path.dirname, subpath), sickbeard.SUBTITLES_DIR, ek.ek(os.path.basename, subpath))
 
                 inner_cmd = script_cmd + [video.name, subpath, sub.language.opensubtitles, epObj.show.name,
                                          str(epObj.season), str(epObj.episode), epObj.name, str(epObj.show.indexerid)]


### PR DESCRIPTION
This PR restores support for relative paths and includes many little fixes regarding subtitles recognition/download. It has been been tested with all possible variants (relative, absolute and empty paths) for a few days and should be working correctly in all situations.

_What has been done in this PR?_
- Restored support for relative paths
- Subtitles are being correctly recognized in all situations (afaik never really worked for relative paths)
- Subtitles won't be downloaded multiple times (overwritten), if not necessary
- Subtitles in the show directory will be ignored, if the subtitles directory differs from the show directory (this bug affects the current branch with the absolute path)
- Empty SUBTITLES_DIR defaults to /show/season/
- Probably something else that I don't remember now

Some more info about why the relative paths were removed: https://github.com/SiCKRAGETV/sickrage-issues/issues/2071
