### PR TITLE
Fix dailysearch not respecting timezone setting

### DIFF
--- a/sickbeard/dailysearcher.py
+++ b/sickbeard/dailysearcher.py
@@ -27,7 +27,7 @@ from sickbeard import logger
 from sickbeard import db
 from sickbeard import common
 from sickbeard import helpers
-from sickbeard import network_timezones
+from sickbeard import sbdatetime, network_timezones
 from sickrage.helper.exceptions import MultipleShowObjectsException
 
 
@@ -80,9 +80,12 @@ class DailySearcher():
                 continue
 
             try:
-                end_time = network_timezones.parse_date_time(sqlEp['airdate'], show.airs,
-                                                             show.network) + datetime.timedelta(
+                end_time = sbdatetime.sbdatetime.convert_to_setting(network_timezones.parse_date_time(sqlEp['airdate'], show.airs,
+                                                             show.network)) + datetime.timedelta(
                     minutes=helpers.tryInt(show.runtime, 60))
+                #Keep this for future debug
+                #logger.log(u"Show %s ends at %s and now it is %s. Runtime is %s and airs %s" % (show.name, end_time, curTime, show.runtime, show.airs),logger.DEBUG )
+
                 # filter out any episodes that haven't aried yet
                 if end_time > curTime:
                     continue


### PR DESCRIPTION
When local enabled the time that show ends is using network GMT not user local timezone
DAILYSEARCHER :: Show **** ends at 2015-09-24 21:00:00-04:00 and now it is 2015-09-23 10:00:49.733573-03:00. Runtime is 60 and airs Thursday 8:00 PM

with this fix:
DAILYSEARCHER :: Show ***** ends at 2015-09-24 22:00:00-03:00 and now it is 2015-09-23 09:53:19.452325-03:00. Runtime is 60 and airs Thursday 8:00 PM

So in this show. the conversion from UNAIRED > WANTED was delayed 2 hours. User could not notice this error because dailysearch frequency could be high and user don't mind start searching for shows MINUTES after airdate+runtime