### PR TITLE
Fix tntvillage match

### DIFF
--- a/sickbeard/providers/tntvillage.py
+++ b/sickbeard/providers/tntvillage.py
@@ -425,6 +425,17 @@ class TNTVillageProvider(generic.TorrentProvider):
                                     logger.log(u"Subtitled, skipping "  + title + "(" + searchURL + ")", logger.DEBUG)
                                     continue
 
+                                search_show = re.split(r'([Ss][\d{1,2}]+)', search_string)[0]
+                                show_title = search_show
+                                rindex = re.search(r'([Ss][\d{1,2}]+)', title)
+                                if rindex:
+                                    show_title = title[:rindex.start()]
+                                    ep_params = title[rindex.start():]
+                                if show_title.lower() != search_show.lower() and search_show.lower() in show_title.lower():
+                                    new_title = search_show + ep_params
+                                    logger.log(u"WARNING - Changing found title from: " + title + " to: " + new_title, logger.DEBUG)
+                                    title = new_title
+
                                 if self._is_season_pack(title):
                                     title = re.sub(r'([Ee][\d{1,2}\-?]+)', '', title)
 


### PR DESCRIPTION
This commit fix a no-match when episodes are named with
concatenated original and italian serie's name on TntVillage.
i.e. searching for an episode of "The game of thrones" on
TntVillage returns results named "Il trono di spade - Game
of thrones S0XeXX...".
With this fix if the returned show tilte differs from (and
contains the) searched one, the returned title is replaced
with the desired one before continuing the matching process.