### PR TITLE
Fix more log messages and reduce quantity

### DIFF
--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -723,7 +723,7 @@ class TVShow(object):
                 newStatus = None
 
                 # if it was snatched and now exists then set the status correctly
-                if (oldStatus == SNATCHED and oldQuality <= newQuality) or (oldStatus == SNATCHED_PROPER and oldQuality <= newQuality):
+                if (oldStatus == SNATCHED and oldQuality <= newQuality) or (oldStatus == SNATCHED_PROPER and oldQuality < newQuality):
                     newStatus = DOWNLOADED
 
                 elif oldStatus not in (SNATCHED, SNATCHED_PROPER):


### PR DESCRIPTION
Remove some duplicate code/logs while fixing some log message. Will reduce one log message per new file found.

2015-10-11 12:04:23 INFO     SHOWQUEUE-REFRESH :: Show * S02E02 used to be Skipped but a file exists with quality 720p HDTV so I'm setting the status to Downloaded (720p HDTV)

@miigotu can you check line 729? Ok? Tested with some new files and it's working ok! As log above


In the future we should check if ARCHIVE FIRST MATCH is enabled and instead of `newStatus = DOWNLOADED` we should set 'newStatus = ARCHIVED'  - but I didn't fully thinked about this