### PR TITLE
etree.ElementTree was failing to set the <id> correctly because we we…

### DIFF
--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -93,20 +93,17 @@ def indentXML(elem, level=0):
     '''
     Does our pretty printing, makes Matt very happy
     '''
-    i = "\n" + level * "  "
+    i = "\n" + level*"  "
     if len(elem):
         if not elem.text or not elem.text.strip():
             elem.text = i + "  "
         if not elem.tail or not elem.tail.strip():
             elem.tail = i
         for elem in elem:
-            indentXML(elem, level + 1)
+            indentXML(elem, level+1)
         if not elem.tail or not elem.tail.strip():
             elem.tail = i
     else:
-        # Strip out the newlines from text
-        if elem.text:
-            elem.text = elem.text.replace('\n', ' ')
         if level and (not elem.tail or not elem.tail.strip()):
             elem.tail = i
 

--- a/sickbeard/metadata/generic.py
+++ b/sickbeard/metadata/generic.py
@@ -292,9 +292,8 @@ class GenericMetadata:
                 indexerid = showXML.find('id')
 
                 root = showXML.getroot()
-
-                if indexerid:
-                    indexerid.text = show_obj.indexerid
+                if indexerid is not None:
+                    indexerid.text = str(show_obj.indexerid)
                 else:
                     etree.SubElement(root, "id").text = str(show_obj.indexerid)
 


### PR DESCRIPTION
…re passing it an int, and because newlines were tampered with in the indentXML.

Should Fixes SiCKRAGETV/sickrage-issues/issues/3208