### PR TITLE
Anime: Added leading zero search string for single digit episode numbers

### DIFF
--- a/sickbeard/providers/generic.py
+++ b/sickbeard/providers/generic.py
@@ -603,7 +603,13 @@ class TorrentProvider(GenericProvider):
                 ep_string += str(ep_obj.airdate).replace('-', '|') + '|' + \
                         ep_obj.airdate.strftime('%b')
             elif ep_obj.show.anime:
-                ep_string += "%i" % int(ep_obj.scene_absolute_number)
+                scene_number = int(ep_obj.scene_absolute_number)
+                # If the episode number is 1-9 we add a leading zero since the episode number usually starts with a 0
+                # in that case so we search for both variations to maximize our results
+                if scene_number < 10:
+                    ep_string_leading_zero = "%s0%i" % (ep_string, scene_number)
+                    search_string['Episode'].append(ep_string_leading_zero)
+                ep_string += "%i" % scene_number
             else:
                 ep_string += sickbeard.config.naming_ep_type[2] % {'seasonnumber': ep_obj.scene_season,
                                                               'episodenumber': ep_obj.scene_episode}


### PR DESCRIPTION
I noticed that SickRage cannot find episodes for shows in for example NyaaTorrents if the episode number is 1-9.
An example i used is Lucifer comet. Currently sickrage will generate the url http://www.nyaa.se/?sort=2&term=Comet+Lucifer+1&cats=1_0&page=rss&order=1 for this show. And as you can see that returns no results.
So I made it add an additional search string when the episode scene number is single digit so it will still use the old search string as well as the following one http://www.nyaa.se/?sort=2&term=Comet+Lucifer+01&cats=1_0&page=rss&order=1 which gives all results.
I left the original search string since not all groups use a leading zero.