### PR TITLE
Add "srRoot" template variable

### DIFF
--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -115,6 +115,7 @@ class PageTemplate(MakoTemplate):
         super(PageTemplate, self).__init__(*args, **kwargs)
 
         self.arguments['sbRoot'] = sickbeard.WEB_ROOT
+        self.arguments['srRoot'] = sickbeard.WEB_ROOT
         self.arguments['sbHttpPort'] = sickbeard.WEB_PORT
         self.arguments['sbHttpsPort'] = sickbeard.WEB_PORT
         self.arguments['sbHttpsEnabled'] = sickbeard.ENABLE_HTTPS


### PR DESCRIPTION
This add a new template variable `srRoot`.
It is exactly the same as `sbRoot`, but adapted for SickRage.
By having both, we can freely switch the mako files to `srRoot` if we change one, and it shouldn't break anything as both values are available, for now.

Suggested by @OmgImAlexis in https://github.com/SiCKRAGETV/SickRage/pull/2587