### PR TITLE
Update domain name for nxtgn

### DIFF
--- a/sickbeard/providers/nextgen.py
+++ b/sickbeard/providers/nextgen.py
@@ -50,12 +50,12 @@ class NextGenProvider(generic.TorrentProvider):
 
         self.cache = NextGenCache(self)
 
-        self.urls = {'base_url': 'https://nxtgn.org/',
-                'search': 'https://nxtgn.org/browse.php?search=%s&cat=0&incldead=0&modes=%s',
-                'login_page': 'https://nxtgn.org/login.php',
-                'detail': 'https://nxtgn.org/details.php?id=%s',
-                'download': 'https://nxtgn.org/download.php?id=%s',
-                'takelogin': 'https://nxtgn.org/takelogin.php?csrf=',
+        self.urls = {'base_url': 'https://nxgn.org/',
+                'search': 'https://nxgn.org/browse.php?search=%s&cat=0&incldead=0&modes=%s',
+                'login_page': 'https://nxgn.org/login.php',
+                'detail': 'https://nxgn.org/details.php?id=%s',
+                'download': 'https://nxgn.org/download.php?id=%s',
+                'takelogin': 'https://nxgn.org/takelogin.php?csrf=',
                 }
 
         self.url = self.urls['base_url']


### PR DESCRIPTION
Domain changed from nxtgn.org to nxgn.org.. Update all URL references