### PR TITLE
Added thousand seperator to free disk space in status

### DIFF
--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -1017,7 +1017,7 @@ class Home(WebRoot):
             return "Error sending Pushbullet notification"
 
     def status(self):
-        tvdirFree = helpers.getDiskSpaceUsage(sickbeard.TV_DOWNLOAD_DIR)
+        tvdirFree = "{:,}".format(helpers.getDiskSpaceUsage(sickbeard.TV_DOWNLOAD_DIR))
         rootDir = {}
         if sickbeard.ROOT_DIRS:
             backend_pieces = sickbeard.ROOT_DIRS.split('|')
@@ -1027,7 +1027,7 @@ class Home(WebRoot):
 
         if len(backend_dirs):
             for subject in backend_dirs:
-                rootDir[subject] = helpers.getDiskSpaceUsage(subject)
+                rootDir[subject] = "{:,}".format(helpers.getDiskSpaceUsage(subject))
 
         t = PageTemplate(rh=self, file="status.mako")
         return t.render(title='Status', header='Status', topmenu='system', tvdirFree=tvdirFree, rootDir=rootDir)


### PR DESCRIPTION
Having disks above 1 TB it gets difficult to see how much free space you actually have, so I added thousand separators to free disk space on the status page.
This is my first python code ever, but hopefully it is okay.