### PR TITLE
Fixed a corner case issue where scene exceptions can't be found for some animes

### DIFF
--- a/sickbeard/scene_exceptions.py
+++ b/sickbeard/scene_exceptions.py
@@ -309,7 +309,7 @@ def _xem_exceptions_fetcher():
         for indexer in sickbeard.indexerApi().indexers:
             logger.log(u"Checking for XEM scene exception updates for " + sickbeard.indexerApi(indexer).name)
 
-            url = "http://thexem.de/map/allNames?origin=%s&seasonNumbers=1&language=us" % sickbeard.indexerApi(indexer).config[
+            url = "http://thexem.de/map/allNames?origin=%s&seasonNumbers=1" % sickbeard.indexerApi(indexer).config[
                 'xem_origin']
 
             parsedJSON = helpers.getURL(url, session=xem_session, timeout = 90, json=True)

--- a/sickbeard/show_name_helpers.py
+++ b/sickbeard/show_name_helpers.py
@@ -248,6 +248,9 @@ def makeSceneSearchString(show, ep_obj):
                     if len(ep_obj.show.release_groups.whitelist) > 0:
                         for keyword in ep_obj.show.release_groups.whitelist:
                             toReturn.append(keyword + '.' + curShow + '.' + curEpString)
+                    elif len(ep_obj.show.release_groups.blacklist) == 0:
+                        # If we have neither whitelist or blacklist we just append what we have
+                        toReturn.append(curShow + '.' + curEpString)
             else:
                 toReturn.append(curShow + '.' + curEpString)
 


### PR DESCRIPTION
This fixes an issue I had with the second season of the anime show Utawarerumono. It was a two part issue.

Firstly on XEM the show does not have an english name listed, so the allNames call to xem would not get Utawarerumono season 2 name in the result. I spoke with the XEM team about it and their opinion was that it was correct for the show to not have an english name in this instance. So I removed the language=us portion of the url so all shows will be returned.

So now it found the exceptions, but now the next problem was that the exceptions would not get added to the episode search. Upon stepping through what was happening I saw that in makeSceneSearchString() it would just skip adding a name for an episode if the whitelist is empty for it. In my case SickRage won't find any groups or anything for Utawarerumono and I hand't manually added any whitelists, so it just fell through.

So the second thing I added was that if both the the whitelist is empty and the blacklists are empty as well then it will add the name it has already built, otherwise it will fall through like it did before.
If SickRage would get the groups 100% of the time I assume this second change would not be needed, but it seems to happen from time to time and it would help to make it a bit more robust.

Steps to reproduce would be:
Add Utawarerumono as an anime show with Scene Numbering checked.
Now search for episode one of season 2 and it will not find an episode due to the XEM language issue.
For the second part this hinges on if it has managed to populate the group list or not. As of today my server has managed to populate the group list in the end, but previously this was not the case.