### PR TITLE
Do not make torrent labels lower case.

### DIFF
--- a/gui/slick/views/inc_qualityChooser.mako
+++ b/gui/slick/views/inc_qualityChooser.mako
@@ -16,7 +16,7 @@ bestQualities = qualities[1]
 
 <% overall_quality = Quality.combineQualities(anyQualities, bestQualities) %>
 <% selected = None %>
-<select id="qualityPreset" class="form-control form-control-inline input-sm">
+<select id="qualityPreset" name="quality_preset" class="form-control form-control-inline input-sm">
     <option value="0">Custom</option>
     % for curPreset in sorted(qualityPresets):
         <option value="${curPreset}" ${('', 'selected="selected"')[curPreset == overall_quality]} ${('', 'style="padding-left: 15px;"')[qualityPresetStrings[curPreset].endswith("0p")]}>${qualityPresetStrings[curPreset]}</option>

--- a/sickbeard/clients/rtorrent_client.py
+++ b/sickbeard/clients/rtorrent_client.py
@@ -71,8 +71,6 @@ class rTorrentAPI(GenericClient):
             label = sickbeard.TORRENT_LABEL
             if result.show.is_anime:
                 label = sickbeard.TORRENT_LABEL_ANIME
-            if label:
-                torrent.set_custom(1, label.lower())
 
             if sickbeard.TORRENT_PATH:
                 torrent.set_directory(sickbeard.TORRENT_PATH)

--- a/sickbeard/postProcessor.py
+++ b/sickbeard/postProcessor.py
@@ -813,29 +813,29 @@ class PostProcessor(object):
         # if SR downloaded this on purpose we likely have a priority download
         if self.in_history or ep_obj.status in common.Quality.SNATCHED + common.Quality.SNATCHED_PROPER + common.Quality.SNATCHED_BEST:
             # if the episode is still in a snatched status, then we can assume we want this
-            if ep_obj.status in common.Quality.SNATCHED + common.Quality.SNATCHED_PROPER + common.Quality.SNATCHED_BEST:
+            if not self.in_history:
                 self._log(u"SR snatched this episode and it is not processed before", logger.DEBUG)
                 return True
-            # if it's not snatched, we only want it if the new quality is higher or if it's a proper of equal or higher quality
+
+            # if it's in history, we only want it if the new quality is higher or if it's a proper of equal or higher quality
             if new_ep_quality > old_ep_quality and new_ep_quality != common.Quality.UNKNOWN:
                 self._log(u"SR snatched this episode and it is a higher quality so I'm marking it as priority", logger.DEBUG)
                 return True
+
             if self.is_proper and new_ep_quality >= old_ep_quality and new_ep_quality != common.Quality.UNKNOWN:
                 self._log(u"SR snatched this episode and it is a proper of equal or higher quality so I'm marking it as priority", logger.DEBUG)
                 return True
+
             return False
 
         # if the user downloaded it manually and it's higher quality than the existing episode then it's priority
         if new_ep_quality > old_ep_quality and new_ep_quality != common.Quality.UNKNOWN:
-            self._log(
-                u"This was manually downloaded but it appears to be better quality than what we have so I'm marking it as priority",
-                logger.DEBUG)
+            self._log(u"This was manually downloaded but it appears to be better quality than what we have so I'm marking it as priority", logger.DEBUG)
             return True
 
         # if the user downloaded it manually and it appears to be a PROPER/REPACK then it's priority
         if self.is_proper and new_ep_quality >= old_ep_quality and new_ep_quality != common.Quality.UNKNOWN:
-            self._log(u"This was manually downloaded but it appears to be a proper so I'm marking it as priority",
-                      logger.DEBUG)
+            self._log(u"This was manually downloaded but it appears to be a proper so I'm marking it as priority", logger.DEBUG)
             return True
 
         return False

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -1270,7 +1270,7 @@ class Home(WebRoot):
                  flatten_folders=None, paused=None, directCall=False, air_by_date=None, sports=None, dvdorder=None,
                  indexerLang=None, subtitles=None, archive_firstmatch=None, rls_ignore_words=None,
                  rls_require_words=None, anime=None, blacklist=None, whitelist=None,
-                 scene=None, defaultEpStatus=None):
+                 scene=None, defaultEpStatus=None, quality_preset=None):
 
         anidb_failed = False
         if show is None:
@@ -1290,6 +1290,9 @@ class Home(WebRoot):
                 return self._genericMessage("Error", errString)
 
         showObj.exceptions = sickbeard.scene_exceptions.get_scene_exceptions(showObj.indexerid)
+
+        if quality_preset:
+            bestQualities = []
 
         if not location and not anyQualities and not bestQualities and not flatten_folders:
             t = PageTemplate(rh=self, file="editShow.mako")
@@ -2522,9 +2525,9 @@ class HomeAddShows(Home):
         return self.redirect('/home/')
 
     def addNewShow(self, whichSeries=None, indexerLang=None, rootDir=None, defaultStatus=None,
-                   anyQualities=None, bestQualities=None, flatten_folders=None, subtitles=None,
+                   quality_preset=None, anyQualities=None, bestQualities=None, flatten_folders=None, subtitles=None,
                    fullShowPath=None, other_shows=None, skipShow=None, providedIndexer=None, anime=None,
-                   scene=None, blacklist=None, whitelist=None, defaultStatusAfter=None, archive=None):
+                   scene=None, blacklist=None, whitelist=None, defaultStatusAfter=None, archive=None, ):
         """
         Receive tvdb id, dir, and other options and create a show from them. If extra show dirs are
         provided then it forwards back to newShow, if not it goes to /home.
@@ -2621,7 +2624,7 @@ class HomeAddShows(Home):
 
         if not anyQualities:
             anyQualities = []
-        if not bestQualities:
+        if not bestQualities or quality_preset:
             bestQualities = []
         if type(anyQualities) != list:
             anyQualities = [anyQualities]
@@ -3209,6 +3212,8 @@ class Manage(Home, WebRoot):
 
             if quality_preset == 'keep':
                 anyQualities, bestQualities = Quality.splitQuality(showObj.quality)
+            elif int(quality_preset):
+                bestQualities = []
 
             exceptions_list = []
 


### PR DESCRIPTION
This can cause some issues when using rTorrent, as the upper and lower case labels are seen as two different labels, and will tell the client to move files into the wrong directory if the file system is case-sensitive. If the user wishes to keep the label lower-case, they can input a lower case label name into the field. However, the label should be accepted as-is.