### PR TITLE
add category options to nzbget and sabnzb for backlog episodes

### DIFF
--- a/gui/slick/views/config_search.mako
+++ b/gui/slick/views/config_search.mako
@@ -276,6 +276,16 @@
 
                             <div class="field-pair">
                                 <label>
+                                    <span class="component-title">Use SABnzbd category (backlog episodes)</span>
+                                    <span class="component-desc">
+                                        <input type="text" name="sab_category_backlog" id="sab_category_backlog" value="${sickbeard.SAB_CATEGORY_BACKLOG}" class="form-control input-sm input200" />
+                                        <p>add downloads of old episodes to this category (e.g. TV)</p>
+                                    </span>
+                                </label>
+                            </div>
+
+                            <div class="field-pair">
+                                <label>
                                     <span class="component-title">Use SABnzbd category for anime</span>
                                     <span class="component-desc">
                                         <input type="text" name="sab_category_anime" id="sab_category_anime" value="${sickbeard.SAB_CATEGORY_ANIME}" class="form-control input-sm input200" />
@@ -283,6 +293,18 @@
                                     </span>
                                 </label>
                             </div>
+
+
+                            <div class="field-pair">
+                                <label>
+                                    <span class="component-title">Use SABnzbd category for anime (backlog episodes)</span>
+                                    <span class="component-desc">
+                                        <input type="text" name="sab_category_anime_backlog" id="sab_category_anime_backlog" value="${sickbeard.SAB_CATEGORY_ANIME_BACKLOG}" class="form-control input-sm input200" />
+                                        <p>add anime downloads of old episodes to this category (e.g. anime)</p>
+                                    </span>
+                                </label>
+                            </div>
+
                             % if sickbeard.ALLOW_HIGH_PRIORITY == True:
                             <div class="field-pair">
                                 <label for="sab_forced">
@@ -350,10 +372,30 @@
 
                             <div class="field-pair">
                                 <label>
+                                    <span class="component-title">Use NZBget category (backlog episodes)</span>
+                                    <span class="component-desc">
+                                        <input type="text" name="nzbget_category_backlog" id="nzbget_category_backlog" value="${sickbeard.NZBGET_CATEGORY_BACKLOG}" class="form-control input-sm input200" />
+                                        <p>send downloads of old episodes marked this category (e.g. TV)</p>
+                                    </span>
+                                </label>
+                            </div>
+
+                            <div class="field-pair">
+                                <label>
                                     <span class="component-title">Use NZBget category for anime</span>
                                     <span class="component-desc">
                                         <input type="text" name="nzbget_category_anime" id="nzbget_category_anime" value="${sickbeard.NZBGET_CATEGORY_ANIME}" class="form-control input-sm input200" />
                                         <p>send anime downloads marked this category (e.g. anime)</p>
+                                    </span>
+                                </label>
+                            </div>
+
+                            <div class="field-pair">
+                                <label>
+                                    <span class="component-title">Use NZBget category for anime (backlog episodes)</span>
+                                    <span class="component-desc">
+                                        <input type="text" name="nzbget_category_anime_backlog" id="nzbget_category_anime_backlog" value="${sickbeard.NZBGET_CATEGORY_ANIME_BACKLOG}" class="form-control input-sm input200" />
+                                        <p>send anime downloads of old episodes marked this category (e.g. anime)</p>
                                     </span>
                                 </label>
                             </div>

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -303,13 +303,17 @@ SAB_USERNAME = None
 SAB_PASSWORD = None
 SAB_APIKEY = None
 SAB_CATEGORY = None
+SAB_CATEGORY_BACKLOG = None
 SAB_CATEGORY_ANIME = None
+SAB_CATEGORY_ANIME_BACKLOG = None
 SAB_HOST = ''
 
 NZBGET_USERNAME = None
 NZBGET_PASSWORD = None
 NZBGET_CATEGORY = None
+NZBGET_CATEGORY_BACKLOG = None
 NZBGET_CATEGORY_ANIME = None
+NZBGET_CATEGORY_ANIME_BACKLOG = None
 NZBGET_HOST = None
 NZBGET_USE_HTTPS = False
 NZBGET_PRIORITY = 100
@@ -580,8 +584,8 @@ def initialize(consoleLogging=True):
 
         global BRANCH, GIT_RESET, GIT_REMOTE, GIT_REMOTE_URL, CUR_COMMIT_HASH, CUR_COMMIT_BRANCH, GIT_NEWVER, ACTUAL_LOG_DIR, LOG_DIR, LOG_NR, LOG_SIZE, WEB_PORT, WEB_LOG, ENCRYPTION_VERSION, ENCRYPTION_SECRET, WEB_ROOT, WEB_USERNAME, WEB_PASSWORD, WEB_HOST, WEB_IPV6, WEB_COOKIE_SECRET, WEB_USE_GZIP, API_KEY, API_ROOT, ENABLE_HTTPS, HTTPS_CERT, HTTPS_KEY, \
             HANDLE_REVERSE_PROXY, USE_NZBS, USE_TORRENTS, NZB_METHOD, NZB_DIR, DOWNLOAD_PROPERS, RANDOMIZE_PROVIDERS, CHECK_PROPERS_INTERVAL, ALLOW_HIGH_PRIORITY, SAB_FORCED, TORRENT_METHOD, \
-            SAB_USERNAME, SAB_PASSWORD, SAB_APIKEY, SAB_CATEGORY, SAB_CATEGORY_ANIME, SAB_HOST, \
-            NZBGET_USERNAME, NZBGET_PASSWORD, NZBGET_CATEGORY, NZBGET_CATEGORY_ANIME, NZBGET_PRIORITY, NZBGET_HOST, NZBGET_USE_HTTPS, backlogSearchScheduler, \
+            SAB_USERNAME, SAB_PASSWORD, SAB_APIKEY, SAB_CATEGORY, SAB_CATEGORY_BACKLOG, SAB_CATEGORY_ANIME, SAB_CATEGORY_ANIME_BACKLOG, SAB_HOST, \
+            NZBGET_USERNAME, NZBGET_PASSWORD, NZBGET_CATEGORY, NZBGET_CATEGORY_BACKLOG, NZBGET_CATEGORY_ANIME, NZBGET_CATEGORY_ANIME_BACKLOG, NZBGET_PRIORITY, NZBGET_HOST, NZBGET_USE_HTTPS, backlogSearchScheduler, \
             TORRENT_USERNAME, TORRENT_PASSWORD, TORRENT_HOST, TORRENT_PATH, TORRENT_SEED_TIME, TORRENT_PAUSED, TORRENT_HIGH_BANDWIDTH, TORRENT_LABEL, TORRENT_LABEL_ANIME, TORRENT_VERIFY_CERT, TORRENT_RPCURL, TORRENT_AUTH_TYPE, \
             USE_KODI, KODI_ALWAYS_ON, KODI_NOTIFY_ONSNATCH, KODI_NOTIFY_ONDOWNLOAD, KODI_NOTIFY_ONSUBTITLEDOWNLOAD, KODI_UPDATE_FULL, KODI_UPDATE_ONLYFIRST, \
             KODI_UPDATE_LIBRARY, KODI_HOST, KODI_USERNAME, KODI_PASSWORD, BACKLOG_FREQUENCY, \
@@ -939,14 +943,18 @@ def initialize(consoleLogging=True):
         SAB_PASSWORD = check_setting_str(CFG, 'SABnzbd', 'sab_password', '', censor_log=True)
         SAB_APIKEY = check_setting_str(CFG, 'SABnzbd', 'sab_apikey', '', censor_log=True)
         SAB_CATEGORY = check_setting_str(CFG, 'SABnzbd', 'sab_category', 'tv')
+        SAB_CATEGORY_BACKLOG = check_setting_str(CFG, 'SABnzbd', 'sab_category_backlog', SAB_CATEGORY )
         SAB_CATEGORY_ANIME = check_setting_str(CFG, 'SABnzbd', 'sab_category_anime', 'anime')
+        SAB_CATEGORY_ANIME_BACKLOG = check_setting_str(CFG, 'SABnzbd', 'sab_category_anime_backlog', SAB_CATEGORY_ANIME )
         SAB_HOST = check_setting_str(CFG, 'SABnzbd', 'sab_host', '')
         SAB_FORCED = bool(check_setting_int(CFG, 'SABnzbd', 'sab_forced', 0))
 
         NZBGET_USERNAME = check_setting_str(CFG, 'NZBget', 'nzbget_username', 'nzbget', censor_log=True)
         NZBGET_PASSWORD = check_setting_str(CFG, 'NZBget', 'nzbget_password', 'tegbzn6789', censor_log=True)
         NZBGET_CATEGORY = check_setting_str(CFG, 'NZBget', 'nzbget_category', 'tv')
+        NZBGET_CATEGORY_BACKLOG = check_setting_str(CFG, 'NZBget', 'nzbget_category_backlog', NZBGET_CATEGORY )
         NZBGET_CATEGORY_ANIME = check_setting_str(CFG, 'NZBget', 'nzbget_category_anime', 'anime')
+        NZBGET_CATEGORY_ANIME_BACKLOG = check_setting_str(CFG, 'NZBget', 'nzbget_category_anime_backlog', NZBGET_CATEGORY_ANIME )
         NZBGET_HOST = check_setting_str(CFG, 'NZBget', 'nzbget_host', '')
         NZBGET_USE_HTTPS = bool(check_setting_int(CFG, 'NZBget', 'nzbget_use_https', 0))
         NZBGET_PRIORITY = check_setting_int(CFG, 'NZBget', 'nzbget_priority', 100)
@@ -1907,7 +1915,9 @@ def save_config():
     new_config['SABnzbd']['sab_password'] = helpers.encrypt(SAB_PASSWORD, ENCRYPTION_VERSION)
     new_config['SABnzbd']['sab_apikey'] = SAB_APIKEY
     new_config['SABnzbd']['sab_category'] = SAB_CATEGORY
+    new_config['SABnzbd']['sab_category_backlog'] = SAB_CATEGORY_BACKLOG
     new_config['SABnzbd']['sab_category_anime'] = SAB_CATEGORY_ANIME
+    new_config['SABnzbd']['sab_category_anime_backlog'] = SAB_CATEGORY_ANIME_BACKLOG
     new_config['SABnzbd']['sab_host'] = SAB_HOST
     new_config['SABnzbd']['sab_forced'] = int(SAB_FORCED)
 
@@ -1916,7 +1926,9 @@ def save_config():
     new_config['NZBget']['nzbget_username'] = NZBGET_USERNAME
     new_config['NZBget']['nzbget_password'] = helpers.encrypt(NZBGET_PASSWORD, ENCRYPTION_VERSION)
     new_config['NZBget']['nzbget_category'] = NZBGET_CATEGORY
+    new_config['NZBget']['nzbget_category_backlog'] = NZBGET_CATEGORY_BACKLOG
     new_config['NZBget']['nzbget_category_anime'] = NZBGET_CATEGORY_ANIME
+    new_config['NZBget']['nzbget_category_anime_backlog'] = NZBGET_CATEGORY_ANIME_BACKLOG
     new_config['NZBget']['nzbget_host'] = NZBGET_HOST
     new_config['NZBget']['nzbget_use_https'] = int(NZBGET_USE_HTTPS)
     new_config['NZBget']['nzbget_priority'] = NZBGET_PRIORITY

--- a/sickbeard/nzbget.py
+++ b/sickbeard/nzbget.py
@@ -92,6 +92,10 @@ def sendNZB(nzb, proper=False):
         if datetime.date.today() - curEp.airdate <= datetime.timedelta(days=7):
             addToTop = True
             nzbgetprio = sickbeard.NZBGET_PRIORITY
+        else:
+            category = sickbeard.NZBGET_CATEGORY_BACKLOG
+            if nzb.show.is_anime:
+                category = sickbeard.NZBGET_CATEGORY_ANIME_BACKLOG
 
     if nzb.quality != Quality.UNKNOWN:
         dupescore = nzb.quality * 100

--- a/sickbeard/sab.py
+++ b/sickbeard/sab.py
@@ -52,6 +52,14 @@ def sendNZB(nzb):
     category = sickbeard.SAB_CATEGORY
     if nzb.show.is_anime:
         category = sickbeard.SAB_CATEGORY_ANIME
+
+    # if it aired more than 7 days ago, override with the backlog category IDs
+    for curEp in nzb.episodes:
+        if datetime.date.today() - curEp.airdate > datetime.timedelta(days=7):
+            category = sickbeard.NZBGET_CATEGORY_BACKLOG
+            if nzb.show.is_anime:
+                category = sickbeard.NZBGET_CATEGORY_ANIME_BACKLOG
+
     if category != None:
         params['cat'] = category
 

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -3804,8 +3804,8 @@ class ConfigSearch(Config):
         return t.render(submenu=self.ConfigMenu(), title='Config - Episode Search', header='Search Settings', topmenu='config')
 
     def saveSearch(self, use_nzbs=None, use_torrents=None, nzb_dir=None, sab_username=None, sab_password=None,
-                   sab_apikey=None, sab_category=None, sab_category_anime=None, sab_host=None, nzbget_username=None,
-                   nzbget_password=None, nzbget_category=None, nzbget_category_anime=None, nzbget_priority=None,
+                   sab_apikey=None, sab_category=None, sab_category_anime=None, sab_category_backlog=None, sab_category_anime_backlog=None, sab_host=None, nzbget_username=None,
+                   nzbget_password=None, nzbget_category=None, nzbget_category_backlog=None, nzbget_category_anime=None, nzbget_category_anime_backlog=None, nzbget_priority=None,
                    nzbget_host=None, nzbget_use_https=None, backlog_frequency=None,
                    dailysearch_frequency=None, nzb_method=None, torrent_method=None, usenet_retention=None,
                    download_propers=None, check_propers_interval=None, allow_high_priority=None, sab_forced=None,
@@ -3853,14 +3853,18 @@ class ConfigSearch(Config):
         sickbeard.SAB_PASSWORD = sab_password
         sickbeard.SAB_APIKEY = sab_apikey.strip()
         sickbeard.SAB_CATEGORY = sab_category
+        sickbeard.SAB_CATEGORY_BACKLOG = sab_category_backlog
         sickbeard.SAB_CATEGORY_ANIME = sab_category_anime
+        sickbeard.SAB_CATEGORY_ANIME_BACKLOG = sab_category_anime_backlog
         sickbeard.SAB_HOST = config.clean_url(sab_host)
         sickbeard.SAB_FORCED = config.checkbox_to_value(sab_forced)
 
         sickbeard.NZBGET_USERNAME = nzbget_username
         sickbeard.NZBGET_PASSWORD = nzbget_password
         sickbeard.NZBGET_CATEGORY = nzbget_category
+        sickbeard.NZBGET_CATEGORY_BACKLOG = nzbget_category_backlog
         sickbeard.NZBGET_CATEGORY_ANIME = nzbget_category_anime
+        sickbeard.NZBGET_CATEGORY_ANIME_BACKLOG = nzbget_category_anime_backlog
         sickbeard.NZBGET_HOST = config.clean_host(nzbget_host)
         sickbeard.NZBGET_USE_HTTPS = config.checkbox_to_value(nzbget_use_https)
         sickbeard.NZBGET_PRIORITY = config.to_int(nzbget_priority, default=100)


### PR DESCRIPTION
This patch allows the user to set backlog vs. daily fetch categories in nzbget and sabnzb. I have fully tested that the config changes work, and that episodes get added to nzbget correctly. I have not tested sabnzb, which consists of 4 lines of code that were almost copy and pasted from the nzbget change.

Upgrade:
the backlog categories are set by default to the value of the daily fetch category

Purpose:
For users who fetch on one machine and then transfer the files to the SickRage host, this will allow them to prioritize daily fetch episodes over backlog episodes by putting them in a completely different directory or doing other post-processing via NZBGet's postprocesor (which doesn't have access to the priorities we set when adding an nzb file, but does have access to the category)