### PR TITLE
SCC search improvements

### DIFF
--- a/sickbeard/providers/scc.py
+++ b/sickbeard/providers/scc.py
@@ -48,15 +48,13 @@ class SCCProvider(generic.TorrentProvider):
         self.urls = {'base_url': 'https://sceneaccess.eu',
                      'login': 'https://sceneaccess.eu/login',
                      'detail': 'https://www.sceneaccess.eu/details?id=%s',
-                     'search': 'https://sceneaccess.eu/browse?search=%s&method=1&%s',
-                     'nonscene': 'https://sceneaccess.eu/nonscene?search=%s&method=1&c44=44&c45=44',
-                     'foreign': 'https://sceneaccess.eu/foreign?search=%s&method=1&c34=34&c33=33',
-                     'archive': 'https://sceneaccess.eu/archive?search=%s&method=1&c26=26',
+                     'search': 'https://sceneaccess.eu/all?search=%s&method=1&%s',
                      'download': 'https://www.sceneaccess.eu/%s'}
 
         self.url = self.urls['base_url']
 
-        self.categories = "c27=27&c17=17&c11=11"
+        self.categories = { 'sponly': 'c26=26&c44=44&c45=45', # Archive, non-scene HD, non-scene SD; need to include non-scene because WEB-DL packs get added to those categories
+                            'eponly': 'c27=27&c17=17&c44=44&c45=45&c33=33&c34=34'} # TV HD, TV SD, non-scene HD, non-scene SD, foreign XviD, foreign x264
 
     def isEnabled(self):
         return self.enabled
@@ -100,73 +98,61 @@ class SCCProvider(generic.TorrentProvider):
                 if mode != 'RSS':
                     logger.log(u"Search string: %s " % search_string, logger.DEBUG)
 
-                searchURLS = []
-                if search_mode == 'sponly':
-                    searchURLS += [self.urls['archive'] % (urllib.quote(search_string))]
-                else:
-                    searchURLS += [self.urls['search'] % (urllib.quote(search_string), self.categories)]
-                    searchURLS += [self.urls['nonscene'] % (urllib.quote(search_string))]
-                    searchURLS += [self.urls['foreign'] % (urllib.quote(search_string))]
+                searchURL = self.urls['search'] % (urllib.quote(search_string), self.categories[search_mode])
 
-                for searchURL in searchURLS:
-                    try:
-                        logger.log(u"Search URL: %s" %  searchURL, logger.DEBUG)
-                        data = self.getURL(searchURL)
-                        time.sleep(cpu_presets[sickbeard.CPU_PRESET])
-                    except Exception as e:
-                        logger.log(u"Unable to fetch data. Error: %s" % repr(e), logger.WARNING)
+                try:
+                    logger.log(u"Search URL: %s" %  searchURL, logger.DEBUG)
+                    data = self.getURL(searchURL)
+                    time.sleep(cpu_presets[sickbeard.CPU_PRESET])
+                except Exception as e:
+                    logger.log(u"Unable to fetch data. Error: %s" % repr(e), logger.WARNING)
 
-                    if not data:
+                if not data:
+                    continue
+
+                with BS4Parser(data, features=["html5lib", "permissive"]) as html:
+                    torrent_table = html.find('table', attrs={'id': 'torrents-table'})
+                    torrent_rows = torrent_table.find_all('tr') if torrent_table else []
+
+                    #Continue only if at least one Release is found
+                    if len(torrent_rows) < 2:
+                        logger.log(u"Data returned from provider does not contain any torrents", logger.DEBUG)
                         continue
 
-                    with BS4Parser(data, features=["html5lib", "permissive"]) as html:
-                        torrent_table = html.find('table', attrs={'id': 'torrents-table'})
-                        torrent_rows = torrent_table.find_all('tr') if torrent_table else []
+                    for result in torrent_table.find_all('tr')[1:]:
 
-                        #Continue only if at least one Release is found
-                        if len(torrent_rows) < 2:
-                            logger.log(u"Data returned from provider does not contain any torrents", logger.DEBUG)
+                        try:
+                            link = result.find('td', attrs={'class': 'ttr_name'}).find('a')
+                            url  = result.find('td', attrs={'class': 'td_dl'}).find('a')
+
+                            title = link.string
+                            if re.search(r'\.\.\.', title):
+                                data = self.getURL(self.url + "/" + link['href'])
+                                if data:
+                                    with BS4Parser(data) as details_html:
+                                        title = re.search('(?<=").+(?<!")', details_html.title.string).group(0)
+                            download_url = self.urls['download'] % url['href']
+                            seeders = int(result.find('td', attrs={'class': 'ttr_seeders'}).string)
+                            leechers = int(result.find('td', attrs={'class': 'ttr_leechers'}).string)
+                            #FIXME
+                            size = -1
+                        except (AttributeError, TypeError):
                             continue
 
-                        for result in torrent_table.find_all('tr')[1:]:
+                        if not all([title, download_url]):
+                            continue
 
-                            try:
-                                link = result.find('td', attrs={'class': 'ttr_name'}).find('a')
-                                all_urls = result.find('td', attrs={'class': 'td_dl'}).find_all('a', limit=2)
-                                # Foreign section contain two links, the others one
-                                if self._isSection('Foreign', data):
-                                    url = all_urls[1]
-                                else:
-                                    url = all_urls[0]
-
-                                title = link.string
-                                if re.search(r'\.\.\.', title):
-                                    data = self.getURL(self.url + "/" + link['href'])
-                                    if data:
-                                        with BS4Parser(data) as details_html:
-                                            title = re.search('(?<=").+(?<!")', details_html.title.string).group(0)
-                                download_url = self.urls['download'] % url['href']
-                                seeders = int(result.find('td', attrs={'class': 'ttr_seeders'}).string)
-                                leechers = int(result.find('td', attrs={'class': 'ttr_leechers'}).string)
-                                #FIXME
-                                size = -1
-                            except (AttributeError, TypeError):
-                                continue
-
-                            if not all([title, download_url]):
-                                continue
-
-                            #Filter unseeded torrent
-                            if seeders < self.minseed or leechers < self.minleech:
-                                if mode != 'RSS':
-                                    logger.log(u"Discarding torrent because it doesn't meet the minimum seeders or leechers: {0} (S:{1} L:{2})".format(title, seeders, leechers), logger.DEBUG)
-                                continue
-
-                            item = title, download_url, size, seeders, leechers
+                        #Filter unseeded torrent
+                        if seeders < self.minseed or leechers < self.minleech:
                             if mode != 'RSS':
-                                logger.log(u"Found result: %s " % title, logger.DEBUG)
+                                logger.log(u"Discarding torrent because it doesn't meet the minimum seeders or leechers: {0} (S:{1} L:{2})".format(title, seeders, leechers), logger.DEBUG)
+                            continue
 
-                            items[mode].append(item)
+                        item = title, download_url, size, seeders, leechers
+                        if mode != 'RSS':
+                            logger.log(u"Found result: %s " % title, logger.DEBUG)
+
+                        items[mode].append(item)
 
             #For each search mode sort all the items by seeders if available
             items[mode].sort(key=lambda tup: tup[3], reverse=True)


### PR DESCRIPTION
Updated the searching to use the new 'all' section of SCC. Changed:
- Searching in all categories now requires only one request instead of a request to all the URLs.
- Foreign categories can be handled just as any other, as the new section doesn't include a second link to the language.
- Season pack search also includes their non-scene sections as they release WEB-DL packs there instead of the archive.