### PR TITLE
Remove findPropers override from HDTorrents

### DIFF
--- a/sickbeard/providers/alpharatio.py
+++ b/sickbeard/providers/alpharatio.py
@@ -32,7 +32,7 @@ class AlphaRatioProvider(generic.TorrentProvider):
         generic.TorrentProvider.__init__(self, "AlphaRatio")
 
         self.supportsBacklog = True
-        self.public = False
+
 
         self.username = None
         self.password = None

--- a/sickbeard/providers/animenzb.py
+++ b/sickbeard/providers/animenzb.py
@@ -19,14 +19,14 @@
 import urllib
 import datetime
 
-import generic
 
 from sickbeard import classes
 from sickbeard import show_name_helpers
 
 from sickbeard import logger
-from sickbeard.common import *
+
 from sickbeard import tvcache
+from sickbeard.providers import generic
 
 
 class animenzb(generic.NZBProvider):

--- a/sickbeard/providers/bitsoup.py
+++ b/sickbeard/providers/bitsoup.py
@@ -39,7 +39,7 @@ class BitSoupProvider(generic.TorrentProvider):
         self.url = self.urls['base_url']
 
         self.supportsBacklog = True
-        self.public = False
+
         self.username = None
         self.password = None
         self.ratio = None

--- a/sickbeard/providers/bluetigers.py
+++ b/sickbeard/providers/bluetigers.py
@@ -34,7 +34,7 @@ class BLUETIGERSProvider(generic.TorrentProvider):
         generic.TorrentProvider.__init__(self, "BLUETIGERS")
 
         self.supportsBacklog = True
-        self.public = False
+
         self.username = None
         self.password = None
         self.ratio = None

--- a/sickbeard/providers/btn.py
+++ b/sickbeard/providers/btn.py
@@ -39,7 +39,7 @@ class BTNProvider(generic.TorrentProvider):
         generic.TorrentProvider.__init__(self, "BTN")
 
         self.supportsBacklog = True
-        self.public = False
+
         self.supportsAbsoluteNumbering = True
 
         self.api_key = None

--- a/sickbeard/providers/fnt.py
+++ b/sickbeard/providers/fnt.py
@@ -32,7 +32,7 @@ class FNTProvider(generic.TorrentProvider):
         generic.TorrentProvider.__init__(self, "FNT")
 
         self.supportsBacklog = True
-        self.public = False
+
         self.username = None
         self.password = None
         self.ratio = None

--- a/sickbeard/providers/frenchtorrentdb.py
+++ b/sickbeard/providers/frenchtorrentdb.py
@@ -31,7 +31,7 @@ class FrenchTorrentDBProvider(generic.TorrentProvider):
         generic.TorrentProvider.__init__(self, "FrenchTorrentDB")
 
         self.supportsBacklog = True
-        self.public = False
+
 
         self.urls = {
             'base_url': 'http://www.frenchtorrentdb.com',

--- a/sickbeard/providers/freshontv.py
+++ b/sickbeard/providers/freshontv.py
@@ -34,7 +34,7 @@ class FreshOnTVProvider(generic.TorrentProvider):
         generic.TorrentProvider.__init__(self, "FreshOnTV")
 
         self.supportsBacklog = True
-        self.public = False
+
 
         self._uid = None
         self._hash = None

--- a/sickbeard/providers/generic.py
+++ b/sickbeard/providers/generic.py
@@ -55,7 +55,8 @@ class GenericProvider:
         self.proxyGlypeProxySSLwarning = None
         self.urls = {}
         self.url = ''
-        self.public = True
+
+        self.public = False
 
         self.show = None
 

--- a/sickbeard/providers/hdbits.py
+++ b/sickbeard/providers/hdbits.py
@@ -34,9 +34,8 @@ class HDBitsProvider(generic.TorrentProvider):
         generic.TorrentProvider.__init__(self, "HDBits")
 
         self.supportsBacklog = True
-        self.public = False
 
-        self.enabled = False
+
         self.username = None
         self.passkey = None
         self.ratio = None

--- a/sickbeard/providers/hdtorrents.py
+++ b/sickbeard/providers/hdtorrents.py
@@ -18,23 +18,13 @@
 # along with SickRage.  If not, see <http://www.gnu.org/licenses/>.
 
 import re
-import sickbeard
-import generic
 import urllib
-from sickbeard.common import Quality
-from sickbeard import logger
-from sickbeard import tvcache
-from sickbeard import db
-from sickbeard import classes
-from sickbeard import helpers
-from sickbeard import show_name_helpers
-from sickrage.helper.exceptions import AuthException
 import requests
 from bs4 import BeautifulSoup
-from unidecode import unidecode
-from sickbeard.helpers import sanitizeSceneName
-from datetime import datetime
-import traceback
+
+from sickbeard import logger
+from sickbeard import tvcache
+from sickbeard.providers import generic
 
 class HDTorrentsProvider(generic.TorrentProvider):
     def __init__(self):
@@ -42,7 +32,7 @@ class HDTorrentsProvider(generic.TorrentProvider):
         generic.TorrentProvider.__init__(self, "HDTorrents")
 
         self.supportsBacklog = True
-        self.public = False
+
 
         self.username = None
         self.password = None
@@ -54,8 +44,7 @@ class HDTorrentsProvider(generic.TorrentProvider):
                      'login': 'https://hd-torrents.org/login.php',
                      'search': 'https://hd-torrents.org/torrents.php?search=%s&active=1&options=0%s',
                      'rss': 'https://hd-torrents.org/torrents.php?search=&active=1&options=0%s',
-                     'home': 'https://hd-torrents.org/%s'
-        }
+                     'home': 'https://hd-torrents.org/%s'}
 
         self.url = self.urls['base_url']
 
@@ -82,7 +71,7 @@ class HDTorrentsProvider(generic.TorrentProvider):
                         'pwd': self.password,
                         'submit': 'Confirm'}
 
-        response = self.getURL(self.urls['login'],  post_data=login_params, timeout=30)
+        response = self.getURL(self.urls['login'], post_data=login_params, timeout=30)
         if not response:
             logger.log(u"Unable to connect to provider", logger.WARNING)
             return False
@@ -181,7 +170,7 @@ class HDTorrentsProvider(generic.TorrentProvider):
                                         if not size:
                                             size = -1
 
-                            except:
+                            except Exception:
                                 logger.log(u"Failed parsing provider. Traceback: %s" % traceback.format_exc(), logger.ERROR)
 
                         if not all([title, download_url]):
@@ -206,41 +195,6 @@ class HDTorrentsProvider(generic.TorrentProvider):
             items[mode].sort(key=lambda tup: tup[3], reverse=True)
 
             results += items[mode]
-
-        return results
-
-    def findPropers(self, search_date=datetime.today()):
-
-        results = []
-
-        myDB = db.DBConnection()
-        sqlResults = myDB.select(
-            'SELECT s.show_name, e.showid, e.season, e.episode, e.status, e.airdate FROM tv_episodes AS e' +
-            ' INNER JOIN tv_shows AS s ON (e.showid = s.indexer_id)' +
-            ' WHERE e.airdate >= ' + str(search_date.toordinal()) +
-            ' AND (e.status IN (' + ','.join([str(x) for x in Quality.DOWNLOADED]) + ')' +
-            ' OR (e.status IN (' + ','.join([str(x) for x in Quality.SNATCHED]) + ')))'
-        )
-
-        if not sqlResults:
-            return []
-
-        for sqlshow in sqlResults:
-            self.show = curshow = helpers.findCertainShow(sickbeard.showList, int(sqlshow["showid"]))
-            if not self.show: continue
-            curEp = curshow.getEpisode(int(sqlshow["season"]), int(sqlshow["episode"]))
-
-            proper_searchString = self._get_episode_search_strings(curEp, add_string='PROPER')
-
-            for item in self._doSearch(proper_searchString[0]):
-                title, url = self._get_title_and_url(item)
-                results.append(classes.Proper(title, url, datetime.today(), self.show))
-
-            repack_searchString = self._get_episode_search_strings(curEp, add_string='REPACK')
-
-            for item in self._doSearch(repack_searchString[0]):
-                title, url = self._get_title_and_url(item)
-                results.append(classes.Proper(title, url, datetime.today(), self.show))
 
         return results
 

--- a/sickbeard/providers/iptorrents.py
+++ b/sickbeard/providers/iptorrents.py
@@ -17,7 +17,6 @@
 # along with SickRage.  If not, see <http://www.gnu.org/licenses/>.
 
 import re
-import traceback
 from sickbeard.providers import generic
 from sickbeard import logger
 from sickbeard import tvcache
@@ -30,7 +29,7 @@ class IPTorrentsProvider(generic.TorrentProvider):
         generic.TorrentProvider.__init__(self, "IPTorrents")
 
         self.supportsBacklog = True
-        self.public = False
+
 
         self.username = None
         self.password = None

--- a/sickbeard/providers/kat.py
+++ b/sickbeard/providers/kat.py
@@ -30,10 +30,6 @@ import HTMLParser
 import sickbeard
 from sickbeard import logger
 from sickbeard import tvcache
-from sickbeard import helpers
-from sickbeard import db
-from sickbeard import classes
-from sickbeard.common import Quality
 from sickbeard.common import USER_AGENT
 from sickbeard.providers import generic
 from xml.parsers.expat import ExpatError
@@ -46,7 +42,6 @@ class KATProvider(generic.TorrentProvider):
         self.supportsBacklog = True
         self.public = True
 
-        self.enabled = False
         self.confirmed = True
         self.ratio = None
         self.minseed = None
@@ -165,33 +160,6 @@ class KATProvider(generic.TorrentProvider):
             items[mode].sort(key=lambda tup: tup[3], reverse=True)
 
             results += items[mode]
-
-        return results
-
-    def findPropers(self, search_date=datetime.datetime.today()-datetime.timedelta(days=1)):
-        results = []
-
-        myDB = db.DBConnection()
-        sqlResults = myDB.select(
-            'SELECT s.show_name, e.showid, e.season, e.episode, e.status, e.airdate, s.indexer FROM tv_episodes AS e' +
-            ' INNER JOIN tv_shows AS s ON (e.showid = s.indexer_id)' +
-            ' WHERE e.airdate >= ' + str(search_date.toordinal()) +
-            ' AND (e.status IN (' + ','.join([str(x) for x in Quality.DOWNLOADED]) + ')' +
-            ' OR (e.status IN (' + ','.join([str(x) for x in Quality.SNATCHED]) + ')))'
-        )
-
-        for sqlshow in sqlResults or []:
-            show = helpers.findCertainShow(sickbeard.showList, int(sqlshow["showid"]))
-            if show:
-                curEp = show.getEpisode(int(sqlshow["season"]), int(sqlshow["episode"]))
-
-                searchStrings = self._get_episode_search_strings(curEp, add_string='PROPER|REPACK')
-
-                for item in self._doSearch(searchStrings[0]):
-                    title, url = self._get_title_and_url(item)
-                    pubdate = item[6]
-
-                    results.append(classes.Proper(title, url, pubdate, show))
 
         return results
 

--- a/sickbeard/providers/omgwtfnzbs.py
+++ b/sickbeard/providers/omgwtfnzbs.py
@@ -17,22 +17,20 @@
 # along with SickRage. If not, see <http://www.gnu.org/licenses/>.
 
 import urllib
+from datetime import datetime
 
 import sickbeard
-import generic
-
 from sickbeard import tvcache
 from sickbeard import classes
 from sickbeard import logger
 from sickbeard import show_name_helpers
-from datetime import datetime
-from sickrage.helper.exceptions import AuthException
+from sickbeard.providers import generic
 
 
 class OmgwtfnzbsProvider(generic.NZBProvider):
     def __init__(self):
         generic.NZBProvider.__init__(self, "omgwtfnzbs")
-        self.enabled = False
+
         self.username = None
         self.api_key = None
         self.cache = OmgwtfnzbsCache(self)
@@ -41,7 +39,7 @@ class OmgwtfnzbsProvider(generic.NZBProvider):
         self.url = self.urls['base_url']
 
         self.supportsBacklog = True
-        self.public = False
+
 
     def isEnabled(self):
         return self.enabled
@@ -141,7 +139,7 @@ class OmgwtfnzbsProvider(generic.NZBProvider):
                     title, url = self._get_title_and_url(item)
                     try:
                         result_date = datetime.fromtimestamp(int(item['usenetage']))
-                    except:
+                    except Exception:
                         result_date = None
 
                     if result_date:

--- a/sickbeard/providers/rarbg.py
+++ b/sickbeard/providers/rarbg.py
@@ -19,22 +19,15 @@
 
 import traceback
 import re
-import generic
 import datetime
 import json
 import time
 
-
-import sickbeard
-from sickbeard.common import Quality, USER_AGENT
 from sickbeard import logger
 from sickbeard import tvcache
-from sickbeard import show_name_helpers
-from sickbeard import db
-from sickbeard import helpers
-from sickbeard import classes
+from sickbeard.providers import generic
+from sickbeard.common import USER_AGENT
 from sickbeard.indexers.indexer_config import INDEXER_TVDB
-from sickrage.helper.exceptions import ex
 
 
 class GetOutOfLoop(Exception):
@@ -61,20 +54,18 @@ class RarbgProvider(generic.TorrentProvider):
                      'listing': u'http://torrentapi.org/pubapi_v2.php?mode=list&app_id=sickrage',
                      'search': u'http://torrentapi.org/pubapi_v2.php?mode=search&app_id=sickrage&search_string={search_string}',
                      'search_tvdb': u'http://torrentapi.org/pubapi_v2.php?mode=search&app_id=sickrage&search_tvdb={tvdb}&search_string={search_string}',
-                     'api_spec': u'https://rarbg.com/pubapi/apidocs.txt',
-                     }
+                     'api_spec': u'https://rarbg.com/pubapi/apidocs.txt'}
 
         self.url = self.urls['listing']
 
         self.urlOptions = {'categories': '&category={categories}',
-                        'seeders': '&min_seeders={min_seeders}',
-                        'leechers': '&min_leechers={min_leechers}',
-                        'sorting' : '&sort={sorting}',
-                        'limit': '&limit={limit}',
-                        'format': '&format={format}',
-                        'ranked': '&ranked={ranked}',
-                        'token': '&token={token}',
-        }
+                           'seeders': '&min_seeders={min_seeders}',
+                           'leechers': '&min_leechers={min_leechers}',
+                           'sorting' : '&sort={sorting}',
+                           'limit': '&limit={limit}',
+                           'format': '&format={format}',
+                           'ranked': '&ranked={ranked}',
+                           'token': '&token={token}'}
 
         self.defaultOptions = self.urlOptions['categories'].format(categories='tv') + \
                                 self.urlOptions['limit'].format(limit='100') + \
@@ -255,34 +246,6 @@ class RarbgProvider(generic.TorrentProvider):
             # For each search mode sort all the items by seeders
             items[mode].sort(key=lambda tup: tup[3], reverse=True)
             results += items[mode]
-
-        return results
-
-    def findPropers(self, search_date=datetime.datetime.today()):
-
-        results = []
-
-        myDB = db.DBConnection()
-        sqlResults = myDB.select(
-            'SELECT s.show_name, e.showid, e.season, e.episode, e.status, e.airdate FROM tv_episodes AS e' +
-            ' INNER JOIN tv_shows AS s ON (e.showid = s.indexer_id)' +
-            ' WHERE e.airdate >= ' + str(search_date.toordinal()) +
-            ' AND (e.status IN (' + ','.join([str(x) for x in Quality.DOWNLOADED]) + ')' +
-            ' OR (e.status IN (' + ','.join([str(x) for x in Quality.SNATCHED]) + ')))'
-        )
-
-        if not sqlResults:
-            return []
-
-        for sqlshow in sqlResults:
-            self.show = helpers.findCertainShow(sickbeard.showList, int(sqlshow["showid"]))
-            if self.show:
-                curEp = self.show.getEpisode(int(sqlshow["season"]), int(sqlshow["episode"]))
-                searchString = self._get_episode_search_strings(curEp, add_string='PROPER|REPACK')
-
-                for item in self._doSearch(searchString[0]):
-                    title, url = self._get_title_and_url(item)
-                    results.append(classes.Proper(title, url, datetime.datetime.today(), self.show))
 
         return results
 

--- a/sickbeard/providers/rsstorrent.py
+++ b/sickbeard/providers/rsstorrent.py
@@ -1,6 +1,6 @@
 # Author: Mr_Orange
 #
-# This file is part of SickRage. 
+# This file is part of SickRage.
 #
 # SickRage is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -37,11 +37,10 @@ class TorrentRssProvider(generic.TorrentProvider):
         generic.TorrentProvider.__init__(self, name)
         self.cache = TorrentRssCache(self)
 
-        self.urls = {'base_url': re.sub('\/$', '', url)}
+        self.urls = {'base_url': re.sub(r'\/$', '', url)}
 
         self.url = self.urls['base_url']
 
-        self.enabled = True
         self.ratio = None
         self.supportsBacklog = False
 

--- a/sickbeard/providers/scenetime.py
+++ b/sickbeard/providers/scenetime.py
@@ -1,7 +1,7 @@
 # Author: Idan Gutman
 # URL: http://code.google.com/p/sickbeard/
 #
-# This file is part of SickRage.  
+# This file is part of SickRage.
 #
 # SickRage is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -17,21 +17,13 @@
 # along with SickRage.  If not, see <http://www.gnu.org/licenses/>.
 
 import re
-import traceback
-import datetime
-import sickbeard
-import generic
 import urllib
-from sickbeard.common import Quality
+import traceback
+
 from sickbeard import logger
 from sickbeard import tvcache
-from sickbeard import db
-from sickbeard import classes
-from sickbeard import helpers
-from sickbeard import show_name_helpers
+from sickbeard.providers import generic
 from sickbeard.bs4_parser import BS4Parser
-from unidecode import unidecode
-from sickbeard.helpers import sanitizeSceneName
 
 
 class SceneTimeProvider(generic.TorrentProvider):
@@ -41,9 +33,8 @@ class SceneTimeProvider(generic.TorrentProvider):
         generic.TorrentProvider.__init__(self, "SceneTime")
 
         self.supportsBacklog = True
-        self.public = False
 
-        self.enabled = False
+
         self.username = None
         self.password = None
         self.ratio = None
@@ -53,11 +44,10 @@ class SceneTimeProvider(generic.TorrentProvider):
         self.cache = SceneTimeCache(self)
 
         self.urls = {'base_url': 'https://www.scenetime.com',
-                'login': 'https://www.scenetime.com/takelogin.php',
-                'detail': 'https://www.scenetime.com/details.php?id=%s',
-                'search': 'https://www.scenetime.com/browse.php?search=%s%s',
-                'download': 'https://www.scenetime.com/download.php/%s/%s',
-                }
+                     'login': 'https://www.scenetime.com/takelogin.php',
+                     'detail': 'https://www.scenetime.com/details.php?id=%s',
+                     'search': 'https://www.scenetime.com/browse.php?search=%s%s',
+                     'download': 'https://www.scenetime.com/download.php/%s/%s'}
 
         self.url = self.urls['base_url']
 
@@ -69,10 +59,9 @@ class SceneTimeProvider(generic.TorrentProvider):
     def _doLogin(self):
 
         login_params = {'username': self.username,
-                        'password': self.password
-        }
+                        'password': self.password}
 
-        response = self.getURL(self.urls['login'],  post_data=login_params, timeout=30)
+        response = self.getURL(self.urls['login'], post_data=login_params, timeout=30)
         if not response:
             logger.log(u"Unable to connect to provider", logger.WARNING)
             return False
@@ -99,7 +88,7 @@ class SceneTimeProvider(generic.TorrentProvider):
                     logger.log(u"Search string: %s " % search_string, logger.DEBUG)
 
                 searchURL = self.urls['search'] % (urllib.quote(search_string), self.categories)
-                logger.log(u"Search URL: %s" %  searchURL, logger.DEBUG) 
+                logger.log(u"Search URL: %s" %  searchURL, logger.DEBUG)
 
                 data = self.getURL(searchURL)
                 if not data:
@@ -107,7 +96,7 @@ class SceneTimeProvider(generic.TorrentProvider):
 
                 try:
                     with BS4Parser(data, features=["html5lib", "permissive"]) as html:
-                        torrent_table = html.select("#torrenttable table");
+                        torrent_table = html.select("#torrenttable table")
                         torrent_rows = torrent_table[0].select("tr") if torrent_table else []
 
                         #Continue only if one Release is found
@@ -118,24 +107,21 @@ class SceneTimeProvider(generic.TorrentProvider):
                         # Scenetime apparently uses different number of cells in #torrenttable based
                         # on who you are. This works around that by extracting labels from the first
                         # <tr> and using their index to find the correct download/seeders/leechers td.
-                        labels = [ label.get_text() for label in torrent_rows[0].find_all('td') ]
+                        labels = [label.get_text() for label in torrent_rows[0].find_all('td')]
 
                         for result in torrent_rows[1:]:
                             cells = result.find_all('td')
 
-                            link = cells[labels.index('Name')].find('a');
+                            link = cells[labels.index('Name')].find('a')
 
                             full_id = link['href'].replace('details.php?id=', '')
                             torrent_id = full_id.split("&")[0]
 
                             try:
                                 title = link.contents[0].get_text()
-
                                 filename = "%s.torrent" % title.replace(" ", ".")
-
                                 download_url = self.urls['download'] % (torrent_id, filename)
 
-                                id = int(torrent_id)
                                 seeders = int(cells[labels.index('Seeders')].get_text())
                                 leechers = int(cells[labels.index('Leechers')].get_text())
                                 #FIXME
@@ -166,35 +152,6 @@ class SceneTimeProvider(generic.TorrentProvider):
             items[mode].sort(key=lambda tup: tup[3], reverse=True)
 
             results += items[mode]
-
-        return results
-
-    def findPropers(self, search_date=datetime.datetime.today()):
-
-        results = []
-
-        myDB = db.DBConnection()
-        sqlResults = myDB.select(
-            'SELECT s.show_name, e.showid, e.season, e.episode, e.status, e.airdate FROM tv_episodes AS e' +
-            ' INNER JOIN tv_shows AS s ON (e.showid = s.indexer_id)' +
-            ' WHERE e.airdate >= ' + str(search_date.toordinal()) +
-            ' AND (e.status IN (' + ','.join([str(x) for x in Quality.DOWNLOADED]) + ')' +
-            ' OR (e.status IN (' + ','.join([str(x) for x in Quality.SNATCHED]) + ')))'
-        )
-
-        if not sqlResults:
-            return []
-
-        for sqlshow in sqlResults:
-            self.show = helpers.findCertainShow(sickbeard.showList, int(sqlshow["showid"]))
-            if self.show:
-                curEp = self.show.getEpisode(int(sqlshow["season"]), int(sqlshow["episode"]))
-
-                searchString = self._get_episode_search_strings(curEp, add_string='PROPER|REPACK')
-
-                for item in self._doSearch(searchString[0]):
-                    title, url = self._get_title_and_url(item)
-                    results.append(classes.Proper(title, url, datetime.datetime.today(), self.show))
 
         return results
 

--- a/sickbeard/providers/shazbat.py
+++ b/sickbeard/providers/shazbat.py
@@ -29,7 +29,7 @@ class ShazbatProvider(generic.TorrentProvider):
         generic.TorrentProvider.__init__(self, "Shazbat.tv")
 
         self.supportsBacklog = False
-        self.public = False
+
 
         self.passkey = None
         self.ratio = None

--- a/sickbeard/providers/speedcd.py
+++ b/sickbeard/providers/speedcd.py
@@ -17,18 +17,10 @@
 # along with SickRage.  If not, see <http://www.gnu.org/licenses/>.
 
 import re
-import datetime
-import sickbeard
-import generic
 
-from sickbeard.common import Quality
 from sickbeard import logger
 from sickbeard import tvcache
-from sickbeard import db
-from sickbeard import classes
-from sickbeard import helpers
-from sickbeard import show_name_helpers
-from sickbeard.helpers import sanitizeSceneName
+from sickbeard.providers import generic
 
 
 class SpeedCDProvider(generic.TorrentProvider):
@@ -38,7 +30,7 @@ class SpeedCDProvider(generic.TorrentProvider):
         generic.TorrentProvider.__init__(self, "Speedcd")
 
         self.supportsBacklog = True
-        self.public = False
+
 
         self.username = None
         self.password = None
@@ -50,11 +42,10 @@ class SpeedCDProvider(generic.TorrentProvider):
         self.cache = SpeedCDCache(self)
 
         self.urls = {'base_url': 'http://speed.cd/',
-                'login': 'http://speed.cd/take_login.php',
-                'detail': 'http://speed.cd/t/%s',
-                'search': 'http://speed.cd/V3/API/API.php',
-                'download': 'http://speed.cd/download.php?torrent=%s',
-                }
+                     'login': 'http://speed.cd/take_login.php',
+                     'detail': 'http://speed.cd/t/%s',
+                     'search': 'http://speed.cd/V3/API/API.php',
+                     'download': 'http://speed.cd/download.php?torrent=%s'}
 
         self.url = self.urls['base_url']
 
@@ -66,10 +57,9 @@ class SpeedCDProvider(generic.TorrentProvider):
     def _doLogin(self):
 
         login_params = {'username': self.username,
-                        'password': self.password
-        }
+                        'password': self.password}
 
-        response = self.getURL(self.urls['login'],  post_data=login_params, timeout=30)
+        response = self.getURL(self.urls['login'], post_data=login_params, timeout=30)
         if not response:
             logger.log(u"Unable to connect to provider", logger.WARNING)
             return False
@@ -106,7 +96,7 @@ class SpeedCDProvider(generic.TorrentProvider):
 
                 try:
                     torrents = parsedJSON.get('Fs', [])[0].get('Cn', {}).get('torrents', [])
-                except:
+                except Exception:
                     continue
 
                 for torrent in torrents:
@@ -140,35 +130,6 @@ class SpeedCDProvider(generic.TorrentProvider):
             items[mode].sort(key=lambda tup: tup[3], reverse=True)
 
             results += items[mode]
-
-        return results
-
-    def findPropers(self, search_date=datetime.datetime.today()):
-
-        results = []
-
-        myDB = db.DBConnection()
-        sqlResults = myDB.select(
-            'SELECT s.show_name, e.showid, e.season, e.episode, e.status, e.airdate FROM tv_episodes AS e' +
-            ' INNER JOIN tv_shows AS s ON (e.showid = s.indexer_id)' +
-            ' WHERE e.airdate >= ' + str(search_date.toordinal()) +
-            ' AND (e.status IN (' + ','.join([str(x) for x in Quality.DOWNLOADED]) + ')' +
-            ' OR (e.status IN (' + ','.join([str(x) for x in Quality.SNATCHED]) + ')))'
-        )
-
-        if not sqlResults:
-            return []
-
-        for sqlshow in sqlResults:
-            self.show = helpers.findCertainShow(sickbeard.showList, int(sqlshow["showid"]))
-            if self.show:
-                curEp = self.show.getEpisode(int(sqlshow["season"]), int(sqlshow["episode"]))
-
-                searchString = self._get_episode_search_strings(curEp, add_string='PROPER|REPACK')
-
-                for item in self._doSearch(searchString[0]):
-                    title, url = self._get_title_and_url(item)
-                    results.append(classes.Proper(title, url, datetime.datetime.today(), self.show))
 
         return results
 

--- a/sickbeard/providers/strike.py
+++ b/sickbeard/providers/strike.py
@@ -1,7 +1,7 @@
 # Author: matigonkas
 # URL: https://github.com/SiCKRAGETV/sickrage
 #
-# This file is part of SickRage. 
+# This file is part of SickRage.
 #
 # SickRage is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -16,14 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage.  If not, see <http://www.gnu.org/licenses/>.
 
-import datetime
-import generic
-
 from sickbeard import logger
 from sickbeard import tvcache
-from sickbeard import show_name_helpers
-from sickbeard.config import naming_ep_type
-from sickbeard.helpers import sanitizeSceneName
+from sickbeard.providers import generic
 
 class STRIKEProvider(generic.TorrentProvider):
 
@@ -53,7 +48,7 @@ class STRIKEProvider(generic.TorrentProvider):
                     logger.log(u"Search string: " + search_string.strip(), logger.DEBUG)
 
                 searchURL = self.url + "api/v2/torrents/search/?category=TV&phrase=" + search_string
-                logger.log(u"Search URL: %s" %  searchURL, logger.DEBUG) 
+                logger.log(u"Search URL: %s" %  searchURL, logger.DEBUG)
                 jdata = self.getURL(searchURL, json=True)
                 if not jdata:
                     logger.log("No data returned from provider", logger.DEBUG)

--- a/sickbeard/providers/thepiratebay.py
+++ b/sickbeard/providers/thepiratebay.py
@@ -19,19 +19,12 @@
 from __future__ import with_statement
 
 import re
-import datetime
 from urllib import urlencode
 
-import sickbeard
-from sickbeard.providers import generic
-from sickbeard.common import Quality
-from sickbeard.common import USER_AGENT
-from sickbeard import db
-from sickbeard import classes
 from sickbeard import logger
 from sickbeard import tvcache
-from sickbeard import helpers
-from sickbeard.show_name_helpers import allPossibleShowNames, sanitizeSceneName
+from sickbeard.providers import generic
+from sickbeard.common import USER_AGENT
 
 
 class ThePirateBayProvider(generic.TorrentProvider):
@@ -146,30 +139,6 @@ class ThePirateBayProvider(generic.TorrentProvider):
         elif modifier in 'TiB':
             size = size * 1024**4
         return size
-
-    def findPropers(self, search_date=datetime.datetime.today()-datetime.timedelta(days=1)):
-
-        results = []
-
-        myDB = db.DBConnection()
-        sqlResults = myDB.select(
-            'SELECT s.show_name, e.showid, e.season, e.episode, e.status, e.airdate FROM tv_episodes AS e' +
-            ' INNER JOIN tv_shows AS s ON (e.showid = s.indexer_id)' +
-            ' WHERE e.airdate >= ' + str(search_date.toordinal()) +
-            ' AND (e.status IN (' + ','.join([str(x) for x in Quality.DOWNLOADED]) + ')' +
-            ' OR (e.status IN (' + ','.join([str(x) for x in Quality.SNATCHED]) + ')))'
-        )
-
-        for sqlshow in sqlResults or []:
-            show = helpers.findCertainShow(sickbeard.showList, int(sqlshow["showid"]))
-            if show:
-                curEp = show.getEpisode(int(sqlshow["season"]), int(sqlshow["episode"]))
-                searchStrings = self._get_episode_search_strings(curEp, add_string='PROPER|REPACK')
-                for item in self._doSearch(searchStrings[0]):
-                    title, url = self._get_title_and_url(item)
-                    results.append(classes.Proper(title, url, search_date, show))
-
-        return results
 
     def seedRatio(self):
         return self.ratio

--- a/sickbeard/providers/titansoftv.py
+++ b/sickbeard/providers/titansoftv.py
@@ -30,7 +30,7 @@ class TitansOfTVProvider(generic.TorrentProvider):
     def __init__(self):
         generic.TorrentProvider.__init__(self, 'TitansOfTV')
         self.supportsBacklog = True
-        self.public = False
+
         self.supportsAbsoluteNumbering = True
         self.api_key = None
         self.ratio = None

--- a/sickbeard/providers/tntvillage.py
+++ b/sickbeard/providers/tntvillage.py
@@ -1,7 +1,7 @@
 # Author: Giovanni Borri
 # Modified by gborri, https://github.com/gborri for TNTVillage
 #
-# This file is part of SickRage. 
+# This file is part of SickRage.
 #
 # SickRage is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -18,49 +18,41 @@
 
 import re
 import traceback
-import datetime
-import sickbeard
-import generic
 from sickbeard.common import Quality
 from sickbeard import logger
 from sickbeard import tvcache
 from sickbeard import db
-from sickbeard import classes
-from sickbeard import helpers
-from sickbeard import show_name_helpers
+
+from sickbeard.providers import generic
 from sickbeard.bs4_parser import BS4Parser
-from unidecode import unidecode
-from sickbeard.helpers import sanitizeSceneName
 from sickbeard.name_parser.parser import NameParser, InvalidNameException, InvalidShowException
 from sickrage.helper.exceptions import AuthException
 
-category_excluded = {
-              'Sport' : 22,
-              'Teatro' : 23,
-              'Video Musicali' : 21,
-              'Film' : 4,
-              'Musica' : 2,
-              'Students Releases' : 13,
-              'E Books' : 3,
-              'Linux' : 6,
-              'Macintosh' : 9,
-              'Windows Software' : 10,
-              'Pc Game' : 11,
-              'Playstation 2' : 12,
-              'Wrestling' : 24,
-              'Varie' : 25,
-              'Xbox' : 26,
-              'Immagini sfondi' : 27,
-              'Altri Giochi' : 28,
-              'Fumetteria' : 30,
-              'Trash' : 31,
-              'PlayStation 1' : 32,
-              'PSP Portable' : 33,
-              'A Book' : 34,
-              'Podcast' : 35,
-              'Edicola' : 36,
-              'Mobile' : 37,
-             }
+category_excluded = {'Sport' : 22,
+                     'Teatro' : 23,
+                     'Video Musicali' : 21,
+                     'Film' : 4,
+                     'Musica' : 2,
+                     'Students Releases' : 13,
+                     'E Books' : 3,
+                     'Linux' : 6,
+                     'Macintosh' : 9,
+                     'Windows Software' : 10,
+                     'Pc Game' : 11,
+                     'Playstation 2' : 12,
+                     'Wrestling' : 24,
+                     'Varie' : 25,
+                     'Xbox' : 26,
+                     'Immagini sfondi' : 27,
+                     'Altri Giochi' : 28,
+                     'Fumetteria' : 30,
+                     'Trash' : 31,
+                     'PlayStation 1' : 32,
+                     'PSP Portable' : 33,
+                     'A Book' : 34,
+                     'Podcast' : 35,
+                     'Edicola' : 36,
+                     'Mobile' : 37}
 
 class TNTVillageProvider(generic.TorrentProvider):
     def __init__(self):
@@ -68,9 +60,8 @@ class TNTVillageProvider(generic.TorrentProvider):
         generic.TorrentProvider.__init__(self, "TNTVillage")
 
         self.supportsBacklog = True
-        self.public = False
 
-        self.enabled = False
+
         self._uid = None
         self._hash = None
         self.username = None
@@ -83,8 +74,7 @@ class TNTVillageProvider(generic.TorrentProvider):
         self.minseed = None
         self.minleech = None
 
-        self.hdtext = [
-                       ' - Versione 720p',
+        self.hdtext = [' - Versione 720p',
                        ' Versione 720p',
                        ' V 720p',
                        ' V 720',
@@ -95,25 +85,21 @@ class TNTVillageProvider(generic.TorrentProvider):
                        ' 720p HEVC',
                        ' Ver 720',
                        ' 720p HEVC',
-                       ' 720p',
-                      ]
+                       ' 720p']
 
-        self.category_dict = {
-                              'Serie TV' : 29,
+        self.category_dict = {'Serie TV' : 29,
                               'Cartoni' : 8,
                               'Anime' : 7,
                               'Programmi e Film TV' : 1,
                               'Documentari' : 14,
-                              'All' : 0,
-                             }
+                              'All' : 0}
 
         self.urls = {'base_url' : 'http://forum.tntvillage.scambioetico.org',
-            'login' : 'http://forum.tntvillage.scambioetico.org/index.php?act=Login&CODE=01',
-            'detail' : 'http://forum.tntvillage.scambioetico.org/index.php?showtopic=%s',
-            'search' : 'http://forum.tntvillage.scambioetico.org/?act=allreleases&%s',
-            'search_page' : 'http://forum.tntvillage.scambioetico.org/?act=allreleases&st={0}&{1}',
-            'download' : 'http://forum.tntvillage.scambioetico.org/index.php?act=Attach&type=post&id=%s',
-        }
+                     'login' : 'http://forum.tntvillage.scambioetico.org/index.php?act=Login&CODE=01',
+                     'detail' : 'http://forum.tntvillage.scambioetico.org/index.php?showtopic=%s',
+                     'search' : 'http://forum.tntvillage.scambioetico.org/?act=allreleases&%s',
+                     'search_page' : 'http://forum.tntvillage.scambioetico.org/?act=allreleases&st={0}&{1}',
+                     'download' : 'http://forum.tntvillage.scambioetico.org/index.php?act=Attach&type=post&id=%s'}
 
         self.sub_string = ['sub', 'softsub']
 
@@ -140,10 +126,9 @@ class TNTVillageProvider(generic.TorrentProvider):
         login_params = {'UserName': self.username,
                         'PassWord': self.password,
                         'CookieDate': 0,
-                        'submit': 'Connettiti al Forum',
-        }
+                        'submit': 'Connettiti al Forum'}
 
-        response = self.getURL(self.urls['login'],  post_data=login_params, timeout=30)
+        response = self.getURL(self.urls['login'], post_data=login_params, timeout=30)
         if not response:
             logger.log(u"Unable to connect to provider", logger.WARNING)
             return False
@@ -180,18 +165,18 @@ class TNTVillageProvider(generic.TorrentProvider):
 
         return quality_string
 
-    def _episodeQuality(self,torrent_rows):
+    def _episodeQuality(self, torrent_rows):
         """
             Return The quality from the scene episode HTML row.
         """
-        file_quality=''
+        file_quality = ''
 
         img_all = (torrent_rows.find_all('td'))[1].find_all('img')
 
         if len(img_all) > 0:
             for img_type in img_all:
                 try:
-                    file_quality = file_quality + " " + img_type['src'].replace("style_images/mkportal-636/","").replace(".gif","").replace(".png","")
+                    file_quality = file_quality + " " + img_type['src'].replace("style_images/mkportal-636/", "").replace(".gif", "").replace(".png", "")
                 except Exception:
                     logger.log(u"Failed parsing quality. Traceback: %s" % traceback.format_exc(), logger.ERROR)
 
@@ -202,7 +187,7 @@ class TNTVillageProvider(generic.TorrentProvider):
         checkName = lambda list, func: func([re.search(x, file_quality, re.I) for x in list])
 
         dvdOptions = checkName(["dvd", "dvdrip", "dvdmux", "DVD9", "DVD5"], any)
-        bluRayOptions = checkName(["BD","BDmux", "BDrip", "BRrip", "Bluray"], any)
+        bluRayOptions = checkName(["BD", "BDmux", "BDrip", "BRrip", "Bluray"], any)
         sdOptions = checkName(["h264", "divx", "XviD", "tv", "TVrip", "SATRip", "DTTrip", "Mpeg2"], any)
         hdOptions = checkName(["720p"], any)
         fullHD = checkName(["1080p", "fullHD"], any)
@@ -254,7 +239,7 @@ class TNTVillageProvider(generic.TorrentProvider):
             italian = True
 
         return italian
-		
+
     def _is_english(self, torrent_rows):
 
         name = str(torrent_rows.find_all('td')[1].find('b').find('span'))
@@ -274,14 +259,14 @@ class TNTVillageProvider(generic.TorrentProvider):
             myParser = NameParser(tryIndexers=True, trySceneExceptions=True)
             parse_result = myParser.parse(name)
         except InvalidNameException:
-            logger.log(u"Unable to parse the filename %s into a valid episode" % title, logger.DEBUG)
+            logger.log(u"Unable to parse the filename %s into a valid episode" % name, logger.DEBUG)
             return False
         except InvalidShowException:
-            logger.log(u"Unable to parse the filename %s into a valid show" % title, logger.DEBUG)
+            logger.log(u"Unable to parse the filename %s into a valid show" % name, logger.DEBUG)
             return False
 
         myDB = db.DBConnection()
-        sql_selection="select count(*) as count from tv_episodes where showid = ? and season = ?"
+        sql_selection = "select count(*) as count from tv_episodes where showid = ? and season = ?"
         episodes = myDB.select(sql_selection, [parse_result.show.indexerid, parse_result.season_number])
         if int(episodes[0]['count']) == len(parse_result.episode_numbers):
             return True
@@ -303,28 +288,28 @@ class TNTVillageProvider(generic.TorrentProvider):
                 if mode == 'RSS':
                     self.page = 2
 
-                last_page=0
-                y=int(self.page)
+                last_page = 0
+                y = int(self.page)
 
                 if search_string == '':
                     continue
 
                 search_string = str(search_string).replace('.', ' ')
 
-                for x in range(0,y):
-                    z=x*20
+                for x in range(0, y):
+                    z = x*20
                     if last_page:
                         break
 
                     if mode != 'RSS':
-                        searchURL = (self.urls['search_page'] + '&filter={2}').format(z,self.categories,search_string)
+                        searchURL = (self.urls['search_page'] + '&filter={2}').format(z, self.categories, search_string)
                     else:
-                        searchURL = self.urls['search_page'].format(z,self.categories)
+                        searchURL = self.urls['search_page'].format(z, self.categories)
 
                     if mode != 'RSS':
                         logger.log(u"Search string: %s " % search_string, logger.DEBUG)
 
-                    logger.log(u"Search URL: %s" %  searchURL, logger.DEBUG) 
+                    logger.log(u"Search URL: %s" %  searchURL, logger.DEBUG)
                     data = self.getURL(searchURL)
                     if not data:
                         logger.log("No data returned from provider", logger.DEBUG)
@@ -332,25 +317,24 @@ class TNTVillageProvider(generic.TorrentProvider):
 
                     try:
                         with BS4Parser(data, features=["html5lib", "permissive"]) as html:
-                            torrent_table = html.find('table', attrs = {'class' : 'copyright'})
+                            torrent_table = html.find('table', attrs={'class' : 'copyright'})
                             torrent_rows = torrent_table.find_all('tr') if torrent_table else []
 
                             #Continue only if one Release is found
-                            if len(torrent_rows)<3:
+                            if len(torrent_rows) < 3:
                                 logger.log(u"Data returned from provider does not contain any torrents", logger.DEBUG)
-                                last_page=1
+                                last_page = 1
                                 continue
 
                             if len(torrent_rows) < 42:
-                                last_page=1
+                                last_page = 1
 
                             for result in torrent_table.find_all('tr')[2:]:
 
                                 try:
                                     link = result.find('td').find('a')
                                     title = link.string
-                                    id = ((result.find_all('td')[8].find('a'))['href'])[-8:]
-                                    download_url = self.urls['download'] % (id)
+                                    download_url = self.urls['download'] % result.find_all('td')[8].find('a')['href'][-8:]
                                     leechers = result.find_all('td')[3].find_all('td')[1].text
                                     leechers = int(leechers.strip('[]'))
                                     seeders = result.find_all('td')[3].find_all('td')[2].text
@@ -363,7 +347,7 @@ class TNTVillageProvider(generic.TorrentProvider):
                                 filename_qt = self._reverseQuality(self._episodeQuality(result))
                                 for text in self.hdtext:
                                     title1 = title
-                                    title = title.replace(text,filename_qt)
+                                    title = title.replace(text, filename_qt)
                                     if title != title1:
                                         break
 
@@ -413,35 +397,6 @@ class TNTVillageProvider(generic.TorrentProvider):
                 items[mode].sort(key=lambda tup: tup[3], reverse=True)
 
                 results += items[mode]
-
-        return results
-
-    def findPropers(self, search_date=datetime.datetime.today()):
-
-        results = []
-
-        myDB = db.DBConnection()
-        sqlResults = myDB.select(
-            'SELECT s.show_name, e.showid, e.season, e.episode, e.status, e.airdate FROM tv_episodes AS e' +
-            ' INNER JOIN tv_shows AS s ON (e.showid = s.indexer_id)' +
-            ' WHERE e.airdate >= ' + str(search_date.toordinal()) +
-            ' AND (e.status IN (' + ','.join([str(x) for x in Quality.DOWNLOADED]) + ')' +
-            ' OR (e.status IN (' + ','.join([str(x) for x in Quality.SNATCHED]) + ')))'
-        )
-
-        if not sqlResults:
-            return []
-
-        for sqlshow in sqlResults:
-            self.show = curshow = helpers.findCertainShow(sickbeard.showList, int(sqlshow["showid"]))
-            if not self.show: continue
-            curEp = curshow.getEpisode(int(sqlshow["season"]), int(sqlshow["episode"]))
-
-            searchString = self._get_episode_search_strings(curEp, add_string='PROPER|REPACK')
-
-            for item in self._doSearch(searchString[0]):
-                title, url = self._get_title_and_url(item)
-                results.append(classes.Proper(title, url, datetime.datetime.today(), self.show))
 
         return results
 

--- a/sickbeard/providers/tokyotoshokan.py
+++ b/sickbeard/providers/tokyotoshokan.py
@@ -19,12 +19,9 @@
 import urllib
 import traceback
 
-import generic
-
-from sickbeard import show_name_helpers
 from sickbeard import logger
-from sickbeard.common import Quality
 from sickbeard import tvcache
+from sickbeard.providers import generic
 from sickbeard import show_name_helpers
 from sickbeard.bs4_parser import BS4Parser
 
@@ -50,9 +47,6 @@ class TokyoToshokanProvider(generic.TorrentProvider):
 
     def seedRatio(self):
         return self.ratio
-
-    def findSearchResults(self, show, episodes, search_mode, manualSearch=False, downCurQuality=False):
-        return generic.TorrentProvider.findSearchResults(self, show, episodes, search_mode, manualSearch, downCurQuality)
 
     def _get_season_search_strings(self, ep_obj):
         return [x.replace('.', ' ') for x in show_name_helpers.makeSceneSeasonSearchString(self.show, ep_obj)]

--- a/sickbeard/providers/torrentbytes.py
+++ b/sickbeard/providers/torrentbytes.py
@@ -1,7 +1,7 @@
 # Author: Idan Gutman
 # URL: http://code.google.com/p/sickbeard/
 #
-# This file is part of SickRage. 
+# This file is part of SickRage.
 #
 # SickRage is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -17,21 +17,13 @@
 # along with SickRage.  If not, see <http://www.gnu.org/licenses/>.
 
 import re
-import traceback
-import datetime
-import sickbeard
-import generic
 import urllib
-from sickbeard.common import Quality
+import traceback
+
 from sickbeard import logger
 from sickbeard import tvcache
-from sickbeard import db
-from sickbeard import classes
-from sickbeard import helpers
-from sickbeard import show_name_helpers
+from sickbeard.providers import generic
 from sickbeard.bs4_parser import BS4Parser
-from unidecode import unidecode
-from sickbeard.helpers import sanitizeSceneName
 
 
 class TorrentBytesProvider(generic.TorrentProvider):
@@ -41,9 +33,8 @@ class TorrentBytesProvider(generic.TorrentProvider):
         generic.TorrentProvider.__init__(self, "TorrentBytes")
 
         self.supportsBacklog = True
-        self.public = False
 
-        self.enabled = False
+
         self.username = None
         self.password = None
         self.ratio = None
@@ -53,11 +44,10 @@ class TorrentBytesProvider(generic.TorrentProvider):
         self.cache = TorrentBytesCache(self)
 
         self.urls = {'base_url': 'https://www.torrentbytes.net',
-                'login': 'https://www.torrentbytes.net/takelogin.php',
-                'detail': 'https://www.torrentbytes.net/details.php?id=%s',
-                'search': 'https://www.torrentbytes.net/browse.php?search=%s%s',
-                'download': 'https://www.torrentbytes.net/download.php?id=%s&name=%s',
-                }
+                     'login': 'https://www.torrentbytes.net/takelogin.php',
+                     'detail': 'https://www.torrentbytes.net/details.php?id=%s',
+                     'search': 'https://www.torrentbytes.net/browse.php?search=%s%s',
+                     'download': 'https://www.torrentbytes.net/download.php?id=%s&name=%s'}
 
         self.url = self.urls['base_url']
 
@@ -70,10 +60,9 @@ class TorrentBytesProvider(generic.TorrentProvider):
 
         login_params = {'username': self.username,
                         'password': self.password,
-                        'login': 'Log in!'
-        }
+                        'login': 'Log in!'}
 
-        response = self.getURL(self.urls['login'],  post_data=login_params, timeout=30)
+        response = self.getURL(self.urls['login'], post_data=login_params, timeout=30)
         if not response:
             logger.log(u"Unable to connect to provider", logger.WARNING)
             return False
@@ -100,7 +89,7 @@ class TorrentBytesProvider(generic.TorrentProvider):
                     logger.log(u"Search string: %s " % search_string, logger.DEBUG)
 
                 searchURL = self.urls['search'] % (urllib.quote(search_string.encode('utf-8')), self.categories)
-                logger.log(u"Search URL: %s" %  searchURL, logger.DEBUG) 
+                logger.log(u"Search URL: %s" %  searchURL, logger.DEBUG)
 
                 data = self.getURL(searchURL)
                 if not data:
@@ -130,7 +119,6 @@ class TorrentBytesProvider(generic.TorrentProvider):
                                 else:
                                     title = link.contents[0]
                                 download_url = self.urls['download'] % (torrent_id, link.contents[0])
-                                id = int(torrent_id)
                                 seeders = int(cells[8].find('span').contents[0])
                                 leechers = int(cells[9].find('span').contents[0])
                                 #FIXME
@@ -160,35 +148,6 @@ class TorrentBytesProvider(generic.TorrentProvider):
             items[mode].sort(key=lambda tup: tup[3], reverse=True)
 
             results += items[mode]
-
-        return results
-
-    def findPropers(self, search_date=datetime.datetime.today()):
-
-        results = []
-
-        myDB = db.DBConnection()
-        sqlResults = myDB.select(
-            'SELECT s.show_name, e.showid, e.season, e.episode, e.status, e.airdate FROM tv_episodes AS e' +
-            ' INNER JOIN tv_shows AS s ON (e.showid = s.indexer_id)' +
-            ' WHERE e.airdate >= ' + str(search_date.toordinal()) +
-            ' AND (e.status IN (' + ','.join([str(x) for x in Quality.DOWNLOADED]) + ')' +
-            ' OR (e.status IN (' + ','.join([str(x) for x in Quality.SNATCHED]) + ')))'
-        )
-
-        if not sqlResults:
-            return []
-
-        for sqlshow in sqlResults:
-            self.show = helpers.findCertainShow(sickbeard.showList, int(sqlshow["showid"]))
-            if self.show:
-                curEp = self.show.getEpisode(int(sqlshow["season"]), int(sqlshow["episode"]))
-
-                searchString = self._get_episode_search_strings(curEp, add_string='PROPER|REPACK')
-
-                for item in self._doSearch(searchString[0]):
-                    title, url = self._get_title_and_url(item)
-                    results.append(classes.Proper(title, url, datetime.datetime.today(), self.show))
 
         return results
 

--- a/sickbeard/providers/torrentday.py
+++ b/sickbeard/providers/torrentday.py
@@ -16,19 +16,10 @@
 # along with SickRage.  If not, see <http://www.gnu.org/licenses/>.
 
 import re
-import datetime
-import sickbeard
-import generic
-from sickbeard.common import Quality
+import requests
 from sickbeard import logger
 from sickbeard import tvcache
-from sickbeard import db
-from sickbeard import classes
-from sickbeard import helpers
-from sickbeard import show_name_helpers
-import requests
-from sickbeard.helpers import sanitizeSceneName
-
+from sickbeard.providers import generic
 
 class TorrentDayProvider(generic.TorrentProvider):
 
@@ -37,7 +28,7 @@ class TorrentDayProvider(generic.TorrentProvider):
         generic.TorrentProvider.__init__(self, "TorrentDay")
 
         self.supportsBacklog = True
-        self.public = False
+
 
         self._uid = None
         self._hash = None
@@ -51,10 +42,9 @@ class TorrentDayProvider(generic.TorrentProvider):
         self.cache = TorrentDayCache(self)
 
         self.urls = {'base_url': 'https://classic.torrentday.com',
-                'login': 'https://classic.torrentday.com/torrents/',
-                'search': 'https://classic.torrentday.com/V3/API/API.php',
-                'download': 'https://classic.torrentday.com/download.php/%s/%s'
-        }
+                     'login': 'https://classic.torrentday.com/torrents/',
+                     'search': 'https://classic.torrentday.com/V3/API/API.php',
+                     'download': 'https://classic.torrentday.com/download.php/%s/%s'}
 
         self.url = self.urls['base_url']
 
@@ -78,10 +68,9 @@ class TorrentDayProvider(generic.TorrentProvider):
             login_params = {'username': self.username,
                             'password': self.password,
                             'submit.x': 0,
-                            'submit.y': 0
-            }
+                            'submit.y': 0}
 
-            response = self.getURL(self.urls['login'],  post_data=login_params, timeout=30)
+            response = self.getURL(self.urls['login'], post_data=login_params, timeout=30)
             if not response:
                 logger.log(u"Unable to connect to provider", logger.WARNING)
                 return False
@@ -96,10 +85,9 @@ class TorrentDayProvider(generic.TorrentProvider):
                     self._hash = requests.utils.dict_from_cookiejar(self.session.cookies)['pass']
 
                     self.cookies = {'uid': self._uid,
-                                    'pass': self._hash
-                    }
+                                    'pass': self._hash}
                     return True
-            except:
+            except Exception:
                 pass
 
             logger.log(u"Unable to obtain cookie", logger.WARNING)
@@ -109,8 +97,6 @@ class TorrentDayProvider(generic.TorrentProvider):
 
         results = []
         items = {'Season': [], 'Episode': [], 'RSS': []}
-
-        freeleech = '&free=on' if self.freeleech else ''
 
         if not self._doLogin():
             return results
@@ -137,14 +123,14 @@ class TorrentDayProvider(generic.TorrentProvider):
 
                 try:
                     torrents = parsedJSON.get('Fs', [])[0].get('Cn', {}).get('torrents', [])
-                except:
+                except Exception:
                     logger.log(u"Data returned from provider does not contain any torrents", logger.DEBUG)
                     continue
 
                 for torrent in torrents:
 
                     title = re.sub(r"\[.*\=.*\].*\[/.*\]", "", torrent['name'])
-                    download_url = self.urls['download'] % ( torrent['id'], torrent['fname'] )
+                    download_url = self.urls['download'] % ( torrent['id'], torrent['fname'])
                     seeders = int(torrent['seed'])
                     leechers = int(torrent['leech'])
                     #FIXME
@@ -169,35 +155,6 @@ class TorrentDayProvider(generic.TorrentProvider):
             items[mode].sort(key=lambda tup: tup[3], reverse=True)
 
             results += items[mode]
-
-        return results
-
-    def findPropers(self, search_date=datetime.datetime.today()):
-
-        results = []
-
-        myDB = db.DBConnection()
-        sqlResults = myDB.select(
-            'SELECT s.show_name, e.showid, e.season, e.episode, e.status, e.airdate FROM tv_episodes AS e' +
-            ' INNER JOIN tv_shows AS s ON (e.showid = s.indexer_id)' +
-            ' WHERE e.airdate >= ' + str(search_date.toordinal()) +
-            ' AND (e.status IN (' + ','.join([str(x) for x in Quality.DOWNLOADED]) + ')' +
-            ' OR (e.status IN (' + ','.join([str(x) for x in Quality.SNATCHED]) + ')))'
-        )
-
-        if not sqlResults:
-            return []
-
-        for sqlshow in sqlResults:
-            self.show = helpers.findCertainShow(sickbeard.showList, int(sqlshow["showid"]))
-            if self.show:
-                curEp = self.show.getEpisode(int(sqlshow["season"]), int(sqlshow["episode"]))
-
-                searchString = self._get_episode_search_strings(curEp, add_string='PROPER|REPACK')
-
-                for item in self._doSearch(searchString[0]):
-                    title, url = self._get_title_and_url(item)
-                    results.append(classes.Proper(title, url, datetime.datetime.today(), self.show))
 
         return results
 

--- a/sickbeard/providers/torrentproject.py
+++ b/sickbeard/providers/torrentproject.py
@@ -16,19 +16,12 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage.  If not, see <http://www.gnu.org/licenses/>.
 
-import datetime
-import generic
-import json
 from urllib import quote_plus
 
 from sickbeard import logger
 from sickbeard import tvcache
-from sickbeard import show_name_helpers
-from sickbeard import db
-from sickbeard.common import WANTED
+from sickbeard.providers import generic
 from sickbeard.common import USER_AGENT
-from sickbeard.config import naming_ep_type
-from sickbeard.helpers import sanitizeSceneName
 
 class TORRENTPROJECTProvider(generic.TorrentProvider):
 
@@ -79,19 +72,19 @@ class TORRENTPROJECTProvider(generic.TorrentProvider):
                             logger.log("Torrent doesn't meet minimum seeds & leechers not selecting : %s" % title, logger.DEBUG)
                         continue
 
-                    hash = torrents[i]["torrent_hash"]
+                    t_hash = torrents[i]["torrent_hash"]
                     size = int(torrents[i]["torrent_size"])
 
-                    if seeders < 10 :
+                    if seeders < 10:
                         logger.log("Torrent has less than 10 seeds getting dyn trackers: " + title, logger.DEBUG)
-                        trackerUrl = self.urls['api'] + "" + hash + "/trackers_json"
+                        trackerUrl = self.urls['api'] + "" + t_hash + "/trackers_json"
                         jdata = self.getURL(trackerUrl, json=True)
-                        download_url = "magnet:?xt=urn:btih:" + hash + "&dn=" + title + "".join(["&tr=" + s for s in jdata])
+                        download_url = "magnet:?xt=urn:btih:" + t_hash + "&dn=" + title + "".join(["&tr=" + s for s in jdata])
                         logger.log("Dyn Magnet: " + download_url, logger.DEBUG)
                     else:
                         #logger.log("Torrent has more than 10 seeds using hard coded trackers", logger.DEBUG)
-                        download_url = "magnet:?xt=urn:btih:" + hash + "&dn=" + title + "&tr=udp://tracker.openbittorrent.com:80&tr=udp://tracker.coppersurfer.tk:6969&tr=udp://open.demonii.com:1337&tr=udp://tracker.leechers-paradise.org:6969&tr=udp://exodus.desync.com:6969"					
-				
+                        download_url = "magnet:?xt=urn:btih:" + t_hash + "&dn=" + title + "&tr=udp://tracker.openbittorrent.com:80&tr=udp://tracker.coppersurfer.tk:6969&tr=udp://open.demonii.com:1337&tr=udp://tracker.leechers-paradise.org:6969&tr=udp://exodus.desync.com:6969"
+
 
                     if not all([title, download_url]):
                         continue
@@ -121,7 +114,7 @@ class TORRENTPROJECTCache(tvcache.TVCache):
     def _getRSSData(self):
         # no rss for torrentproject afaik,& can't search with empty string
         # newest results are always > 1 day since added anyways
-        search_strings = {'RSS': ['']}
+        # search_strings = {'RSS': ['']}
         return {'entries': {}}
 
 provider = TORRENTPROJECTProvider()

--- a/sickbeard/providers/xthor.py
+++ b/sickbeard/providers/xthor.py
@@ -18,21 +18,13 @@
 # along with SickRage.  If not, see <http://www.gnu.org/licenses/>.
 
 import re
-import datetime
-import sickbeard
-import generic
 import cookielib
 import urllib
 import requests
-from sickbeard.bs4_parser import BS4Parser
-from sickbeard.common import Quality
+
 from sickbeard import logger
-from sickbeard import show_name_helpers
-from sickbeard import db
-from sickbeard import helpers
-from unidecode import unidecode
-from sickbeard import classes
-from sickbeard.helpers import sanitizeSceneName
+from sickbeard.providers import generic
+from sickbeard.bs4_parser import BS4Parser
 
 
 class XthorProvider(generic.TorrentProvider):
@@ -42,7 +34,6 @@ class XthorProvider(generic.TorrentProvider):
         generic.TorrentProvider.__init__(self, "Xthor")
 
         self.supportsBacklog = True
-        self.public = False
 
         self.cj = cookielib.CookieJar()
 
@@ -50,7 +41,6 @@ class XthorProvider(generic.TorrentProvider):
         self.urlsearch = "https://xthor.bz/browse.php?search=\"%s\"%s"
         self.categories = "&searchin=title&incldead=0"
 
-        self.enabled = False
         self.username = None
         self.password = None
         self.ratio = None
@@ -65,10 +55,9 @@ class XthorProvider(generic.TorrentProvider):
 
         login_params = {'username': self.username,
                         'password': self.password,
-                        'submitme': 'X'
-        }
+                        'submitme': 'X'}
 
-        response = self.getURL(self.url + '/takelogin.php',  post_data=login_params, timeout=30)
+        response = self.getURL(self.url + '/takelogin.php', post_data=login_params, timeout=30)
         if not response:
             logger.log(u"Unable to connect to provider", logger.WARNING)
             return False
@@ -105,14 +94,14 @@ class XthorProvider(generic.TorrentProvider):
                     continue
 
                 with BS4Parser(data, features=["html5lib", "permissive"]) as html:
-                    resultsTable = html.find("table", { "class" : "table2 table-bordered2"  })
+                    resultsTable = html.find("table", {"class" : "table2 table-bordered2"})
                     if resultsTable:
                         rows = resultsTable.findAll("tr")
                         for row in rows:
-                            link = row.find("a",href=re.compile("details.php"))
+                            link = row.find("a", href=re.compile("details.php"))
                             if link:
                                 title = link.text
-                                download_url =  self.url + '/' + row.find("a",href=re.compile("download.php"))['href']
+                                download_url = self.url + '/' + row.find("a", href=re.compile("download.php"))['href']
                                 #FIXME
                                 size = -1
                                 seeders = 1
@@ -142,33 +131,5 @@ class XthorProvider(generic.TorrentProvider):
 
     def seedRatio(self):
         return self.ratio
-
-    def findPropers(self, search_date=datetime.datetime.today()):
-
-        results = []
-
-        myDB = db.DBConnection()
-        sqlResults = myDB.select(
-            'SELECT s.show_name, e.showid, e.season, e.episode, e.status, e.airdate FROM tv_episodes AS e' +
-            ' INNER JOIN tv_shows AS s ON (e.showid = s.indexer_id)' +
-            ' WHERE e.airdate >= ' + str(search_date.toordinal()) +
-            ' AND (e.status IN (' + ','.join([str(x) for x in Quality.DOWNLOADED]) + ')' +
-            ' OR (e.status IN (' + ','.join([str(x) for x in Quality.SNATCHED]) + ')))'
-        )
-
-        if not sqlResults:
-            return results
-
-        for sqlshow in sqlResults:
-            self.show = helpers.findCertainShow(sickbeard.showList, int(sqlshow["showid"]))
-            if self.show:
-                curEp = self.show.getEpisode(int(sqlshow["season"]), int(sqlshow["episode"]))
-                search_params = self._get_episode_search_strings(curEp, add_string='PROPER|REPACK')
-
-                for item in self._doSearch(search_params[0]):
-                    title, url = self._get_title_and_url(item)
-                    results.append(classes.Proper(title, url, datetime.datetime.today(), self.show))
-
-        return results
 
 provider = XthorProvider()


### PR DESCRIPTION
Remove duplicitous self.enabled definitions
Remove some unused imports

Remove findPropers override from HoundDawgs
More cleanup in HDTorrents (imports)

Remove `public = False` from all private providers and make it the default

Remove findPropers override form the rest of torrent providers that dont need it
Clean up most unused imports, and redefined built-ins
Light linting on these files
Fix download_url in nextgen