### PR TITLE
Remove leading slash from folders in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,14 @@
 #  SR User Related   #
 ######################
-/cache*/
-/Logs/
-/restore/
-/backup/
+cache*/
+Logs/
+restore/
+backup*/
 cache.db*
 config.ini*
 sickbeard.db*
 failed.db*
-/autoProcessTV/autoProcessTV.cfg
+autoProcessTV.cfg
 server.crt
 server.key
 


### PR DESCRIPTION
autoProcessTV.cfg and SR data dirs cannot be ignored absolutely in the root, since the user might have them set to be in a subdir or the source such as /data/ or /settings/ or /config/ or the like.