### PR TITLE
Do not make torrent labels lower case

### DIFF
--- a/sickbeard/clients/rtorrent_client.py
+++ b/sickbeard/clients/rtorrent_client.py
@@ -71,8 +71,6 @@ class rTorrentAPI(GenericClient):
             label = sickbeard.TORRENT_LABEL
             if result.show.is_anime:
                 label = sickbeard.TORRENT_LABEL_ANIME
-            if label:
-                torrent.set_custom(1, label.lower())
 
             if sickbeard.TORRENT_PATH:
                 torrent.set_directory(sickbeard.TORRENT_PATH)


### PR DESCRIPTION
This can cause some issues when using rTorrent, as the upper and lower case labels are seen as two different labels, and will tell the client to move files into the wrong directory if the file system is case-sensitive. If the user wishes to keep the label lower-case, they can input a lower case label name into the field. However, the label should be accepted as-is.