### PR TITLE
Fix history limit and save on change limit

### DIFF
--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -3496,9 +3496,19 @@ class History(WebRoot):
 
         self.history = HistoryTool()
 
-    def index(self, limit=100):
-        limit = int(limit)
+    def index(self, limit=None):
+    
+        if limit is None:
+            if sickbeard.HISTORY_LIMIT:
+                limit = int(sickbeard.HISTORY_LIMIT)
+            else:
+                limit = 100
+        else:
+            limit = int(limit)
+            
         sickbeard.HISTORY_LIMIT = limit
+        
+        sickbeard.save_config()
 
         compact = []
         data = self.history.get(limit)


### PR DESCRIPTION
This will fix the first loading of history page when you have a history limit <> 100

@duramato