### PR TITLE
Temp patch tpb kat

### DIFF
--- a/sickbeard/providers/kat.py
+++ b/sickbeard/providers/kat.py
@@ -2,7 +2,7 @@
 # Author: Mr_Orange <mr_orange@hotmail.it>
 # URL: http://code.google.com/p/sickbeard/
 #
-# This file is part of SickRage. 
+# This file is part of SickRage.
 #
 # SickRage is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -23,6 +23,7 @@ import traceback
 import re
 import datetime
 import xmltodict
+from urllib import urlencode
 
 import sickbeard
 from sickbeard import logger
@@ -85,7 +86,9 @@ class KATProvider(generic.TorrentProvider):
                     logger.log(u"Search string: %s" % search_string, logger.DEBUG)
 
                 try:
-                    data = self.getURL(self.urls[('search', 'rss')[mode == 'RSS']], params=self.search_params)
+                    stupidURL = self.urls[('search', 'rss')[mode == 'RSS']] + '?' + urlencode(self.search_params)
+                    data = self.getURL(stupidURL)
+                    #data = self.getURL(self.urls[('search', 'rss')[mode == 'RSS']], params=self.search_params)
                     if not data:
                         logger.log("No data returned from provider", logger.DEBUG)
                         continue

--- a/sickbeard/providers/thepiratebay.py
+++ b/sickbeard/providers/thepiratebay.py
@@ -1,7 +1,7 @@
 # Author: Mr_Orange <mr_orange@hotmail.it>
 # URL: http://code.google.com/p/sickbeard/
 #
-# This file is part of SickRage. 
+# This file is part of SickRage.
 #
 # SickRage is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -20,6 +20,7 @@ from __future__ import with_statement
 
 import re
 import datetime
+from urllib import urlencode
 
 import sickbeard
 from sickbeard.providers import generic
@@ -89,7 +90,9 @@ class ThePirateBayProvider(generic.TorrentProvider):
                 if mode != 'RSS':
                     logger.log(u"Search string: " + search_string, logger.DEBUG)
 
-                data = self.getURL(self.urls[('search', 'rss')[mode == 'RSS']], params=self.search_params)
+                stupidURL = self.urls[('search', 'rss')[mode == 'RSS']] + '?' + urlencode(self.search_params)
+                data = self.getURL(stupidURL)
+                #data = self.getURL(self.urls[('search', 'rss')[mode == 'RSS']], params=self.search_params)
                 if not data:
                     continue
 

--- a/tests/all_tests.py
+++ b/tests/all_tests.py
@@ -30,7 +30,7 @@ import unittest
 
 class AllTests(unittest.TestCase):
     #Block issue_submitter_tests to avoid issue tracker spam on every build
-    blacklist = [tests_dir + 'all_tests.py', tests_dir + 'issue_submitter_tests.py']
+    blacklist = [tests_dir + 'all_tests.py', tests_dir + 'issue_submitter_tests.py', tests_dir + 'search_tests.py']
     def setUp(self):
         self.test_file_strings = [ x for x in glob.glob(tests_dir + '*_tests.py') if not x in self.blacklist ]
         self.module_strings = [file_string[len(tests_dir):len(file_string) - 3] for file_string in self.test_file_strings]

--- a/tests/all_tests.py
+++ b/tests/all_tests.py
@@ -18,14 +18,15 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage.  If not, see <http://www.gnu.org/licenses/>.
 
-import glob
-import unittest
 import sys, os.path
 
 tests_dir=os.path.abspath(__file__)[:-len(os.path.basename(__file__))]
 
 sys.path.insert(1, os.path.join(tests_dir, '../lib'))
 sys.path.insert(1, os.path.join(tests_dir, '..'))
+
+import glob
+import unittest
 
 class AllTests(unittest.TestCase):
     #Block issue_submitter_tests to avoid issue tracker spam on every build

--- a/tests/common_tests.py
+++ b/tests/common_tests.py
@@ -1,10 +1,10 @@
-import unittest
-
 import sys
 import os.path
 
 sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '../lib')))
 sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import unittest
 
 from sickbeard import common
 

--- a/tests/config_tests.py
+++ b/tests/config_tests.py
@@ -1,10 +1,10 @@
-import unittest
-
 import sys
 import os.path
 
 sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '../lib')))
 sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import unittest
 
 from sickbeard import config
 

--- a/tests/encoding_tests.py
+++ b/tests/encoding_tests.py
@@ -1,11 +1,12 @@
 # coding=utf-8
 
-import locale
-import unittest
 import sys, os.path
 
 sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '../lib')))
 sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import locale
+import unittest
 
 import sickbeard
 from sickbeard.helpers import sanitizeFileName

--- a/tests/feedparser_tests.py
+++ b/tests/feedparser_tests.py
@@ -1,9 +1,10 @@
-import unittest
 import sys, os.path
-import test_lib as test
 
 sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '../lib')))
 sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import unittest
+import test_lib as test
 
 from sickbeard.rssfeeds import RSSFeeds
 from sickbeard.tvcache import TVCache

--- a/tests/issue_submitter_tests.py
+++ b/tests/issue_submitter_tests.py
@@ -19,15 +19,15 @@
 
 from __future__ import with_statement
 
-import unittest
 import sys, os.path
-
-from sickbeard import logger
-from sickrage.helper.exceptions import ex
 
 sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '../lib')))
 sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
+import unittest
+
+from sickbeard import logger
+from sickrage.helper.exceptions import ex
 
 def error():
     try:

--- a/tests/name_parser_tests.py
+++ b/tests/name_parser_tests.py
@@ -1,11 +1,11 @@
-import datetime
-import unittest
-import test_lib as test
-
 import sys, os.path
 sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '../lib')))
 sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
+import datetime
+import unittest
+
+import test_lib as test
 from sickbeard.name_parser import parser
 
 import sickbeard
@@ -31,7 +31,7 @@ simple_test_cases = {
               'Show.Name.S06E01.Other.WEB-DL': parser.ParseResult(None, 'Show Name', 6, [1], 'Other.WEB-DL' ),
               'Show.Name.S06E01 Some-Stuff Here': parser.ParseResult(None, 'Show Name', 6, [1], 'Some-Stuff Here' ),
               },
-              
+
               'fov': {
               'Show_Name.1x02.Source_Quality_Etc-Group': parser.ParseResult(None, 'Show Name', 1, [2], 'Source_Quality_Etc', 'Group'),
               'Show Name 1x02': parser.ParseResult(None, 'Show Name', 1, [2]),
@@ -52,7 +52,7 @@ simple_test_cases = {
               'Show Name - S01E02 - S01E03 - S01E04 - Ep Name': parser.ParseResult(None, 'Show Name', 1, [2,3,4], 'Ep Name'),
               'Show.Name.S01E02.S01E03.WEB-DL': parser.ParseResult(None, 'Show Name', 1, [2,3], 'WEB-DL'),
               },
-              
+
               'fov_repeat': {
               'Show.Name.1x02.1x03.Source.Quality.Etc-Group': parser.ParseResult(None, 'Show Name', 1, [2,3], 'Source.Quality.Etc', 'Group'),
               'Show.Name.1x02.1x03': parser.ParseResult(None, 'Show Name', 1, [2,3]),
@@ -68,12 +68,12 @@ simple_test_cases = {
               'the.event.401.hdtv-lol': parser.ParseResult(None, 'the event', 4, [1], 'hdtv', 'lol'),
               'show.name.2010.special.hdtv-blah': None,
               },
-              
+
               'stupid': {
               'tpz-abc102': parser.ParseResult(None, None, 1, [2], None, 'tpz'),
               'tpz-abc.102': parser.ParseResult(None, None, 1, [2], None, 'tpz'),
               },
-              
+
               'no_season': {
               'Show Name - 01 - Ep Name': parser.ParseResult(None, 'Show Name', None, [1], 'Ep Name'),
               '01 - Ep Name': parser.ParseResult(None, None, None, [1], 'Ep Name'),
@@ -101,7 +101,7 @@ simple_test_cases = {
               'Show Name Season 2': parser.ParseResult(None, 'Show Name', 2),
               'Season 02': parser.ParseResult(None, None, 2),
               },
-              
+
               'scene_date_format': {
               'Show.Name.2010.11.23.Source.Quality.Etc-Group': parser.ParseResult(None, 'Show Name', None, [], 'Source.Quality.Etc', 'Group', datetime.date(2010,11,23)),
               'Show Name - 2010.11.23': parser.ParseResult(None, 'Show Name', air_date = datetime.date(2010,11,23)),
@@ -116,7 +116,7 @@ combination_test_cases = [
                           ('/test/path/to/Season 02/03 - Ep Name.avi',
                            parser.ParseResult(None, None, 2, [3], 'Ep Name'),
                            ['no_season', 'season_only']),
-                          
+
                           ('Show.Name.S02.Source.Quality.Etc-Group/tpz-sn203.avi',
                            parser.ParseResult(None, 'Show Name', 2, [3], 'Source.Quality.Etc', 'Group'),
                            ['stupid', 'season_only']),
@@ -124,11 +124,11 @@ combination_test_cases = [
                           ('MythBusters.S08E16.720p.HDTV.x264-aAF/aaf-mb.s08e16.720p.mkv',
                            parser.ParseResult(None, 'MythBusters', 8, [16], '720p.HDTV.x264', 'aAF'),
                            ['standard']),
-                           
+
                           ('/home/drop/storage/TV/Terminator The Sarah Connor Chronicles/Season 2/S02E06 The Tower is Tall, But the Fall is Short.mkv',
                            parser.ParseResult(None, None, 2, [6], 'The Tower is Tall, But the Fall is Short'),
                            ['standard']),
-                           
+
                           (r'/Test/TV/Jimmy Fallon/Season 2/Jimmy Fallon - 2010-12-15 - blah.avi',
                            parser.ParseResult(None, 'Jimmy Fallon', extra_info = 'blah', air_date = datetime.date(2010,12,15)),
                            ['scene_date_format']),
@@ -136,11 +136,11 @@ combination_test_cases = [
                           (r'/X/30 Rock/Season 4/30 Rock - 4x22 -.avi',
                            parser.ParseResult(None, '30 Rock', 4, [22]),
                            ['fov']),
-                           
+
                           ('Season 2\\Show Name - 03-04 - Ep Name.ext',
                            parser.ParseResult(None, 'Show Name', 2, [3,4], extra_info = 'Ep Name'),
                            ['no_season', 'season_only']),
-                           
+
                           ('Season 02\\03-04-05 - Ep Name.ext',
                            parser.ParseResult(None, None, 2, [3,4,5], extra_info = 'Ep Name'),
                            ['no_season', 'season_only']),
@@ -159,7 +159,7 @@ failure_cases = ['7sins-jfcs01e09-720p-bluray-x264']
 
 
 class UnicodeTests(test.SickbeardTestDBCase):
-    
+
     def _test_unicode(self, name, result):
         np = parser.NameParser(True)
 
@@ -170,47 +170,47 @@ class UnicodeTests(test.SickbeardTestDBCase):
 
         # this shouldn't raise an exception
         a = repr(str(parse_result))
-    
+
     def test_unicode(self):
         for (name, result) in unicode_test_cases:
             self._test_unicode(name, result)
 
 class FailureCaseTests(test.SickbeardTestDBCase):
-    
+
     def _test_name(self, name):
         np = parser.NameParser(True)
         try:
             parse_result = np.parse(name)
         except (parser.InvalidNameException, parser.InvalidShowException):
             return True
-        
+
         if VERBOSE:
             print 'Actual: ', parse_result.which_regex, parse_result
         return False
-    
+
     def test_failures(self):
         for name in failure_cases:
             self.assertTrue(self._test_name(name))
 
 class ComboTests(test.SickbeardTestDBCase):
-    
+
     def _test_combo(self, name, result, which_regexes):
-        
+
         if VERBOSE:
             print
-            print 'Testing', name 
-        
+            print 'Testing', name
+
         np = parser.NameParser(True)
 
         try:
             test_result = np.parse(name)
         except parser.InvalidShowException:
             return False
-        
+
         if DEBUG:
             print test_result, test_result.which_regex
             print result, which_regexes
-            
+
 
         self.assertEqual(test_result, result)
         for cur_regex in which_regexes:
@@ -218,7 +218,7 @@ class ComboTests(test.SickbeardTestDBCase):
         self.assertEqual(len(which_regexes), len(test_result.which_regex))
 
     def test_combos(self):
-        
+
         for (name, result, which_regexes) in combination_test_cases:
             # Normalise the paths. Converts UNIX-style paths into Windows-style
             # paths when test is run on Windows.
@@ -245,7 +245,7 @@ class BasicTests(test.SickbeardTestDBCase):
                 return
             else:
                 test_result = np.parse(cur_test)
-            
+
             if DEBUG or verbose:
                 print 'air_by_date:', test_result.is_air_by_date, 'air_date:', test_result.air_date
                 print 'anime:', test_result.is_anime, 'ab_episode_numbers:', test_result.ab_episode_numbers

--- a/tests/pp_tests.py
+++ b/tests/pp_tests.py
@@ -17,14 +17,14 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage.  If not, see <http://www.gnu.org/licenses/>.
 
+import sys, os.path
+sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '../lib')))
+sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
 import random
 import unittest
 
 import test_lib as test
-
-import sys, os.path
-sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '../lib')))
-sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from sickbeard.postProcessor import PostProcessor
 import sickbeard

--- a/tests/scene_helpers_tests.py
+++ b/tests/scene_helpers_tests.py
@@ -1,10 +1,10 @@
-import unittest
-import test_lib as test
-
 import sys, os.path
 sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '../lib')))
 sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
+import unittest
+
+import test_lib as test
 from sickbeard import show_name_helpers, scene_exceptions, common, name_cache
 
 import sickbeard

--- a/tests/search_tests.py
+++ b/tests/search_tests.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python2.7
+# coding=UTF-8
+# Author: Dennis Lutter <lad1337@gmail.com>
+# URL: http://code.google.com/p/sickbeard/
+#
+# This file is part of SickRage.
+#
+# SickRage is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# SickRage is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with SickRage.  If not, see <http://www.gnu.org/licenses/>.
+
+import sys, os.path
+sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '../lib')))
+sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import random
+import unittest
+
+import test_lib as test
+
+import sickbeard.search as search
+import sickbeard
+from sickbeard.tv import TVEpisode, TVShow
+import sickbeard.common as c
+
+from sickbeard.providers.generic import GenericProvider
+
+tests = {"Game of Thrones":
+               {"tvdbid": 121361, "s": 5, "e": [10],
+                "s_strings": [{"Season": [u"Game of Thrones S05"]}],
+                "e_strings": [{"Episode": [u"Game of Thrones S05E10"]}]}}
+
+class SearchTest(test.SickbeardTestDBCase):
+
+    def __init__(self, something):
+        super(SearchTest, self).__init__(something)
+
+
+def test_generator(curData, name, provider, forceSearch):
+
+    def test(self):
+        show = TVShow(1, int(curData["tvdbid"]))
+        show.name = name
+        show.quality = c.ANY | c.Quality.UNKNOWN | c.Quality.RAWHDTV
+        show.saveToDB()
+        sickbeard.showList.append(show)
+
+        for epNumber in curData["e"]:
+            episode = TVEpisode(show, curData["s"], epNumber)
+            episode.status = c.WANTED
+
+            # We arent updating scene numbers, so fake it here
+            episode.scene_season = curData["s"]
+            episode.scene_episode = epNumber
+
+            episode.saveToDB()
+
+            provider.show = show
+            season_strings = provider._get_season_search_strings(episode)
+            episode_strings = provider._get_episode_search_strings(episode)
+
+            fail = False
+            for cur_string in season_strings, episode_strings:
+                if not all([isinstance(cur_string, list), isinstance(cur_string[0], dict)]):
+                    print " %s is using a wrong string format!" % provider.name
+                    print cur_string
+                    fail = True
+                    continue
+
+            if fail:
+                continue
+
+            try:
+                assert(season_strings == curData["s_strings"])
+                assert(episode_strings == curData["e_strings"])
+            except AssertionError:
+                print " %s is using a wrong string format!" % provider.name
+                print cur_string
+                continue
+
+            search_strings = episode_strings[0]
+            #search_strings.update(season_strings[0])
+            #search_strings.update({"RSS":['']})
+
+            #print search_strings
+
+            if not provider.public:
+                continue
+
+            items = provider._doSearch(search_strings)
+            if not items:
+                print "No results from provider?"
+                continue
+
+            title, url = provider._get_title_and_url(items[0])
+            for word in show.name.split(" "):
+                if not word in title:
+                    print "Show name not in title: %s" % title
+                    continue
+
+            if not url:
+                print "url is empty"
+                continue
+
+            quality = provider.getQuality(items[0])
+            size = provider._get_size(items[0])
+            if not show.quality & quality:
+                print "Quality not in common.ANY, %r" % quality
+                continue
+
+    return test
+
+if __name__ == '__main__':
+    print "=================="
+    print "STARTING - Search TESTS"
+    print "=================="
+    print "######################################################################"
+    # create the test methods
+    for forceSearch in (True, False):
+        for name, curData in tests.items():
+            fname = name.replace(' ', '_')
+
+            for provider in sickbeard.providers.sortedProviderList():
+                if provider.providerType == GenericProvider.TORRENT:
+                    if forceSearch:
+                        test_name = 'test_manual_%s_%s_%s' % (fname, curData["tvdbid"], provider.name)
+                    else:
+                        test_name = 'test_%s_%s_%s' % (fname, curData["tvdbid"], provider.name)
+                    test = test_generator(curData, name, provider, forceSearch)
+                    setattr(SearchTest, test_name, test)
+
+    suite = unittest.TestLoader().loadTestsFromTestCase(SearchTest)
+    unittest.TextTestRunner(verbosity=2).run(suite)

--- a/tests/snatch_tests.py
+++ b/tests/snatch_tests.py
@@ -17,14 +17,14 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage.  If not, see <http://www.gnu.org/licenses/>.
 
+import sys, os.path
+sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '../lib')))
+sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
 import random
 import unittest
 
 import test_lib as test
-
-import sys, os.path
-sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '../lib')))
-sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 import sickbeard.search as search
 import sickbeard

--- a/tests/ssl_sni_tests.py
+++ b/tests/ssl_sni_tests.py
@@ -17,12 +17,13 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage.  If not, see <http://www.gnu.org/licenses/>.
 
-import unittest
 import sys, os.path
 sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '../lib')))
 sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
+import unittest
 import requests
+
 import sickbeard.providers as providers
 import certifi
 from sickrage.helper.exceptions import ex

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -19,13 +19,13 @@
 
 from __future__ import with_statement
 
-import unittest
-from configobj import ConfigObj
-
 import sys, os.path
 sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '../lib')))
 sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
+import unittest
+
+from configobj import ConfigObj
 import sickbeard
 
 from sickbeard import providers, tvcache

--- a/tests/torrent_tests.py
+++ b/tests/torrent_tests.py
@@ -19,11 +19,11 @@
 
 from __future__ import with_statement
 
-import unittest
-
 import sys, os.path
 sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '../lib')))
 sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import unittest
 
 import urlparse
 import test_lib as test

--- a/tests/tv_tests.py
+++ b/tests/tv_tests.py
@@ -17,12 +17,13 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage.  If not, see <http://www.gnu.org/licenses/>.
 
-import unittest
-import test_lib as test
-
 import sys, os.path
 sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '../lib')))
 sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import unittest
+
+import test_lib as test
 
 import sickbeard
 from sickbeard.tv import TVEpisode, TVShow

--- a/tests/xem_tests.py
+++ b/tests/xem_tests.py
@@ -19,13 +19,13 @@
 
 from __future__ import with_statement
 
-import unittest
-import datetime
-import re
-
 import sys, os.path
 sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '../lib')))
 sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import datetime
+import unittest
+import re
 
 import test_lib as test
 import sickbeard


### PR DESCRIPTION
Moved imports below path insertion in unit tests so they can be run standalone.
Use urlencode for kat and tpb so they can be used with proxy until the new proxy system is in place.
Add the beginnings of a unit test to check uniformity among providers and search failures.