### PR TITLE
Fixed loading network logos when using custom data directory

### DIFF
--- a/sickrage/media/GenericMedia.py
+++ b/sickrage/media/GenericMedia.py
@@ -60,7 +60,7 @@ class GenericMedia:
         :return: The root folder containing the media
         """
 
-        return ek(join, sickbeard.DATA_DIR, 'gui', 'slick')
+        return ek(join, sickbeard.PROG_DIR, 'gui', 'slick')
 
     def get_media_type(self):
         """


### PR DESCRIPTION
I noticed this issue after using the Windows installer which uses a custom DATA_DIR.

Issue: https://github.com/SiCKRAGETV/sickrage-issues/issues/2708