### PR TITLE
Removed unused code

### DIFF
--- a/gui/slick/js/script.js
+++ b/gui/slick/js/script.js
@@ -3,79 +3,15 @@ var srRoot = getMeta('srRoot'),
     anonURL = getMeta('anonURL'),
     top_image_html = '<img src="' + srRoot + '/images/top.gif" width="31" height="11" alt="Jump to top" />';
 
-function initHeader() {
-    //settings
-    var header = $("#header");
-    var fadeSpeed = 100, fadeTo = 0.8, topDistance = 20;
-    var topbarME = function () {
-        $(header).fadeTo(fadeSpeed, 1);
-    }, topbarML = function () {
-        $(header).fadeTo(fadeSpeed, fadeTo);
-    };
-    var inside = false;
-    //do
-    $(window).scroll(function () {
-        position = $(window).scrollTop();
-        if (position > topDistance && !inside) {
-            //add events
-            topbarML();
-            $(header).bind('mouseenter', topbarME);
-            $(header).bind('mouseleave', topbarML);
-            inside = true;
-        }
-        else if (position < topDistance) {
-            topbarME();
-            $(header).unbind('mouseenter', topbarME);
-            $(header).unbind('mouseleave', topbarML);
-            inside = false;
-        }
-    });
-}
-
-
-function showMsg(msg, loader, timeout, ms) {
-    var feedback = $("#ajaxMsg");
-    update = $("#updatebar");
-    if (update.is(":visible")) {
-        var height = update.height() + 35;
-        feedback.css("bottom", height + "px");
-    } else {
-        feedback.removeAttr("style");
-    }
-    feedback.fadeIn();
-    var tmpMessage = $("<div class='msg'>" + msg + "</div>");
-    var message = loader ? $("<div class='msg'><img src='interfaces/default/images/loader_black.gif' alt='loading' class='loader' style='position: relative;top:10px;margin-top:-15px; margin-left:-10px;'/>" + msg + "</div>") : tmpMessage;
-    if (loader) feedback.css("padding", "14px 10px");
-    $(feedback).prepend(message);
-    if (timeout) {
-        setTimeout(function () {
-            message.fadeOut(function () {
-                $(this).remove();
-                feedback.fadeOut();
-            });
-        }, ms);
-    }
-}
-
-function resetFilters(text) {
-    if ($(".dataTables_filter").length > 0) $(".dataTables_filter input").attr("placeholder", "filter " + text + "");
-}
-
-function initTabs() {
+$(document).ready(function () {
     $("#config-components").tabs({
         activate: function (event, ui) {
+            var lastOpenedPanel = $(this).data("lastOpenedPanel"),
+                selected = $(this).tabs('option', 'selected');
 
-            var lastOpenedPanel = $(this).data("lastOpenedPanel");
-            var selected = $(this).tabs('option', 'selected');
+            if (!lastOpenedPanel) lastOpenedPanel = $(ui.oldPanel);
 
-            if (lastOpenedPanel) {
-            } else {
-                lastOpenedPanel = $(ui.oldPanel);
-            }
-
-            if (!$(this).data("topPositionTab")) {
-                $(this).data("topPositionTab", $(ui.newPanel).position().top);
-            }
+            if (!$(this).data("topPositionTab")) $(this).data("topPositionTab", $(ui.newPanel).position().top);
 
             //Dont use the builtin fx effects. This will fade in/out both tabs, we dont want that
             //Fadein the new tab yourself
@@ -98,14 +34,9 @@ function initTabs() {
 
             //Saving the last tab has been opened
             $(this).data("lastOpenedPanel", $(ui.newPanel));
-
         }
-
     });
-}
-$(document).ready(function () {
-    initHeader();
-    initTabs();
+
     $('.dropdown-toggle').dropdownHover();
     if(metaToBool('sickbeard.FUZZY_DATING')){
         $.timeago.settings.allowFuture = true;


### PR DESCRIPTION
`initHeader();` hasn't been used since the old SickBeard and I'm sure of that since it uses `$("#header");` and we use Bootstap's `nav` setup.

Also moved `initTabs();` out of a function and into the `$(document).ready(function () {});` since it only ever gets run once and only inside of that file.