### PR TITLE
Move findPropers into generic.TorrentProvider (Only needs overridden …

### DIFF
--- a/sickbeard/providers/hdtorrents.py
+++ b/sickbeard/providers/hdtorrents.py
@@ -2,7 +2,7 @@
 # Modified by jkaberg, https://github.com/jkaberg for SceneAccess
 # URL: http://code.google.com/p/sickbeard/
 #
-# This file is part of SickRage. 
+# This file is part of SickRage.
 #
 # SickRage is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -258,7 +258,7 @@ class HDTorrentsProvider(generic.TorrentProvider):
             size = size * 1024**3
         elif modifier in 'TB':
             size = size * 1024**4
-        return size
+        return int(size)
 
 class HDTorrentsCache(tvcache.TVCache):
     def __init__(self, provider):

--- a/sickbeard/providers/iptorrents.py
+++ b/sickbeard/providers/iptorrents.py
@@ -18,26 +18,11 @@
 
 import re
 import traceback
-import datetime
-import itertools
-
-import sickbeard
-import generic
-from sickbeard.common import MULTI_EP_RESULT, SEASON_RESULT
-from sickbeard.common import Quality
+from sickbeard.providers import generic
 from sickbeard import logger
 from sickbeard import tvcache
-from sickbeard import db
-from sickbeard import classes
-from sickbeard import helpers
-from sickbeard import show_name_helpers
 from sickrage.helper.exceptions import AuthException
 from sickbeard.bs4_parser import BS4Parser
-from unidecode import unidecode
-from sickbeard.helpers import sanitizeSceneName
-from sickbeard.show_name_helpers import allPossibleShowNames
-from sickbeard.name_parser.parser import NameParser, InvalidNameException, InvalidShowException
-
 
 class IPTorrentsProvider(generic.TorrentProvider):
     def __init__(self):
@@ -58,13 +43,12 @@ class IPTorrentsProvider(generic.TorrentProvider):
         self.cache = IPTorrentsCache(self)
 
         self.urls = {'base_url': 'https://iptorrents.eu',
-                'login': 'https://iptorrents.eu/torrents/',
-                'search': 'https://iptorrents.eu/t?%s%s&q=%s&qf=#torrents',
-        }
+                     'login': 'https://iptorrents.eu/torrents/',
+                     'search': 'https://iptorrents.eu/t?%s%s&q=%s&qf=#torrents'}
 
         self.url = self.urls['base_url']
 
-        self.categorie = 'l73='
+        self.categories = '73=&60='
 
     def isEnabled(self):
         return self.enabled
@@ -80,11 +64,10 @@ class IPTorrentsProvider(generic.TorrentProvider):
 
         login_params = {'username': self.username,
                         'password': self.password,
-                        'login': 'submit',
-        }
+                        'login': 'submit'}
 
         self.getURL(self.urls['login'], timeout=30)
-        response = self.getURL(self.urls['login'],  post_data=login_params, timeout=30)
+        response = self.getURL(self.urls['login'], post_data=login_params, timeout=30)
         if not response:
             logger.log(u"Unable to connect to provider", logger.WARNING)
             return False
@@ -97,193 +80,6 @@ class IPTorrentsProvider(generic.TorrentProvider):
             return False
 
         return True
-
-    def findSearchResults(self, show, episodes, search_mode, manualSearch=False, downCurQuality=False):
-
-        self._checkAuth()
-        self.show = show
-
-        results = {}
-        itemList = []
-
-        if search_mode == 'sponly':
-            logger.log(u"Provider doesn't support season pack. Consider setting Season search mode to episodes only and unchecked Season search fallback", logger.WARNING)
-            search_mode = 'eponly'
-
-        for epObj in episodes:
-            # search cache for episode result
-            cacheResult = self.cache.searchCache(epObj, manualSearch, downCurQuality)
-            if cacheResult:
-                if epObj.episode not in results:
-                    results[epObj.episode] = cacheResult
-                else:
-                    results[epObj.episode].extend(cacheResult)
-
-                # found result, search next episode
-                continue
-
-            for curString in self._get_episode_search_strings(epObj):
-                itemList += self._doSearch(curString, 'eponly', len(episodes))
-
-        # if we found what we needed already from cache then return results and exit
-        if len(results) == len(episodes):
-            return results
-
-        # sort list by quality
-        if len(itemList):
-            items = {}
-            itemsUnknown = []
-            for item in itemList:
-                quality = self.getQuality(item, anime=show.is_anime)
-                if quality == Quality.UNKNOWN:
-                    itemsUnknown += [item]
-                else:
-                    if quality not in items:
-                        items[quality] = [item]
-                    else:
-                        items[quality].append(item)
-
-            itemList = list(itertools.chain(*[v for (k, v) in sorted(items.iteritems(), reverse=True)]))
-            itemList += itemsUnknown if itemsUnknown else []
-
-        # filter results
-        cl = []
-        for item in itemList:
-            (title, url) = self._get_title_and_url(item)
-
-            # parse the file name
-            try:
-                myParser = NameParser(False)
-                parse_result = myParser.parse(title)
-            except InvalidNameException:
-                logger.log(u"Unable to parse the filename %s into a valid episode" % title, logger.DEBUG)
-                continue
-            except InvalidShowException:
-                logger.log(u"Unable to parse the filename %s into a valid show" % title, logger.DEBUG)
-                continue
-
-            showObj = parse_result.show
-            quality = parse_result.quality
-            release_group = parse_result.release_group
-            version = parse_result.version
-
-            addCacheEntry = False
-            if not (showObj.air_by_date or showObj.sports):
-                if search_mode == 'sponly':
-                    if len(parse_result.episode_numbers):
-                        logger.log(
-                            u"This is supposed to be a season pack search but the result %s is not a valid season pack, skipping it" % title,
-                            logger.DEBUG)
-                        addCacheEntry = True
-                    if len(parse_result.episode_numbers) and (
-                                    parse_result.season_number not in set([ep.season for ep in episodes]) or not [ep for ep in episodes if
-                                                                                 ep.scene_episode in parse_result.episode_numbers]):
-                        logger.log(
-                            u"The result %s doesn't seem to be a valid episode that we are trying to snatch, ignoring" % title,
-                            logger.DEBUG)
-                        addCacheEntry = True
-                else:
-                    if not len(parse_result.episode_numbers) and parse_result.season_number and not [ep for ep in
-                                                                                                     episodes if
-                                                                                                     ep.season == parse_result.season_number and ep.episode in parse_result.episode_numbers]:
-                        logger.log(
-                            u"The result %s doesn't seem to be a valid season that we are trying to snatch, ignoring" % title,
-                            logger.DEBUG)
-                        addCacheEntry = True
-                    elif len(parse_result.episode_numbers) and not [ep for ep in episodes if
-                                                                    ep.season == parse_result.season_number and ep.episode in parse_result.episode_numbers]:
-                        logger.log(
-                            u"The result %s doesn't seem to be a valid episode that we are trying to snatch, ignoring" % title,
-                            logger.DEBUG)
-                        addCacheEntry = True
-
-                if not addCacheEntry:
-                    # we just use the existing info for normal searches
-                    actual_season = parse_result.season_number
-                    actual_episodes = parse_result.episode_numbers
-            else:
-                if not (parse_result.is_air_by_date):
-                    logger.log(
-                        u"This is supposed to be a date search but the result %s didn't parse as one, skipping it" % title,
-                        logger.DEBUG)
-                    addCacheEntry = True
-                else:
-                    airdate = parse_result.air_date.toordinal()
-                    myDB = db.DBConnection()
-                    sql_results = myDB.select(
-                        "SELECT season, episode FROM tv_episodes WHERE showid = ? AND airdate = ?",
-                        [showObj.indexerid, airdate])
-
-                    if len(sql_results) != 1:
-                        logger.log(
-                            u"Tried to look up the date for the episode %s but the database didn't give proper results, skipping it" % title,
-                            logger.WARNING)
-                        addCacheEntry = True
-
-                if not addCacheEntry:
-                    actual_season = int(sql_results[0]["season"])
-                    actual_episodes = [int(sql_results[0]["episode"])]
-
-            # add parsed result to cache for usage later on
-            if addCacheEntry:
-                logger.log(u"Adding item from search to cache: %s " % title, logger.DEBUG)
-                ci = self.cache._addCacheEntry(title, url, parse_result=parse_result)
-                if ci is not None:
-                    cl.append(ci)
-                continue
-
-            # make sure we want the episode
-            wantEp = True
-            for epNo in actual_episodes:
-                if not showObj.wantEpisode(actual_season, epNo, quality, manualSearch, downCurQuality):
-                    wantEp = False
-                    break
-
-            if not wantEp:
-                logger.log(
-                    u"Ignoring result %s because we don't want an episode that is %s" % (title,Quality.qualityStrings[quality]),
-                    logger.DEBUG)
-
-                continue
-
-            logger.log(u"Found result %s at %s " % (title, url), logger.DEBUG)
-
-            # make a result object
-            epObj = []
-            for curEp in actual_episodes:
-                epObj.append(showObj.getEpisode(actual_season, curEp))
-
-            result = self.getResult(epObj)
-            result.show = showObj
-            result.url = url
-            result.name = title
-            result.quality = quality
-            result.release_group = release_group
-            result.version = version
-            result.content = None
-
-            if len(epObj) == 1:
-                epNum = epObj[0].episode
-                logger.log(u"Single episode result", logger.DEBUG)
-            elif len(epObj) > 1:
-                epNum = MULTI_EP_RESULT
-                logger.log(u"Separating multi-episode result to check for later - result contains episodes: %s " % parse_result.episode_numbers,
-                logger.DEBUG)
-            elif len(epObj) == 0:
-                epNum = SEASON_RESULT
-                logger.log(u"Separating full season result to check for later", logger.DEBUG)
-
-            if epNum not in results:
-                results[epNum] = [result]
-            else:
-                results[epNum].append(result)
-
-        # check if we have items to add to cache
-        if len(cl) > 0:
-            myDB = self.cache._getDB()
-            myDB.mass_action(cl)
-
-        return results
 
     def _doSearch(self, search_params, search_mode='eponly', epcount=0, age=0, epObj=None):
 
@@ -303,7 +99,7 @@ class IPTorrentsProvider(generic.TorrentProvider):
                     logger.log(u"Search string: %s " % search_string, logger.DEBUG)
 
                 # URL with 50 tv-show results, or max 150 if adjusted in IPTorrents profile
-                searchURL = self.urls['search'] % (self.categorie, freeleech, search_string)
+                searchURL = self.urls['search'] % (self.categories, freeleech, search_string)
                 searchURL += ';o=seeders' if mode != 'RSS' else ''
                 logger.log(u"Search URL: %s" %  searchURL, logger.DEBUG)
 
@@ -331,18 +127,13 @@ class IPTorrentsProvider(generic.TorrentProvider):
                             continue
 
                         for result in torrents[1:]:
-
                             try:
-                                # FIXME
-                                size = -1
-                                torrent = result.find_all('td')[1].find('a')
-                                title = torrent.string
-                                download_url = self.urls['base_url'] + (result.find_all('td')[3].find('a'))['href']
-                                details_url = self.urls['base_url'] + torrent['href']
-                                seeders = int(result.find('td', attrs={'class': 'ac t_seeders'}).string)
-                                id = int(torrent['href'].replace('/details.php?id=', ''))
-                                leechers = int(result.find('td', attrs = {'class' : 'ac t_leechers'}).string)
-                            except (AttributeError, TypeError):
+                                title = result.find_all('td')[1].find('a').text
+                                download_url = self.urls['base_url'] + result.find_all('td')[3].find('a')['href']
+                                size = self._convertSize(result.find_all('td')[5].text)
+                                seeders = int(result.find('td', attrs={'class': 'ac t_seeders'}).text)
+                                leechers = int(result.find('td', attrs = {'class' : 'ac t_leechers'}).text)
+                            except (AttributeError, TypeError, KeyError):
                                 continue
 
                             if not all([title, download_url]):
@@ -361,7 +152,7 @@ class IPTorrentsProvider(generic.TorrentProvider):
                             items[mode].append(item)
 
                 except Exception, e:
-                    logger.log(u"Failed parsing provider. Traceback: %s" % traceback.format_exc(), logger.ERROR)
+                    logger.log(u"Failed parsing provider. Error: %r" % ex(e), logger.ERROR)
 
             #For each search mode sort all the items by seeders if available
             items[mode].sort(key=lambda tup: tup[3], reverse=True)
@@ -370,41 +161,26 @@ class IPTorrentsProvider(generic.TorrentProvider):
 
         return results
 
-    def findPropers(self, search_date=datetime.datetime.today()):
-
-        results = []
-
-        myDB = db.DBConnection()
-        sqlResults = myDB.select(
-            'SELECT s.show_name, e.showid, e.season, e.episode, e.status, e.airdate FROM tv_episodes AS e' +
-            ' INNER JOIN tv_shows AS s ON (e.showid = s.indexer_id)' +
-            ' WHERE e.airdate >= ' + str(search_date.toordinal()) +
-            ' AND (e.status IN (' + ','.join([str(x) for x in Quality.DOWNLOADED]) + ')' +
-            ' OR (e.status IN (' + ','.join([str(x) for x in Quality.SNATCHED]) + ')))'
-        )
-
-        if not sqlResults:
-            return []
-
-        for sqlshow in sqlResults:
-            self.show = helpers.findCertainShow(sickbeard.showList, int(sqlshow["showid"]))
-            if self.show:
-                curEp = self.show.getEpisode(int(sqlshow["season"]), int(sqlshow["episode"]))
-                searchString = self._get_episode_search_strings(curEp, add_string='PROPER|REPACK')
-
-                for item in self._doSearch(searchString[0]):
-                    title, url = self._get_title_and_url(item)
-                    results.append(classes.Proper(title, url, datetime.datetime.today(), self.show))
-
-        return results
-
     def seedRatio(self):
         return self.ratio
 
-class IPTorrentsCache(tvcache.TVCache):
-    def __init__(self, provider):
+    def _convertSize(self, size):
+        size, modifier = size.split(' ')
+        size = float(size)
+        if modifier in 'KB':
+            size = size * 1024
+        elif modifier in 'MB':
+            size = size * 1024**2
+        elif modifier in 'GB':
+            size = size * 1024**3
+        elif modifier in 'TB':
+            size = size * 1024**4
+        return int(size)
 
-        tvcache.TVCache.__init__(self, provider)
+class IPTorrentsCache(tvcache.TVCache):
+    def __init__(self, provider_obj):
+
+        tvcache.TVCache.__init__(self, provider_obj)
 
         # Only poll IPTorrents every 10 minutes max
         self.minTime = 10


### PR DESCRIPTION
…now if provider doesnt use the new search strings types!)

Remove findSearchResults from IPT (Dont override this in providers...)
Add anime category to IPT, Fixes https://github.com/SiCKRAGETV/sickrage-issues/issues/3348
Add size parsing to IPT, and clean up IPT (a lot!)