### PR TITLE
fix typo : downloadURL should be download_url

### DIFF
--- a/sickbeard/providers/xthor.py
+++ b/sickbeard/providers/xthor.py
@@ -2,7 +2,7 @@
 # Author: adaur <adaur.underground@gmail.com>
 # URL: http://code.google.com/p/sickbeard/
 #
-# This file is part of SickRage. 
+# This file is part of SickRage.
 #
 # SickRage is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -112,15 +112,15 @@ class XthorProvider(generic.TorrentProvider):
                             link = row.find("a",href=re.compile("details.php"))
                             if link:
                                 title = link.text
-                                downloadURL =  self.url + '/' + row.find("a",href=re.compile("download.php"))['href']
+                                download_url =  self.url + '/' + row.find("a",href=re.compile("download.php"))['href']
                                 #FIXME
                                 size = -1
                                 seeders = 1
                                 leechers = 0
-        
+
                                 if not all([title, download_url]):
                                     continue
-            
+
                                 #Filter unseeded torrent
                                 #if seeders < self.minseed or leechers < self.minleech:
                                 #    if mode != 'RSS':


### PR DESCRIPTION
Error log was :

AA
AANameError: global name 'download_url' is not defined
AA    if not all([title, download_url]):
AA  File "/Applications/SickRage/sickbeard/providers/xthor.py", line 121, in _doSearch
AA    itemList += self._doSearch(curString, search_mode, len(episodes), epObj=epObj)
AA  File "/Applications/SickRage/sickbeard/providers/generic.py", line 352, in findSearchResults
AA    searchResults = curProvider.findSearchResults(show, episodes, search_mode, manualSearch, downCurQuality)
AA  File "/Applications/SickRage/sickbeard/search.py", line 488, in searchProviders
2015-10-09 19:59:34 DEBUG    SEARCHQUEUE-MANUAL-281620 :: [Xthor] :: Traceback (most recent call last):
AANameError: global name 'download_url' is not defined
AA    if not all([title, download_url]):
AA  File "/Applications/SickRage/sickbeard/providers/xthor.py", line 121, in _doSearch
AA    itemList += self._doSearch(curString, search_mode, len(episodes), epObj=epObj)
AA  File "/Applications/SickRage/sickbeard/providers/generic.py", line 352, in findSearchResults
AA    searchResults = curProvider.findSearchResults(show, episodes, search_mode, manualSearch, downCurQuality)
AA  File "/Applications/SickRage/sickbeard/search.py", line 488, in searchProviders
AATraceback (most recent call last):
2015-10-09 19:59:34 ERROR    SEARCHQUEUE-MANUAL-281620 :: [Xthor] :: Error while searching Xthor, skipping: global name 'download_url' is not defined