### PR TITLE
Use mako global variables instead of calling `sickbeard.*`

### DIFF
--- a/gui/slick/views/config.mako
+++ b/gui/slick/views/config.mako
@@ -59,8 +59,8 @@
     <tr><td class="infoTableHeader">SR Cache Dir:</td><td class="infoTableCell">${sickbeard.CACHE_DIR}</td></tr>
     <tr><td class="infoTableHeader">SR Log Dir:</td><td class="infoTableCell">${sickbeard.LOG_DIR}</td></tr>
     <tr><td class="infoTableHeader">SR Arguments:</td><td class="infoTableCell">${sickbeard.MY_ARGS}</td></tr>
-% if sickbeard.WEB_ROOT:
-    <tr><td class="infoTableHeader">SR Web Root:</td><td class="infoTableCell">${sickbeard.WEB_ROOT}</td></tr>
+% if srRoot:
+    <tr><td class="infoTableHeader">SR Web Root:</td><td class="infoTableCell">${srRoot}</td></tr>
 % endif
     <tr><td class="infoTableHeader">Python Version:</td><td class="infoTableCell">${sys.version[:120]}</td></tr>
     <tr class="infoTableSeperator"><td class="infoTableHeader"><i class="icon16-sb"></i> Homepage</td><td class="infoTableCell"><a href="${anon_url('http://www.sickrage.tv/')}" rel="noreferrer" onclick="window.open(this.href, '_blank'); return false;">http://www.sickrage.tv/</a></td></tr>

--- a/gui/slick/views/config_general.mako
+++ b/gui/slick/views/config_general.mako
@@ -75,11 +75,11 @@
                                 <span class="component-title">Initial page</span>
                                 <span class="component-desc">
                                     <select id="default_page" name="default_page" class="form-control input-sm">
-                                        <option value="news" ${('', 'selected="selected"')[sickbeard.DEFAULT_PAGE == 'news']}>News</option>
-                                        <option value="IRC" ${('', 'selected="selected"')[sickbeard.DEFAULT_PAGE == 'IRC']}>IRC</option>
-                                        <option value="home" ${('', 'selected="selected"')[sickbeard.DEFAULT_PAGE == 'home']}>Shows</option>
-                                        <option value="comingEpisodes" ${('', 'selected="selected"')[sickbeard.DEFAULT_PAGE == 'comingEpisodes']}>Coming Episodes</option>
-                                        <option value="history" ${('', 'selected="selected"')[sickbeard.DEFAULT_PAGE == 'history']}>History</option>
+                                        <option value="news" ${('', 'selected="selected"')[sbDefaultPage == 'news']}>News</option>
+                                        <option value="IRC" ${('', 'selected="selected"')[sbDefaultPage == 'IRC']}>IRC</option>
+                                        <option value="home" ${('', 'selected="selected"')[sbDefaultPage == 'home']}>Shows</option>
+                                        <option value="comingEpisodes" ${('', 'selected="selected"')[sbDefaultPage == 'comingEpisodes']}>Coming Episodes</option>
+                                        <option value="history" ${('', 'selected="selected"')[sbDefaultPage == 'history']}>History</option>
                                     </select>
                                     <span>when launching SickRage interface</span>
                                 </span>
@@ -249,8 +249,8 @@
                                 <span class="component-title">Display theme:</span>
                                 <span class="component-desc">
                                     <select id="theme_name" name="theme_name" class="form-control input-sm">
-                                        <option value="dark" ${('', 'selected="selected"')[sickbeard.THEME_NAME == 'dark']}>Dark</option>
-                                        <option value="light" ${('', 'selected="selected"')[sickbeard.THEME_NAME == 'light']}>Light</option>
+                                        <option value="dark" ${('', 'selected="selected"')[sbThemeName == 'dark']}>Dark</option>
+                                        <option value="light" ${('', 'selected="selected"')[sbThemeName == 'light']}>Light</option>
                                     </select>
                                     <span class="red-text">for appearance to take effect, save then refresh your browser</span>
                                 </span>
@@ -440,7 +440,7 @@
                             <label for="web_port">
                                 <span class="component-title">HTTP port</span>
                                 <span class="component-desc">
-                                    <input type="text" name="web_port" id="web_port" value="${sickbeard.WEB_PORT}" class="form-control input-sm input100" />
+                                    <input type="text" name="web_port" id="web_port" value="${sbHttpPort}" class="form-control input-sm input100" />
                                     <p>web port to browse and access SickRage (default:8081)</p>
                                 </span>
                             </label>
@@ -460,7 +460,7 @@
                             <label for="enable_https">
                                 <span class="component-title">Enable HTTPS</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" name="enable_https" class="enabler" id="enable_https" ${('', 'checked="checked"')[bool(sickbeard.ENABLE_HTTPS)]}/>
+                                    <input type="checkbox" name="enable_https" class="enabler" id="enable_https" ${('', 'checked="checked"')[bool(sbHttpsEnabled)]}/>
                                     <p>enable access to the web interface using a HTTPS address</p>
                                 </span>
                             </label>
@@ -490,7 +490,7 @@
                             <label for="handle_reverse_proxy">
                                 <span class="component-title">Reverse proxy headers</span>
                                 <span class="component-desc">
-                                    <input type="checkbox" name="handle_reverse_proxy" id="handle_reverse_proxy" ${('', 'checked="checked"')[bool(sickbeard.HANDLE_REVERSE_PROXY)]}/>
+                                    <input type="checkbox" name="handle_reverse_proxy" id="handle_reverse_proxy" ${('', 'checked="checked"')[bool(sbHandleReverseProxy)]}/>
                                     <p>accept the following reverse proxy headers (advanced)...<br />(X-Forwarded-For, X-Forwarded-Host, and X-Forwarded-Proto)</p>
                                 </span>
                             </label>

--- a/gui/slick/views/layouts/main.mako
+++ b/gui/slick/views/layouts/main.mako
@@ -15,9 +15,6 @@
     except ImportError:
         has_resource_module = False
 %>
-<%
-    srRoot = sickbeard.WEB_ROOT
-%>
 <!DOCTYPE html>
 <html>
     <head>
@@ -27,9 +24,9 @@
         <meta name="viewport" content="width=device-width">
 
         <!-- These values come from css/dark.css and css/light.css -->
-        % if sickbeard.THEME_NAME == "dark":
+        % if sbThemeName == "dark":
         <meta name="theme-color" content="#15528F">
-        % elif sickbeard.THEME_NAME == "light":
+        % elif sbThemeName == "light":
         <meta name="theme-color" content="#333333">
         % endif
 
@@ -67,7 +64,7 @@
         <link rel="stylesheet" type="text/css" href="${srRoot}/css/lib/jquery-ui-1.10.4.custom.min.css?${sbPID}" />
         <link rel="stylesheet" type="text/css" href="${srRoot}/css/lib/jquery.qtip-2.2.1.min.css?${sbPID}"/>
         <link rel="stylesheet" type="text/css" href="${srRoot}/css/style.css?${sbPID}"/>
-        <link rel="stylesheet" type="text/css" href="${srRoot}/css/${sickbeard.THEME_NAME}.css?${sbPID}" />
+        <link rel="stylesheet" type="text/css" href="${srRoot}/css/${sbThemeName}.css?${sbPID}" />
         <link rel="stylesheet" type="text/css" href="${srRoot}/css/print.css?${sbPID}" />
         % if sbLogin:
         <link rel="stylesheet" type="text/css" href="${srRoot}/css/lib/pnotify.custom.min.css?${sbPID}" />
@@ -126,7 +123,7 @@
                             % if sickbeard.USE_EMBY and sickbeard.EMBY_HOST != "" and sickbeard.EMBY_APIKEY != "":
                                 <li><a href="${srRoot}/home/updateEMBY/"><i class="menu-icon-backlog-view"></i>&nbsp;Update Emby</a></li>
                             % endif
-                            % if sickbeard.USE_TORRENTS and sickbeard.TORRENT_METHOD != 'blackhole' and (sickbeard.ENABLE_HTTPS and sickbeard.TORRENT_HOST[:5] == 'https' or not sickbeard.ENABLE_HTTPS and sickbeard.TORRENT_HOST[:5] == 'http:'):
+                            % if sickbeard.USE_TORRENTS and sickbeard.TORRENT_METHOD != 'blackhole' and (sbHttpsEnabled and sickbeard.TORRENT_HOST[:5] == 'https' or not sbHttpsEnabled and sickbeard.TORRENT_HOST[:5] == 'http:'):
                                 <li><a href="${srRoot}/manage/manageTorrents/"><i class="menu-icon-bittorrent"></i>&nbsp;Manage Torrents</a></li>
                             % endif
                             % if sickbeard.USE_FAILED_DOWNLOADS:
@@ -309,7 +306,7 @@
             srRoot = '${srRoot}'; // needed for browser.js & ajaxNotifications.js
             //HTML for scrolltopcontrol, which is auto wrapped in DIV w/ ID="topcontrol"
             top_image_html = '<img src="${srRoot}/images/top.gif" width="31" height="11" alt="Jump to top" />';
-            themeSpinner = '${('', '-dark')[sickbeard.THEME_NAME == 'dark']}';
+            themeSpinner = '${('', '-dark')[sbThemeName == 'dark']}';
             anonURL = '${sickbeard.ANON_REDIRECT}';
         </script>
         <script type="text/javascript" src="${srRoot}/js/lib/jquery.scrolltopcontrol-1.1.js"></script>


### PR DESCRIPTION
Some global mako/template variables were defined in `webserve`.
This PR use them instead of calling `sickbeard.*` directly.