### PR TITLE
Change default DATA_DIR to PROG_DIR/data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 #  SR User Related   #
 ######################
 cache*/
+data*/
 Logs/
 restore/
 backup*/
@@ -16,6 +17,7 @@ server.key
 ######################
 /tests/Logs/*
 /tests/cache/*
+/tests/data*/
 /tests/sickbeard.db*
 /tests/cache.db*
 /tests/failed.db

--- a/SickBeard.py
+++ b/SickBeard.py
@@ -142,7 +142,7 @@ class SickRage(object):
         sickbeard.MY_FULLNAME = os.path.normpath(os.path.abspath(__file__))
         sickbeard.MY_NAME = os.path.basename(sickbeard.MY_FULLNAME)
         sickbeard.PROG_DIR = os.path.dirname(sickbeard.MY_FULLNAME)
-        sickbeard.DATA_DIR = sickbeard.PROG_DIR + os.sep + "data"
+        sickbeard.DATA_DIR = os.path.join(sickbeard.PROG_DIR, 'data')
         sickbeard.MY_ARGS = sys.argv[1:]
         sickbeard.SYS_ENCODING = None
 

--- a/SickBeard.py
+++ b/SickBeard.py
@@ -142,7 +142,7 @@ class SickRage(object):
         sickbeard.MY_FULLNAME = os.path.normpath(os.path.abspath(__file__))
         sickbeard.MY_NAME = os.path.basename(sickbeard.MY_FULLNAME)
         sickbeard.PROG_DIR = os.path.dirname(sickbeard.MY_FULLNAME)
-        sickbeard.DATA_DIR = sickbeard.PROG_DIR
+        sickbeard.DATA_DIR = sickbeard.PROG_DIR + os.sep + "data"
         sickbeard.MY_ARGS = sys.argv[1:]
         sickbeard.SYS_ENCODING = None
 

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -648,7 +648,7 @@ def initialize(consoleLogging=True):
         DEFAULT_PAGE = check_setting_str(CFG, 'General', 'default_page', 'home')
 
         ACTUAL_LOG_DIR = check_setting_str(CFG, 'General', 'log_dir', 'Logs')
-        LOG_DIR = os.path.normpath(os.path.join(LOG_DIR, ACTUAL_LOG_DIR))
+        LOG_DIR = os.path.normpath(os.path.join(DATA_DIR, ACTUAL_LOG_DIR))
         LOG_NR = check_setting_int(CFG, 'General', 'log_nr', 5) #Default to 5 backup file (sickrage.log.x)
         LOG_SIZE = check_setting_int(CFG, 'General', 'log_size', 1048576) #Default to max 1MB per logfile
         fileLogging = True

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -648,7 +648,7 @@ def initialize(consoleLogging=True):
         DEFAULT_PAGE = check_setting_str(CFG, 'General', 'default_page', 'home')
 
         ACTUAL_LOG_DIR = check_setting_str(CFG, 'General', 'log_dir', 'Logs')
-        LOG_DIR = os.path.normpath(os.path.join(DATA_DIR, ACTUAL_LOG_DIR))
+        LOG_DIR = os.path.normpath(os.path.join(LOG_DIR, ACTUAL_LOG_DIR))
         LOG_NR = check_setting_int(CFG, 'General', 'log_nr', 5) #Default to 5 backup file (sickrage.log.x)
         LOG_SIZE = check_setting_int(CFG, 'General', 'log_size', 1048576) #Default to max 1MB per logfile
         fileLogging = True
@@ -1622,7 +1622,7 @@ def save_config():
     new_config['General']['config_version'] = CONFIG_VERSION
     new_config['General']['encryption_version'] = int(ENCRYPTION_VERSION)
     new_config['General']['encryption_secret'] = ENCRYPTION_SECRET
-    new_config['General']['log_dir'] = ACTUAL_LOG_DIR if ACTUAL_LOG_DIR else 'Logs'
+    new_config['General']['log_dir'] = ACTUAL_LOG_DIR if ACTUAL_LOG_DIR else 'logs'
     new_config['General']['log_nr'] = int(LOG_NR)
     new_config['General']['log_size'] = int(LOG_SIZE)
     new_config['General']['socket_timeout'] = SOCKET_TIMEOUT


### PR DESCRIPTION
After some discussions in SiCKRAGETV/sickrage-issues#2788 this proposes to change the default DATA_DIR from PROG_DIR to PROG_DIR/data, and adds it to gitignore.

Offcourse, the cmdline switch to specify DATA_DIR is still available, but this way we at least know where user-specific stuff ends up, and we don't have to keep on excluding all kinds of locations. It's all in PROG_DIR/data by default.

Note: Only on new installs!
Also: Previously made backups may not be able to restore, due to changed file locations