### PR TITLE
Fix tokyotoshokan

### DIFF
--- a/sickbeard/providers/tokyotoshokan.py
+++ b/sickbeard/providers/tokyotoshokan.py
@@ -104,10 +104,10 @@ class TokyoToshokanProvider(generic.TorrentProvider):
                             continue
 
                         #Filter unseeded torrent
-                        if seeders < self.minseed or leechers < self.minleech:
-                            if mode != 'RSS':
-                                logger.log(u"Discarding torrent because it doesn't meet the minimum seeders or leechers: {0} (S:{1} L:{2})".format(title, seeders, leechers), logger.DEBUG)
-                            continue
+                        #if seeders < self.minseed or leechers < self.minleech:
+                        #    if mode != 'RSS':
+                        #        logger.log(u"Discarding torrent because it doesn't meet the minimum seeders or leechers: {0} (S:{1} L:{2})".format(title, seeders, leechers), logger.DEBUG)
+                        #    continue
 
                         item = title, download_url, size, seeders, leechers
 


### PR DESCRIPTION
@miigotu we can't add minseed and minleecher in init because it will show in the provider settings and we don't parse. So no point asking user a setting that will override with seeders =1 and leechers =0
I comment because when we add 'mode' and parse those, we only need to uncomment