### PR TITLE
Fix bug causing redownload of download episode if quality is below th…

### DIFF
--- a/sickbeard/searchBacklog.py
+++ b/sickbeard/searchBacklog.py
@@ -155,16 +155,22 @@ class BacklogSearcher:
 
             if bestQualities:
                 highestBestQuality = max(bestQualities)
+                lowestBestQuality = min(bestQualities)
             else:
                 highestBestQuality = 0
+                lowestBestQuality=0
+
 
             # if we need a better one then say yes
             if (curStatus in (common.DOWNLOADED, common.SNATCHED, common.SNATCHED_PROPER) and curQuality < highestBestQuality) or curStatus == common.WANTED:
                 epObj = show.getEpisode(int(result["season"]), int(result["episode"]))
-                if epObj.season not in wanted:
-                    wanted[epObj.season] = [epObj]
-                else:
-                    wanted[epObj.season].append(epObj)
+
+                # only fetch if not archive on first match, or if show is lowest than the lower expected quality
+                if(epObj.show.archive_firstmatch == 0 or curQuality < lowestBestQuality):
+                    if epObj.season not in wanted:
+                        wanted[epObj.season] = [epObj]
+                    else:
+                        wanted[epObj.season].append(epObj)
 
         return wanted
 


### PR DESCRIPTION
…e highest possible quality (even if archive on first match).

In theory downloaded episode in "good enough quality" should be automatically archived, however this change prevent episode to be redownloaded if they're still in downloaded.