### PR TITLE
Images are binary files

### DIFF
--- a/sickrage/media/GenericMedia.py
+++ b/sickrage/media/GenericMedia.py
@@ -41,7 +41,7 @@ class GenericMedia:
         static_media_path = self.get_static_media_path()
 
         if ek(isfile, static_media_path):
-            with open(static_media_path, 'r') as content:
+            with open(static_media_path, 'rb') as content:
                 return content.read()
 
         return None


### PR DESCRIPTION
As suggested here [here](http://stackoverflow.com/a/3198124/1914223), the `b` mode might be necessary are images are not text files.