### PR TITLE
Alpharatio does not respond to the SSL version

### DIFF
--- a/sickbeard/providers/alpharatio.py
+++ b/sickbeard/providers/alpharatio.py
@@ -53,11 +53,11 @@ class AlphaRatioProvider(generic.TorrentProvider):
 
         self.cache = AlphaRatioCache(self)
 
-        self.urls = {'base_url': 'https://alpharatio.cc/',
-                'login': 'https://alpharatio.cc/login.php',
-                'detail': 'https://alpharatio.cc/torrents.php?torrentid=%s',
-                'search': 'https://alpharatio.cc/torrents.php?searchstr=%s%s',
-                'download': 'https://alpharatio.cc/%s',
+        self.urls = {'base_url': 'http://alpharatio.cc/',
+                'login': 'http://alpharatio.cc/login.php',
+                'detail': 'http://alpharatio.cc/torrents.php?torrentid=%s',
+                'search': 'http://alpharatio.cc/torrents.php?searchstr=%s%s',
+                'download': 'http://alpharatio.cc/%s',
                 }
 
         self.catagories = "&filter_cat[1]=1&filter_cat[2]=1&filter_cat[3]=1&filter_cat[4]=1&filter_cat[5]=1"


### PR DESCRIPTION
Currently alpharatio does not respond on the https:// any more and i'm getting the following error's

```
2015-09-19 22:03:59 ERROR    SEARCHQUEUE-DAILY-SEARCH :: [AlphaRatio] :: Unable to connect to AlphaRatio provider.
AA
AATooManyRedirects: Exceeded 30 redirects.
AA    raise TooManyRedirects('Exceeded %s redirects.' % self.max_redirects)
AA  File "/usr/local/sickrage/var/SickRage/lib/requests/sessions.py", line 114, in resolve_redirects
AA    history = [resp for resp in gen] if allow_redirects else []
AA  File "/usr/local/sickrage/var/SickRage/lib/requests/sessions.py", line 602, in send
AA    resp = self.send(prep, **send_kwargs)
AA  File "/usr/local/sickrage/var/SickRage/lib/requests/sessions.py", line 464, in request
AA    return self.request('POST', url, data=data, json=json, **kwargs)
AA  File "/usr/local/sickrage/var/SickRage/lib/requests/sessions.py", line 507, in post
AA    resp = session.post(url, data=post_data, timeout=timeout, allow_redirects=True, verify=session.verify)
AA  File "/volume1/@appstore/sickrage/var/SickRage/sickbeard/helpers.py", line 1378, in getURL
```