### PR TITLE
Fix urlsearch

### DIFF
--- a/sickbeard/providers/xthor.py
+++ b/sickbeard/providers/xthor.py
@@ -47,7 +47,7 @@ class XthorProvider(generic.TorrentProvider):
         self.cj = cookielib.CookieJar()
 
         self.url = "https://xthor.bz"
-        self.urlsearch = "https://xthor.bz/browse.php?search=\"%s%s\""
+        self.urlsearch = "https://xthor.bz/browse.php?search=\"%s\"%s"
         self.categories = "&searchin=title&incldead=0"
 
         self.enabled = False


### PR DESCRIPTION
urlsearch was malformed, turning quesrystring into :
?search="<search>&searchin=title&incldead=0"

instead of search="<search>"&searchin=title&incldead=0