### PR TITLE
Lower words while comparing with title

### DIFF
--- a/tests/search_tests.py
+++ b/tests/search_tests.py
@@ -103,8 +103,8 @@ def test_generator(curData, name, provider, forceSearch):
 
             title, url = provider._get_title_and_url(items[0])
             for word in show.name.split(" "):
-                if not word in title:
-                    print "Show name not in title: %s" % title
+                if not word.lower() in title.lower():
+                    print "Show name not in title: %s. URL: %s" % (title, url)
                     continue
 
             if not url:


### PR DESCRIPTION
Fix when this happens


test_manual_*_of_Thrones_121361_KickAssTorrents (__main__.SearchTest) ... Show name not in title: *.Of.Thrones.S05E10.FRENCH.REPACK.LD.WEB-DL.XviD.SVR.avi. URL: magnet:?xt=urn:btih:7D4C9A9AEA6EE5031F6A797421B080650037543F&dn=*+of+thrones+s05e10+french+repack+ld+web+dl+xvid+svr+avi&tr=udp%3A%2F%2Ftracker.publicbt.com%2Fannounce&tr=udp%3A%2F%2Fopen.demonii.com%3A1337
