### PR TITLE
sbRoot is no longer used anywhere

### DIFF
--- a/gui/slick/views/config_general.mako
+++ b/gui/slick/views/config_general.mako
@@ -401,7 +401,7 @@
                                     <input class="btn btn-inline" type="button" id="generate_new_apikey" value="Generate">
                                     <div class="clear-left">
                                         <p>used to give 3rd party programs limited access to SickRage</p>
-                                        <p>you can try all the features of the API <a href="${sbRoot}/apibuilder/">here</a></p>
+                                        <p>you can try all the features of the API <a href="${srRoot}/apibuilder/">here</a></p>
                                     </div>
                                 </span>
                             </label>

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -115,7 +115,6 @@ class PageTemplate(MakoTemplate):
 
         super(PageTemplate, self).__init__(*args, **kwargs)
 
-        self.arguments['sbRoot'] = sickbeard.WEB_ROOT
         self.arguments['srRoot'] = sickbeard.WEB_ROOT
         self.arguments['sbHttpPort'] = sickbeard.WEB_PORT
         self.arguments['sbHttpsPort'] = sickbeard.WEB_PORT


### PR DESCRIPTION
@OmgImAlexis switched from `sbRoot` to `srRoot` in all the mako and JS files in https://github.com/SiCKRAGETV/SickRage/pull/2615.
So this removed `sbRoot`.