### PR TITLE
Intialize providers correctly

### DIFF
--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -36,10 +36,7 @@ from github import Github
 from sickbeard import metadata
 from sickbeard import providers
 from sickbeard.providers.generic import GenericProvider
-from sickbeard.providers import btn, newznab, womble, thepiratebay, torrentleech, kat, iptorrents, torrentz, \
-    omgwtfnzbs, scc, hdtorrents, torrentday, hdbits, hounddawgs, nextgen, speedcd, nyaatorrents, animenzb, bluetigers, cpasbien, fnt, xthor, torrentbytes, \
-    frenchtorrentdb, freshontv, titansoftv, libertalia, morethantv, bitsoup, t411, tokyotoshokan, shazbat, rarbg, alpharatio, tntvillage, binsearch, torrentproject, extratorrent, \
-    scenetime, btdigg, strike, transmitthenet, tvchaosuk, bitcannon, pretome, gftracker, hdspace
+
 from sickbeard.config import CheckSection, check_setting_int, check_setting_str, check_setting_float, ConfigMigrator, \
     naming_ep_type
 from sickbeard import searchBacklog, showUpdater, versionChecker, properFinder, autoPostProcesser, \

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import with_statement
 
 import webbrowser
 import datetime

--- a/sickbeard/dailysearcher.py
+++ b/sickbeard/dailysearcher.py
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import with_statement
 
 import datetime
 import threading

--- a/sickbeard/db.py
+++ b/sickbeard/db.py
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import with_statement
 
 import os.path
 import re

--- a/sickbeard/failedProcessor.py
+++ b/sickbeard/failedProcessor.py
@@ -16,7 +16,6 @@
 #
 # You should have received a copy of the GNU General Public License
 
-from __future__ import with_statement
 
 import sickbeard
 from sickbeard import logger

--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import with_statement
 
 import os
 import ctypes

--- a/sickbeard/logger.py
+++ b/sickbeard/logger.py
@@ -18,7 +18,6 @@
 # along with SickRage.  If not, see <http://www.gnu.org/licenses/>.
 # pylint: disable=W0703
 
-from __future__ import with_statement
 import os
 import re
 import sys

--- a/sickbeard/metadata/generic.py
+++ b/sickbeard/metadata/generic.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import with_statement
 
 import os.path
 import re

--- a/sickbeard/metadata/tivo.py
+++ b/sickbeard/metadata/tivo.py
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import with_statement
 
 import datetime
 import os

--- a/sickbeard/name_parser/parser.py
+++ b/sickbeard/name_parser/parser.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import with_statement
 
 import os
 import time

--- a/sickbeard/nzbSplitter.py
+++ b/sickbeard/nzbSplitter.py
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import with_statement
 
 import requests
 import re

--- a/sickbeard/postProcessor.py
+++ b/sickbeard/postProcessor.py
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import with_statement
 
 import glob
 import fnmatch

--- a/sickbeard/processTV.py
+++ b/sickbeard/processTV.py
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import with_statement
 
 import os
 import stat

--- a/sickbeard/providers/__init__.py
+++ b/sickbeard/providers/__init__.py
@@ -16,6 +16,11 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage.  If not, see <http://www.gnu.org/licenses/>.
 
+from sickbeard.providers import btn, newznab, womble, thepiratebay, torrentleech, kat, iptorrents, torrentz, \
+    omgwtfnzbs, scc, hdtorrents, torrentday, hdbits, hounddawgs, nextgen, speedcd, nyaatorrents, animenzb, bluetigers, cpasbien, fnt, xthor, torrentbytes, \
+    frenchtorrentdb, freshontv, titansoftv, libertalia, morethantv, bitsoup, t411, tokyotoshokan, shazbat, rarbg, alpharatio, tntvillage, binsearch, torrentproject, extratorrent, \
+    scenetime, btdigg, strike, transmitthenet, tvchaosuk, bitcannon, pretome, gftracker, hdspace
+
 __all__ = ['womble',
            'btn',
            'thepiratebay',

--- a/sickbeard/providers/generic.py
+++ b/sickbeard/providers/generic.py
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import with_statement
 
 import datetime
 import os

--- a/sickbeard/providers/kat.py
+++ b/sickbeard/providers/kat.py
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import with_statement
 
 import traceback
 

--- a/sickbeard/providers/thepiratebay.py
+++ b/sickbeard/providers/thepiratebay.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import with_statement
 
 import re
 from urllib import urlencode

--- a/sickbeard/rssfeeds.py
+++ b/sickbeard/rssfeeds.py
@@ -1,4 +1,3 @@
-from __future__ import with_statement
 
 import os
 import urllib

--- a/sickbeard/search.py
+++ b/sickbeard/search.py
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import with_statement
 
 import os
 import re

--- a/sickbeard/searchBacklog.py
+++ b/sickbeard/searchBacklog.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import with_statement
 
 import datetime
 import threading

--- a/sickbeard/search_queue.py
+++ b/sickbeard/search_queue.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import with_statement
 
 import time
 import traceback

--- a/sickbeard/show_queue.py
+++ b/sickbeard/show_queue.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import with_statement
 
 import traceback
 

--- a/sickbeard/tv.py
+++ b/sickbeard/tv.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import with_statement
 
 import os.path
 import datetime

--- a/sickbeard/tvcache.py
+++ b/sickbeard/tvcache.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import with_statement
 
 import time
 import datetime

--- a/sickbeard/webapi.py
+++ b/sickbeard/webapi.py
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import with_statement
 
 import os
 import time


### PR DESCRIPTION
No need to import with_statement from future, we don't support Python 2.6
Move providers imports to sickbeard/providers/__init__.py so that __all__ works properly.