### PR TITLE
kat provider for tv and anime

### DIFF
--- a/sickbeard/providers/kat.py
+++ b/sickbeard/providers/kat.py
@@ -58,12 +58,14 @@ class KATProvider(generic.TorrentProvider):
         self.url = self.urls['base_url']
         self.headers.update({'User-Agent': USER_AGENT})
 
+
+        # for serie add 'category': 'tv'
+        # for anime add 'category': 'anime'
         self.search_params = {
             'q': '',
             'field': 'seeders',
             'sorder': 'desc',
-            'rss': 1,
-            'category': 'tv'
+            'rss': 1
         }
 
     def isEnabled(self):


### PR DESCRIPTION
KAT is my favori providers but my anime stay deseperatly empty because for a anime search KAT need 'category': 'anime' instead of 'category': 'anime' 
KAT have 2 interesting category for sickrage "tv" for serie or "anime" for anime 
because we can't select in the provider the search type (anime or serie) the best is to delete the categoy parameter.