### PR TITLE
Make Edit Show page style consistent with other UI.

### DIFF
--- a/gui/slick/views/editShow.mako
+++ b/gui/slick/views/editShow.mako
@@ -71,6 +71,15 @@
                         </div>
 
                         <div class="field-pair">
+                            <label for="">
+                                <span class="component-title">Archive on first match</span>
+                                <span class="component-desc">
+                                    <input type="checkbox" id="archive_firstmatch" name="archive_firstmatch" ${('', 'checked="checked"')[show.archive_firstmatch == 1]} /> archive episode after the first best match is found from your archive quality list
+                                </span>
+                            </label>
+                        </div>
+
+                        <div class="field-pair">
                             <label for="defaultEpStatusSelect">
                                 <span class="component-title">Default Episode Status</span>
                                 <span class="component-desc">
@@ -189,15 +198,6 @@
                 <div class="component-group">
                     <h3>Advanced Settings</h3>
                     <fieldset class="component-group-list">
-
-                        <div class="field-pair">
-                            <label for="">
-                                <span class="component-title">Archive on first match</span>
-                                <span class="component-desc">
-                                    <input type="checkbox" id="archive_firstmatch" name="archive_firstmatch" ${('', 'checked="checked"')[show.archive_firstmatch == 1]} /> archive episode after the first best match is found from your archive quality list
-                                </span>
-                            </label>
-                        </div>
 
                         <div class="field-pair">
                             <label for="rls_ignore_words">

--- a/gui/slick/views/editShow.mako
+++ b/gui/slick/views/editShow.mako
@@ -8,17 +8,20 @@
     from sickrage.helper import exceptions
     from sickbeard import scene_exceptions
 %>
+
 <%block name="metas">
 <meta data-var="show.is_anime" data-content="${show.is_anime}">
 </%block>
+
 <%block name="scripts">
-<script type="text/javascript" src="${srRoot}/js/qualityChooser.js?${sbPID}"></script>
-<script type="text/javascript" src="${srRoot}/js/lib/bootstrap-formhelpers.min-2.3.0.js?${sbPID}"></script>
-<script type="text/javascript" src="${srRoot}/js/new/editShow.js"></script>
+    <script type="text/javascript" src="${srRoot}/js/qualityChooser.js?${sbPID}"></script>
+    <script type="text/javascript" src="${srRoot}/js/lib/bootstrap-formhelpers.min-2.3.0.js?${sbPID}"></script>
+    <script type="text/javascript" src="${srRoot}/js/new/editShow.js"></script>
 % if show.is_anime:
     <script type="text/javascript" src="${srRoot}/js/blackwhite.js?${sbPID}"></script>
 % endif
 </%block>
+
 <%block name="content">
 % if not header is UNDEFINED:
     <h1 class="header">${header}</h1>
@@ -26,117 +29,229 @@
     <h1 class="title">${title}</h1>
 % endif
 
-<div id="editShow">
-<form action="editShow" method="post">
-<input type="hidden" name="show" value="${show.indexerid}" />
-<b>Location:</b></br>
-<input type="text" name="location" id="location" value="${show._location}" class="form-control form-control-inline input-sm input350" /><br />
-<br />
+<div id="config">
 
-<b>Scene Exception:</b><br />
-<input type="text" id="SceneName" class="form-control form-control-inline input-sm input200">
-<input class="btn btn-inline" type="button" value="Add" id="addSceneName"><br />
-This will <b>affect the episode show search</b> on nzb and torrent provider.<br />
-        This list overrides the original name, it doesn't append to it.<br />
+    <div id="config-content">
+        <form action="editShow" method="post">
 
-<div id="SceneException" >
-    <div class="pull-left" style="text-align:center;">
-        <h4>Exceptions List</h4>
-        <select id="exceptions_list" name="exceptions_list" multiple="multiple" style="min-width:10em;" >
-                % for cur_exception in show.exceptions:
-                    <option value="${cur_exception}">${cur_exception}</option>
-                % endfor
-        </select>
-        <div>
-            <input id="removeSceneName" value="Remove" class="btn float-left" type="button" style="margin-top: 10px;"/>
+        <div id="config-components">
+            <ul>
+                <li><a href="#core-component-group1">Main</a></li>
+                <li><a href="#core-component-group2">Format</a></li>
+                <li><a href="#core-component-group3">Advanced</a></li>
+            </ul>
+
+            <div id="core-component-group1">
+                <div class="component-group">
+                    <h3>Main Settings</h3>
+                    <fieldset class="component-group-list">
+                        
+                        <div class="field-pair">
+                            <label for="location">
+                                <span class="component-title">Show Location</span>
+                                <span class="component-desc">
+                                    <input type="hidden" name="show" value="${show.indexerid}" />
+                                    <input type="text" name="location" id="location" value="${show._location}" class="form-control form-control-inline input-sm input350" />
+                                </span>
+                            </label>
+                        </div>
+
+                        <div class="field-pair">
+                            <label for="qualityPreset">
+                                <span class="component-title">Preferred Quality</span>
+                                <span class="component-desc">
+                                    <%
+                                        qualities = common.Quality.splitQuality(int(show.quality))
+                                        anyQualities = qualities[0]
+                                        bestQualities = qualities[1]
+                                    %>
+                                    <%include file="/inc_qualityChooser.mako"/>
+                                </span>
+                            </label>
+                        </div>
+
+                        <div class="field-pair">
+                            <label for="defaultEpStatusSelect">
+                                <span class="component-title">Default Episode Status</span>
+                                <span class="component-desc">
+                                    <select name="defaultEpStatus" id="defaultEpStatusSelect" class="form-control form-control-inline input-sm">
+                                        % for curStatus in [WANTED, SKIPPED, IGNORED]:
+                                        <option value="${curStatus}" ${('', 'selected="selected"')[curStatus == show.default_ep_status]}>${statusStrings[curStatus]}</option>
+                                        % endfor
+                                    </select>
+                                    <div class="clear-left"><p>This will set the status for future episodes.</p></div>
+                                </span>
+                            </label>
+                        </div>
+
+                        <div class="field-pair">
+                            <label for="indexerLangSelect">
+                                <span class="component-title">Info Language</span>
+                                <span class="component-desc">
+                                    <select name="indexerLang" id="indexerLangSelect" class="form-control form-control-inline input-sm bfh-languages" data-language="${show.lang}" data-available="${','.join(sickbeard.indexerApi().config['valid_languages'])}"></select>
+                                    <div class="clear-left"><p>This only applies to episode filenames and the contents of metadata files.</p></div>
+                                </span>
+                            </label>
+                        </div>
+
+                        <div class="field-pair">
+                            <label for="subtitles">
+                                <span class="component-title">Subtitles</span>
+                                <span class="component-desc">
+                                    <input type="checkbox" id="subtitles" name="subtitles" ${('', 'checked="checked"')[show.subtitles == 1 and sickbeard.USE_SUBTITLES == True]} ${('disabled="disabled"', '')[bool(sickbeard.USE_SUBTITLES)]}/> search for subtitles
+                                </span>
+                            </label>
+                        </div>
+
+                        <div class="field-pair">
+                            <label for="paused">
+                                <span class="component-title">Paused</span>
+                                <span class="component-desc">
+                                    <input type="checkbox" id="paused" name="paused" ${('', 'checked="checked"')[show.paused == 1]} /> pause this show (SickRage will not download episodes)
+                                </span>
+                            </label>
+                        </div>
+
+                    </fieldset>
+                </div>
+            </div>
+
+            <div id="core-component-group2">
+                <div class="component-group">
+                    <h3>Format Settings</h3>
+                    <fieldset class="component-group-list">
+
+                        <div class="field-pair">
+                            <label for="airbydate">
+                                <span class="component-title">Air by date</span>
+                                <span class="component-desc">
+                                    <input type="checkbox" id="airbydate" name="air_by_date" ${('', 'checked="checked"')[show.air_by_date == 1]} /> check if the show is released as Show.03.02.2010 rather than Show.S02E03.<br />
+                                    <span style="color:red">In case of an air date conflict between regular and special episodes, the later will be ignored.</span>
+                                </span>
+                            </label>
+                        </div>
+
+                        <div class="field-pair">
+                            <label for="anime">
+                                <span class="component-title">Anime</span>
+                                <span class="component-desc">
+                                    <input type="checkbox" id="anime" name="anime" ${('', 'checked="checked"')[show.is_anime == 1]}> check if the show is Anime and episodes are released as Show.265 rather than Show.S02E03<br />
+                                    % if show.is_anime:
+                                        <%include file="/inc_blackwhitelist.mako"/>
+                                    % endif
+                                </span>
+                            </label>
+                        </div>
+
+                        <div class="field-pair">
+                            <label for="sports">
+                                <span class="component-title">Sports</span>
+                                <span class="component-desc">
+                                    <input type="checkbox" id="sports" name="sports" ${('', 'checked="checked"')[show.sports == 1]}/> check if the show is a sporting or MMA event released as Show.03.02.2010 rather than Show.S02E03<br />
+                                    <span style="color:red">In case of an air date conflict between regular and special episodes, the later will be ignored.</span>
+                                </span>
+                            </label>
+                        </div>
+
+                        <div class="field-pair">
+                            <label for="season_folders">
+                                <span class="component-title">Season folders</span>
+                                <span class="component-desc">
+                                    <input type="checkbox" id="season_folders" name="flatten_folders" ${('checked="checked"', '')[show.flatten_folders == 1 and not sickbeard.NAMING_FORCE_FOLDERS]} ${('', 'disabled="disabled"')[bool(sickbeard.NAMING_FORCE_FOLDERS)]}/> group episodes by season folder (uncheck to store in a single folder)
+                                </span>
+                            </label>
+                        </div>
+
+                        <div class="field-pair">
+                            <label for="scene">
+                                <span class="component-title">Scene Numbering</span>
+                                <span class="component-desc">
+                                    <input type="checkbox" id="scene" name="scene" ${('', 'checked="checked"')[show.scene == 1]} /> search by scene numbering (uncheck to search by indexer numbering)
+                                </span>
+                            </label>
+                        </div>
+
+                        <div class="field-pair">
+                            <label for="dvdorder">
+                                <span class="component-title">DVD Order</span>
+                                <span class="component-desc">
+                                    <input type="checkbox" id="dvdorder" name="dvdorder" ${('', 'checked="checked"')[show.dvdorder == 1]} /> use the DVD order instead of the air order<br />
+                                    <div class="clear-left"><p>A "Force Full Update" is necessary, and if you have existing episodes you need to sort them manually.</p></div>
+                                </span>
+                            </label>
+                        </div>
+
+                    </fieldset>
+                </div>
+            </div>
+
+            <div id="core-component-group3">
+                <div class="component-group">
+                    <h3>Advanced Settings</h3>
+                    <fieldset class="component-group-list">
+
+                        <div class="field-pair">
+                            <label for="">
+                                <span class="component-title">Archive on first match</span>
+                                <span class="component-desc">
+                                    <input type="checkbox" id="archive_firstmatch" name="archive_firstmatch" ${('', 'checked="checked"')[show.archive_firstmatch == 1]} /> archive episode after the first best match is found from your archive quality list
+                                </span>
+                            </label>
+                        </div>
+
+                        <div class="field-pair">
+                            <label for="rls_ignore_words">
+                                <span class="component-title">Ignored Words</span>
+                                <span class="component-desc">
+                                    <input type="text" id="rls_ignore_words" name="rls_ignore_words" id="rls_ignore_words" value="${show.rls_ignore_words}" class="form-control form-control-inline input-sm input350" /><br />
+                                    <div class="clear-left">
+                                        <p>comma-separated <i>e.g. "word1,word2,word3"</i></>
+                                        <p>Search results with one or more words from this list will be ignored.</p>
+                                    </div>
+                                </span>
+                            </label>
+                        </div>
+
+                        <div class="field-pair">
+                            <label for="rls_require_words">
+                                <span class="component-title">Required Words</span>
+                                <span class="component-desc">
+                                    <input type="text" id="rls_require_words" name="rls_require_words" id="rls_require_words" value="${show.rls_require_words}" class="form-control form-control-inline input-sm input350" /><br />
+                                    <div class="clear-left">
+                                        <p>comma-separated <i>e.g. "word1,word2,word3"</i></p>
+                                        <p>Search results with no words from this list will be ignored.</p>
+                                    </div>
+                                </span>
+                            </label>
+                        </div>
+
+                        <div class="field-pair">
+                            <label for="SceneName">
+                                <span class="component-title">Scene Exception</span>
+                                <span class="component-desc">
+                                    <input type="text" id="SceneName" class="form-control form-control-inline input-sm input200" /><input class="btn btn-inline" type="button" value="Add" id="addSceneName" /><br /><br />
+                                    <div class="pull-left">
+                                        <select id="exceptions_list" name="exceptions_list" multiple="multiple" style="min-width:200px;height:99px;">
+                                        % for cur_exception in show.exceptions:
+                                            <option value="${cur_exception}">${cur_exception}</option>
+                                        % endfor
+                                        </select>
+                                        <div><input id="removeSceneName" value="Remove" class="btn float-left" type="button" style="margin-top: 10px;"/></div>
+                                    </div>
+                                    <div class="clear-left"><p>This will affect episode search on NZB and torrent providers. This list overrides the original name; it doesn't append to it.</p></div>
+                                </span>
+                            </label>
+                        </div>
+
+                    </fieldset>
+                </div>
+            </div>
+        
         </div>
-        <br />
+
+        <input id="submit" type="submit" value="Save Changes" class="btn pull-left config_submitter button">
+        </form>
     </div>
 </div>
-<div class="clearfix"></div>
-<br />
 
-<b>Quality:</b><br />
-<%
-    qualities = common.Quality.splitQuality(int(show.quality))
-    anyQualities = qualities[0]
-    bestQualities = qualities[1]
-%>
-<%include file="/inc_qualityChooser.mako"/>
-<br />
-
-<b>Archive on first match:</b>
-<input type="checkbox" name="archive_firstmatch" ${('', 'checked="checked"')[show.archive_firstmatch == 1]} /><br>
-(check this to have the episode archived after the first best match is found from your archive quality list)</br>
-<br />
-
-<b>Default Episode Status:</b><br />
-(this will set the status for future episodes)<br />
-<select name="defaultEpStatus" id="defaultEpStatusSelect" class="form-control form-control-inline input-sm">
-    % for curStatus in [WANTED, SKIPPED, IGNORED]:
-    <option value="${curStatus}" ${('', 'selected="selected"')[curStatus == show.default_ep_status]}>${statusStrings[curStatus]}</option>
-    % endfor
-</select><br />
-<br />
-
-<b>Info Language:</b><br />
-(this will only affect the language of the retrieved metadata file contents and episode filenames)<br />
-<select name="indexerLang" id="indexerLangSelect" class="form-control form-control-inline input-sm bfh-languages" data-language="${show.lang}" data-available="${','.join(sickbeard.indexerApi().config['valid_languages'])}"></select><br />
-<br />
-<b>Flatten files (no folders): </b> <input type="checkbox" name="flatten_folders" ${('', 'checked="checked"')[show.flatten_folders == 1 and not sickbeard.NAMING_FORCE_FOLDERS]} ${('', 'disabled="disabled"')[bool(sickbeard.NAMING_FORCE_FOLDERS)]}/><br />
-(Disabled: episodes folder-grouped by season. Enabled: no season folders)<br/>
-<br />
-
-<b>Paused: </b> <input type="checkbox" name="paused" ${('', 'checked="checked"')[show.paused == 1]} /><br />
-(check this if you wish to pause this show. Will not download anything until unpause)<br/>
-<br />
-
-<b>Subtitles: </b> <input type="checkbox" name="subtitles" ${('', 'checked="checked"')[show.subtitles == 1 and sickbeard.USE_SUBTITLES == True]} ${('disabled="disabled"', '')[bool(sickbeard.USE_SUBTITLES)]}/><br />
-(check this if you wish to search for subtitles in this show)<br/>
-<br />
-
-<b>Scene Numbering: </b>
-<input type="checkbox" name="scene" ${('', 'checked="checked"')[show.scene == 1]} /><br/>
-(check this if you wish to search by scene numbering, uncheck to search by indexer numbering)<br/>
-<br/>
-
-<b>Air by date: </b>
-<input type="checkbox" name="air_by_date" ${('', 'checked="checked"')[show.air_by_date == 1]} /><br />
-(check this if the show is released as Show.03.02.2010 rather than Show.S02E03. <span style="color:red">In case air date conflict between regular and special episodes, the later will be ignored.</span>)<br />
-<br />
-
-<b>Sports: </b>
-<input type="checkbox" name="sports" ${('', 'checked="checked"')[show.sports == 1]}/><br />
-(check this if the show is a sporting or MMA event and released as Show.03.02.2010 rather than Show.S02E03. <span style="color:red">In case air date conflict between regular and special episodes, the later will be ignored.</span>)<br />
-<br />
-
-<b>Anime: </b>
-<input type="checkbox" name="anime" ${('', 'checked="checked"')[show.is_anime == 1]}><br />
-(check this if the show is released as Show.265 rather than Show.S02E03, this show is an anime)<br />
-<br />
-
-<b>DVD Order: </b>
-<input type="checkbox" name="dvdorder" ${('', 'checked="checked"')[show.dvdorder == 1]} /><br/>
-(check this if you wish to use the DVD order instead of the Airing order. A "Force Full Update" is necessary, and if you have existing episodes you need to move them)
-<br/><br/>
-
-<b>Ignored Words:</b></br>
-<input type="text" name="rls_ignore_words" id="rls_ignore_words" value="${show.rls_ignore_words}" class="form-control form-control-inline input-sm input350" /><br />
-Results with one or more word from this list will be ignored<br />
-Separate words with a comma, e.g. "word1,word2,word3"<br />
-<br />
-
-<b>Required Words:</b></br>
-<input type="text" name="rls_require_words" id="rls_require_words" value="${show.rls_require_words}" class="form-control form-control-inline input-sm input350" /><br />
-Results with no word from this list will be ignored<br />
-Separate words with a comma, e.g. "word1,word2,word3"<br />
-<br />
-
-% if show.is_anime:
-    <%include file="/inc_blackwhitelist.mako"/>
-% endif
-
-<input type="submit" id="submit" value="Submit" class="btn btn-primary" />
-</form>
-</div>
 </%block>

--- a/gui/slick/views/inc_qualityChooser.mako
+++ b/gui/slick/views/inc_qualityChooser.mako
@@ -3,9 +3,6 @@
     from sickbeard.common import Quality, qualityPresets, qualityPresetStrings
 %>
 
-<div class="field-pair">
-    <label for="qualityPreset">
-
 <%
 if not show is UNDEFINED:
     __quality = int(show.quality)
@@ -18,18 +15,13 @@ bestQualities = qualities[1]
 %>
 
 <% overall_quality = Quality.combineQualities(anyQualities, bestQualities) %>
-<span class="component-title">Preferred quality of episodes to be download</span>
-<span class="component-desc">
 <% selected = None %>
 <select id="qualityPreset" class="form-control form-control-inline input-sm">
-<option value="0">Custom</option>
-% for curPreset in sorted(qualityPresets):
-<option value="${curPreset}" ${('', 'selected="selected"')[curPreset == overall_quality]} ${('', 'style="padding-left: 15px;"')[qualityPresetStrings[curPreset].endswith("0p")]}>${qualityPresetStrings[curPreset]}</option>
-% endfor
+    <option value="0">Custom</option>
+    % for curPreset in sorted(qualityPresets):
+        <option value="${curPreset}" ${('', 'selected="selected"')[curPreset == overall_quality]} ${('', 'style="padding-left: 15px;"')[qualityPresetStrings[curPreset].endswith("0p")]}>${qualityPresetStrings[curPreset]}</option>
+    % endfor
 </select>
-</span>
-    </label>
-</div>
 
 <div id="customQualityWrapper">
     <div id="customQuality">

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -1313,11 +1313,11 @@ class Home(WebRoot):
 
             if showObj.is_anime:
                 return t.render(show=show, scene_exceptions=scene_exceptions, groups=groups, whitelist=whitelist,
-                                blacklist=blacklist, title='Edit Shows', header='Edit Shows')
+                                blacklist=blacklist, title='Edit Show', header='Edit Show')
             else:
-                return t.render(show=show, scene_exceptions=scene_exceptions, title='Edit Shows', header='Edit Shows')
+                return t.render(show=show, scene_exceptions=scene_exceptions, title='Edit Show', header='Edit Show')
 
-        flatten_folders = config.checkbox_to_value(flatten_folders)
+        flatten_folders = not config.checkbox_to_value(flatten_folders) # UI inverts this value
         dvdorder = config.checkbox_to_value(dvdorder)
         archive_firstmatch = config.checkbox_to_value(archive_firstmatch)
         paused = config.checkbox_to_value(paused)


### PR DESCRIPTION
Changed the "Edit Show" page layout to use tabs similar to settings pages.

The page now has a 3-tab control, "Main" "Format" and "Advanced". Splitting into 3 tabs reduces page height and makes easier to read. No settings were added/removed, just re-arranged with exception of the "Season folders" (formerly "Flatten files"). Setting is now inverted (i.e. tick to group, untick to flatten) - makes more sense to end user I think.

Open to suggestions.