### PR TITLE
WIP - Enable direct link to tabs

### DIFF
--- a/gui/slick/views/config_general.mako
+++ b/gui/slick/views/config_general.mako
@@ -36,12 +36,12 @@
             <div id="config-components">
 
                 <ul>
-                    <li><a href="#core-component-group1">Misc</a></li>
-                    <li><a href="#core-component-group2">Interface</a></li>
-                    <li><a href="#core-component-group3">Advanced Settings</a></li>
+                    <li><a href="#Misc">Misc</a></li>
+                    <li><a href="#Interface">Interface</a></li>
+                    <li><a href="#Advanced-Settings">Advanced Settings</a></li>
                 </ul>
 
-                <div id="core-component-group1">
+                <div id="Misc">
                 <div class="component-group">
 
                     <div class="component-group-desc">
@@ -234,7 +234,7 @@
                 </div><!-- /component-group1 //-->
 
 
-                <div id="core-component-group2">
+                <div id="Interface">
                 <div class="component-group">
 
                     <div class="component-group-desc">
@@ -504,7 +504,7 @@
                 </div>
 
 
-                <div id="core-component-group3" class="component-group">
+                <div id="Advanced-Settings" class="component-group">
 
                 <div class="component-group">
 


### PR DESCRIPTION
@OmgImAlexis What else should I change so when user changes tab, the URL gets updated with the #..... like 

`localhost:8081/config/general#Advanced-Settings`

with this we can go to direct tabs instead of going to general and them go to Advances for example (and we can give this kinds of links to users)

when page reloads it should stay in the same tab (will it work this way?)