### PR TITLE
Enhance quality pills

### DIFF
--- a/gui/slick/views/comingEpisodes.mako
+++ b/gui/slick/views/comingEpisodes.mako
@@ -150,7 +150,7 @@
             </td>
 
             <td align="center">
-            ${renderQualityPill(cur_result['quality'])}
+                ${renderQualityPill(cur_result['quality'], showTitle=True)}
             </td>
 
             <td align="center" style="vertical-align: middle;">
@@ -323,7 +323,7 @@
 
                 <div class="clearfix">
                     <span class="title">Quality:</span>
-                ${renderQualityPill(cur_result['quality'])}
+                    ${renderQualityPill(cur_result['quality'], showTitle=True)}
                 </div>
             </td>
         </tr>

--- a/gui/slick/views/home.mako
+++ b/gui/slick/views/home.mako
@@ -245,7 +245,7 @@
                 </td>
 
                 <td class="show-table">
-            ${renderQualityPill(curShow.quality, overrideClass="show-quality")}
+                    ${renderQualityPill(curShow.quality, showTitle=True, overrideClass="show-quality")}
                 </td>
             </tr>
         </table>
@@ -437,7 +437,7 @@
         </td>
     % endif
 
-        <td align="center">${renderQualityPill(curShow.quality)}</td>
+        <td align="center">${renderQualityPill(curShow.quality, showTitle=True)}</td>
 
         <td align="center">
             ## This first span is used for sorting and is never displayed to user

--- a/gui/slick/views/inc_defs.mako
+++ b/gui/slick/views/inc_defs.mako
@@ -1,7 +1,34 @@
 <%!
+    import cgi
     from sickbeard.common import Quality, qualityPresets, qualityPresetStrings
 %>
-<%def name="renderQualityPill(quality, overrideClass=None)"><%
+<%def name="renderQualityPill(quality, showTitle=False, overrideClass=None)"><%
+    iQuality = quality & 0xFFFF
+    pQuality = quality >> 16
+
+    # If initial and preferred qualities are the same, show pill as initial quality
+    if iQuality == pQuality:
+        quality = iQuality
+
+    # Build a string of quality names to use as title attribute
+    if showTitle:
+        iQuality, pQuality = Quality.splitQuality(quality)
+        title = 'Initial Quality:\n'
+        if iQuality:
+            for curQual in iQuality:
+                title += "  " + Quality.qualityStrings[curQual] + "\n"
+        else:
+            title += "  None\n"
+        title += "\nPreferred Quality:\n"
+        if pQuality:
+            for curQual in pQuality:
+                title += "  " + Quality.qualityStrings[curQual] + "\n"
+        else:
+            title += "  None\n"
+        title = ' title="' + cgi.escape(title.rstrip(), True) + '"'
+    else:
+        title = ""
+
     if quality in qualityPresets:
         cssClass = qualityPresetStrings[quality]
         qualityString = qualityPresetStrings[quality]
@@ -20,4 +47,4 @@
     else:
         cssClass = overrideClass
 
-%><span class="${cssClass}">${qualityString}</span></%def>
+%><span${title} class="${cssClass}">${qualityString}</span></%def>

--- a/gui/slick/views/manage.mako
+++ b/gui/slick/views/manage.mako
@@ -163,7 +163,7 @@ $(document).ready(function(){
         <tr>
             <td align="center"><input type="checkbox" class="editCheck" id="edit-${curShow.indexerid}" /></td>
             <td class="tvShow"><a href="${sbRoot}/home/displayShow?show=${curShow.indexerid}">${curShow.name}</a></td>
-            <td align="center">${renderQualityPill(curShow.quality)}</td>
+            <td align="center">${renderQualityPill(curShow.quality, showTitle=True)}</td>
             <td align="center"><img src="${sbRoot}/images/${('no16.png" alt="N"', 'yes16.png" alt="Y"')[int(curShow.is_sports) == 1]} width="16" height="16" /></td>
             <td align="center"><img src="${sbRoot}/images/${('no16.png" alt="N"', 'yes16.png" alt="Y"')[int(curShow.is_scene) == 1]} width="16" height="16" /></td>
             <td align="center"><img src="${sbRoot}/images/${('no16.png" alt="N"', 'yes16.png" alt="Y"')[int(curShow.is_anime) == 1]} width="16" height="16" /></td>


### PR DESCRIPTION
- When the initial and preferred qualities are the same, show the
  quality instead of 'Custom'.
- Where it makes sense, show a title (mouse hover) for the pill showing
  the specific initial and preferred qualities.