### PR TITLE
Update pkg_resources.py - Sickrage won't start on Openelec and Audo with RPi2 and others.

### DIFF
--- a/lib/pkg_resources.py
+++ b/lib/pkg_resources.py
@@ -218,8 +218,12 @@ def get_build_platform():
     XXX Currently this is the same as ``distutils.util.get_platform()``, but it
     needs some hacks for Linux and Mac OS X.
     """
-    from distutils.util import get_platform
-    plat = get_platform()
+    try:
+        from distutils.util import get_platform
+        plat = get_platform()
+    except ImportError:
+        import platform
+        plat = platform.platform()
     if sys.platform == "darwin" and not plat.startswith('macosx-'):
         try:
             version = _macosx_vers()


### PR DESCRIPTION
Sickrage won't start on Openelec and Audo with RPi2 and others.

See:
http://openelec.tv/forum/80-sabnzbd-suite/78152-unable-to-bring-up-sickrage-page-after-autoupdate?start=45