### PR TITLE
Try to fix encoding error in error messages

### DIFF
--- a/sickrage/helper/exceptions.py
+++ b/sickrage/helper/exceptions.py
@@ -36,7 +36,7 @@ def ex(e):
                 fixed_arg = ss(arg)
             else:
                 try:
-                    fixed_arg = u'error %s' % ss(str(arg))
+                    fixed_arg = u'error %s' % ss(arg)
                 except Exception:
                     fixed_arg = None
 


### PR DESCRIPTION
Error: u"error ('Connection aborted.', gaierror(-2, 'Nome ou servi\\xc3\\xa7o desconhecido'))"

helpers.py are already using %r
`logger.log(u"Connection error to getURL %s Error: %r" % (url, ex(e)), logger.WARNING)`

`ss: Converts string to Unicode, fallback encoding is forced UTF-8.`

So why we are doing str() before ss() ?

```
def ss(var):
    """
    Converts string to Unicode, fallback encoding is forced UTF-8

    :param var: String to convert
    :return: Converted string
    """

    var = _to_unicode(var)
```