### PR TITLE
Fix multiple snatches when 'snatch notification' fails

### DIFF
--- a/sickbeard/search.py
+++ b/sickbeard/search.py
@@ -168,7 +168,12 @@ def snatchEpisode(result, endStatus=SNATCHED):
             sql_l.append(curEpObj.get_sql())
 
         if curEpObj.status not in Quality.DOWNLOADED:
-            notifiers.notify_snatch(curEpObj._format_pattern('%SN - %Sx%0E - %EN - %QN') + " from " + result.provider.name)
+            try:
+                notifiers.notify_snatch(curEpObj._format_pattern('%SN - %Sx%0E - %EN - %QN') + " from " + result.provider.name)
+            except:
+                # Without this, when notification fail, it crashes the snatch thread and SR will
+                # keep snatching until notification is sent
+                logger.log(u"Failed to send snatch notification", logger.DEBUG)
 
             trakt_data.append((curEpObj.season, curEpObj.episode))
 


### PR DESCRIPTION
@miigotu 
This maybe the one of the causes of the of "Unable to send Torrent: Return code undefined" as we succeeded sending torrent to client BUT SR didn't had knowledge of that and next time will try to send again, creating the empty/None return code

```
2015-10-20 23:31:38 INFO     SEARCHQUEUE-DAILY-SEARCH :: Downloading *******.S01E01.1080p.HDTV.X264-DIMENSION from Rarbg
2015-10-20 23:31:38 DEBUG    SEARCHQUEUE-DAILY-SEARCH :: Calling Transmission Client
2015-10-20 23:31:43 DEBUG    SEARCHQUEUE-DAILY-SEARCH :: Transmission: Response to POST request is {"arguments":{},"result":"success"}
2015-10-20 23:32:14 DEBUG    SEARCHQUEUE-DAILY-SEARCH :: Traceback (most recent call last):
  File "/home/osmc/SickRage/sickbeard/search_queue.py", line 145, in run
    self.success = search.snatchEpisode(result)
  File "/usr/lib/python2.7/socket.py", line 571, in create_connection
    raise err
timeout: timed out

2015-10-20 23:41:51 INFO     SEARCHQUEUE-DAILY-SEARCH :: Downloading *******.S01E01.1080p.HDTV.X264-DIMENSION from Rarbg
2015-10-20 23:41:51 DEBUG    SEARCHQUEUE-DAILY-SEARCH :: Calling Transmission Client
2015-10-20 23:41:51 DEBUG    SEARCHQUEUE-DAILY-SEARCH :: Transmission: Response to POST request is {"arguments":{},"result":"success"}
2015-10-20 23:42:21 DEBUG    SEARCHQUEUE-DAILY-SEARCH :: Traceback (most recent call last):
  File "/home/osmc/SickRage/sickbeard/search_queue.py", line 145, in run
    self.success = search.snatchEpisode(result)
  File "/usr/lib/python2.7/socket.py", line 571, in create_connection
    raise err
timeout: timed out

2015-10-20 23:51:43 INFO     SEARCHQUEUE-DAILY-SEARCH :: Downloading *******.S01E01.1080p.HDTV.X264-DIMENSION from Rarbg
2015-10-20 23:51:43 DEBUG    SEARCHQUEUE-DAILY-SEARCH :: Calling Transmission Client
2015-10-20 23:51:43 DEBUG    SEARCHQUEUE-DAILY-SEARCH :: Transmission: Response to POST request is {"arguments":{},"result":"success"}
2015-10-20 23:51:45 INFO     SEARCHQUEUE-DAILY-SEARCH :: ***: Notification sent to *****
```