### PR TITLE
Convert "Shows" back into a submenu

### DIFF
--- a/gui/slick/views/layouts/main.mako
+++ b/gui/slick/views/layouts/main.mako
@@ -98,8 +98,13 @@
                         <li id="NAVirc" ${('', 'class="active"')[topmenu == 'irc']}>
                             <a href="${srRoot}/IRC/">IRC</a>
                         </li>
-                        <li id="NAVhome" ${('', 'class="active"')[topmenu == 'home']}>
-                            <a href="${srRoot}/home/">Shows</a>
+                        <li id="NAVhome" class="dropdown ${('', 'active')[topmenu == 'home']}">
+                            <a href="${srRoot}/home/" class="dropdown-toggle disabled" data-toggle="dropdown">Shows <b class="caret"></b></a>
+                            <ul class="dropdown-menu">
+                                <li><a href="${srRoot}/home/"><i class="menu-icon-home"></i>&nbsp;Show List</a></li>
+                                <li><a href="${srRoot}/home/addShows/"><i class="menu-icon-addshow"></i>&nbsp;Add Shows</a></li>
+                                <li><a href="${srRoot}/home/postprocess/"><i class="menu-icon-postprocess"></i>&nbsp;Manual Post-Processing</a></li>
+                            </ul>
                         </li>
 
                         <li id="NAVcomingEpisodes" ${('', 'class="active"')[topmenu == 'comingEpisodes']}>

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -2139,7 +2139,7 @@ class HomePostProcess(Home):
 
     def index(self):
         t = PageTemplate(rh=self, file="home_postprocess.mako")
-        return t.render(submenu=self.HomeMenu(), title='Post Processing', header='Post Processing')
+        return t.render(submenu=self.HomeMenu(), title='Post Processing', header='Post Processing', topmenu='home')
 
     def processEpisode(self, dir=None, nzbName=None, jobName=None, quiet=None, process_method=None, force=None,
                        is_priority=None, delete_on="0", failed="0", type="auto", *args, **kwargs):
@@ -2183,7 +2183,7 @@ class HomeAddShows(Home):
 
     def index(self):
         t = PageTemplate(rh=self, file="home_addShows.mako")
-        return t.render(submenu=self.HomeMenu(), title='Add Shows', header='Add Shows')
+        return t.render(submenu=self.HomeMenu(), title='Add Shows', header='Add Shows', topmenu='home')
 
     def getIndexerLanguages(self):
         result = sickbeard.indexerApi().config['valid_languages']
@@ -2352,7 +2352,7 @@ class HomeAddShows(Home):
                 use_provided_info=use_provided_info, default_show_name=default_show_name, other_shows=other_shows,
                 provided_show_dir=show_dir, provided_indexer_id=provided_indexer_id, provided_indexer_name=provided_indexer_name,
                 provided_indexer=provided_indexer, indexers=sickbeard.indexerApi().indexers, whitelist=[], blacklist=[], groups=[],
-                title='New Show', header='New Show'
+                title='New Show', header='New Show', topmenu='home'
         )
 
     def recommendedShows(self):
@@ -2473,7 +2473,7 @@ class HomeAddShows(Home):
         except Exception as e:
             popular_shows = None
 
-        return t.render(title="Popular Shows", header="Popular Shows", submenu = self.HomeMenu(), popular_shows=popular_shows, imdb_exception=e)
+        return t.render(title="Popular Shows", header="Popular Shows", submenu = self.HomeMenu(), popular_shows=popular_shows, imdb_exception=e, topmenu="home")
 
 
     def addShowToBlacklist(self, indexer_id):


### PR DESCRIPTION
cf3aabb975a6a41c195b4fb0bcb9a07e25b96c30 removed the "Shows" submenu. I think it adds value. For example, quick access to post processing, which I do fairly frequently. My shows page takes a couple seconds to load so it's annoying to have to navigate there, wait a few seconds and then click the button.

I don't think there is a down side to adding the submenu back. I've added the "disabled" class to the menu so if you click "Shows" it will take you to the show list just like before.

This PR also highlights the "Shows" link when on the Add Shows and Post Processing pages.