### PR TITLE
Show timezone setting in the 'Airdate' column in comingEpisodes

### DIFF
--- a/gui/slick/views/comingEpisodes.mako
+++ b/gui/slick/views/comingEpisodes.mako
@@ -79,7 +79,7 @@
 
     <thead>
         <tr>
-            <th>Airdate</th>
+            <th>Airdate (${('local', 'network')[sickbeard.TIMEZONE_DISPLAY == 'network']})</th>
             <th>Show</th>
             <th nowrap="nowrap">Next Ep</th>
             <th>Next Ep Name</th>


### PR DESCRIPTION
Until we add column widget in comingEpisodes ( https://github.com/SiCKRAGETV/sickrage-issues/issues/2626 ) we should warn user about airdate.

In the future we can add both columns 'Airdate local' and 'Airdate network'