### PR TITLE
Trying to fix broken images

### DIFF
--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -381,19 +381,22 @@ class WebRoot(WebHandler):
         return t.render(title="Api Builder", header="Api Builder", sortedShowList=sortedShowList, seasonSQLResults=seasonSQLResults, episodeSQLResults=episodeSQLResults, apikey=apikey)
 
     def showPoster(self, show=None, which=None):
+        media = None
         media_format = ('normal', 'thumb')[which in ('banner_thumb', 'poster_thumb', 'small')]
 
         if which[0:6] == 'banner':
-            return ShowBanner(show, media_format).get_media()
+            media = ShowBanner(show, media_format)
+        elif which[0:6] == 'fanart':
+            media = ShowFanArt(show, media_format)
+        elif which[0:6] == 'poster':
+            media = ShowPoster(show, media_format)
+        elif which[0:7] == 'network':
+            media = ShowNetworkLogo(show, media_format)
 
-        if which[0:6] == 'fanart':
-            return ShowFanArt(show, media_format).get_media()
+        if media is not None:
+            self.set_header('Content-Type', media.get_media_type())
 
-        if which[0:6] == 'poster':
-            return ShowPoster(show, media_format).get_media()
-
-        if which[0:7] == 'network':
-            return ShowNetworkLogo(show).get_media()
+            return media.get_media()
 
         return None
 

--- a/sickrage/media/GenericMedia.py
+++ b/sickrage/media/GenericMedia.py
@@ -1,6 +1,7 @@
 import sickbeard
 
 from abc import abstractmethod
+from mimetypes import guess_type
 from os.path import isfile, join, normpath
 from sickbeard.encodingKludge import ek
 from sickbeard.exceptions import MultipleShowObjectsException
@@ -59,7 +60,19 @@ class GenericMedia:
         :return: The root folder containing the media
         """
 
-        return sickbeard.DATA_DIR + '/gui/slick'
+        return ek(join, sickbeard.DATA_DIR, 'gui', 'slick')
+
+    def get_media_type(self):
+        """
+        :return: The mime type of the current media
+        """
+
+        static_media_path = self.get_static_media_path()
+
+        if ek(isfile, static_media_path):
+            return guess_type(static_media_path)[0]
+
+        return ''
 
     def get_show(self):
         """
@@ -82,6 +95,6 @@ class GenericMedia:
             if ek(isfile, media_path):
                 return normpath(media_path)
 
-        image_path = join(self.get_media_root(), 'images', self.get_default_media_name())
+        image_path = ek(join, self.get_media_root(), 'images', self.get_default_media_name())
 
         return image_path.replace('\\', '/')

--- a/sickrage/media/ShowNetworkLogo.py
+++ b/sickrage/media/ShowNetworkLogo.py
@@ -1,3 +1,5 @@
+from os.path import join
+from sickbeard.encodingKludge import ek
 from sickrage.media.GenericMedia import GenericMedia
 
 
@@ -7,12 +9,12 @@ class ShowNetworkLogo(GenericMedia):
     """
 
     def get_default_media_name(self):
-        return 'network/nonetwork.png'
+        return join('network', 'nonetwork.png')
 
     def get_media_path(self):
         show = self.get_show()
 
         if show:
-            return '%s/images/network/%s.png' % (self.get_media_root(), show.network_logo_name)
+            return ek(join, self.get_media_root(), 'images', 'network', show.network_logo_name + '.png')
 
         return ''


### PR DESCRIPTION
What I changed is:
- Set the `Content-Type` header before returning an image. Now we can see the image in a new tab instead of its content
- Use `os.path.join` to build every images path

I don't have a Windows machine with me now, so if someone can give me a feedback on this, that would be great.