### PR TITLE
Fix Chrome rendering issue on episode status page

### DIFF
--- a/gui/slick/views/manage_episodeStatuses.mako
+++ b/gui/slick/views/manage_episodeStatuses.mako
@@ -86,6 +86,7 @@ Set checked shows/episodes to <select name="newStatus" class="form-control form-
         <th colspan="2" style="width: 100%; text-align: left;"><a class="whitelink" href="${srRoot}/home/displayShow?show=${cur_indexer_id}">${show_names[cur_indexer_id]}</a> (${ep_counts[cur_indexer_id]}) <input type="button" class="pull-right get_more_eps btn" id="${cur_indexer_id}" value="Expand" /></th>
     </tr>
     % endfor
+    <tr><td style="padding:0;"></td><td style="padding:0;"></td><td style="padding:0;"></td></tr>
 </table>
 </form>
 


### PR DESCRIPTION
This fixes an issue on Chrome when you expand a show and then collapse
it again. Adds a dummy row with 3 columns. Chrome seems to have an
issue with colspan and then hiding rows to where there aren't enough
columns to span.