### PR TITLE
Make the "Select Columns" buttons consistent

### DIFF
--- a/gui/slick/views/displayShow.mako
+++ b/gui/slick/views/displayShow.mako
@@ -260,7 +260,7 @@
             <label for="snatched"><span class="snatched"><input type="checkbox" id="snatched"checked="checked" /> Snatched: <b>${epCounts[Overview.SNATCHED]}</b></span></label>
         </div>
 
-        <button id="popover" type="button" class="btn btn-xs">Select Columns</button>
+        <button id="popover" type="button" class="btn btn-xs">Select Columns <b class="caret"></b></button>
         <div class="pull-right" >
             <button class="btn btn-xs seriesCheck">Select Filtered Episodes</button>
             <button class="btn btn-xs clearAll">Clear All</button>

--- a/gui/slick/views/home.mako
+++ b/gui/slick/views/home.mako
@@ -65,7 +65,7 @@
 
 <div id="HomeLayout" class="pull-right hidden-print" style="margin-top: -40px;">
     % if layout != 'poster':
-        <button id="popover" type="button" class="btn btn-inline">Select Column <b class="caret"></b></button>
+        <button id="popover" type="button" class="btn btn-inline">Select Columns <b class="caret"></b></button>
     % endif
     <span> Layout:
         <select name="layout" class="form-control form-control-inline input-sm" onchange="location = this.options[this.selectedIndex].value;">


### PR DESCRIPTION
- Add 's' to Column on Shows (home) page.
- Add dropdown arrow to button on displayShow page.