### PR TITLE
Hotfix-3450: Fix airdate of 'Never' while avoiding Windows dateutil issues

### DIFF
--- a/gui/slick/views/displayShow.mako
+++ b/gui/slick/views/displayShow.mako
@@ -477,9 +477,13 @@
                 % endif
             </td>
             <td class="col-airdate">
-                % if int(epResult['airdate']) > 1 and show.network and show.airs:
+                % if int(epResult['airdate']) != 1:
                     ## Lets do this exactly like ComingEpisodes and History
-                    <% airDate = sbdatetime.sbdatetime.convert_to_setting(network_timezones.parse_date_time(epResult['airdate'], show.airs, show.network)) %>
+                    ## Avoid issues with dateutil's _isdst on Windows but still provide air dates
+                    <% airDate = datetime.datetime.fromordinal(epResult['airdate']) %>
+                    % if airDate.year >= 1970 or show.network:  
+                        <% airDate = sbdatetime.sbdatetime.convert_to_setting(network_timezones.parse_date_time(epResult['airdate'], show.airs, show.network)) %>
+                    % endif
                     <time datetime="${airDate.isoformat('T')}" class="date">${sbdatetime.sbdatetime.sbfdatetime(airDate)}</time>
                 % else:
                     Never


### PR DESCRIPTION
This fixes shows display an air date of `Never` while still protecting against `dateutil` issues on Windows as referenced in sickragetv/sickrage-issues#3450 and sickragetv/sickrage-issues#3007
