### PR TITLE
2789 Create path if not exists

### DIFF
--- a/sickbeard/postProcessor.py
+++ b/sickbeard/postProcessor.py
@@ -337,6 +337,7 @@ class PostProcessor(object):
 
             self._log(u"Moving file from " + cur_file_path + " to " + new_file_path, logger.DEBUG)
             try:
+                helpers.make_dirs(new_file_path)
                 helpers.moveFile(cur_file_path, new_file_path)
                 helpers.chmodAsParent(new_file_path)
             except (IOError, OSError), e:


### PR DESCRIPTION
Issue #2789 fix to create dir(s) when not existing upon manual post processing