### PR TITLE
Make "newpct" configs more n00b friendly

### DIFF
--- a/gui/slick/views/config_providers.mako
+++ b/gui/slick/views/config_providers.mako
@@ -473,7 +473,7 @@ $('#config-components').tabs();
                                 <span class="component-title">Append identifier:</span>
                                 <span class="component-desc">
                                     <input type="text" name="${curTorrentProvider.getID()}_append_identifier" id="${curTorrentProvider.getID()}_append_identifier" value="${curTorrentProvider.append_identifier}" class="form-control input-sm input350" />
-                                    <p>Append an identifier to every episode snatched by this provider. Usefull in combination with "Required Words" on show configuration if you want to download certain shows only from this provider.</p>
+                                    <p>Append an identifier to every episode snatched by this provider. Usefull in combination with "Required Words" on show configuration if you want to download certain shows only from this provider. Examples: [RARBG], [Newpct], [KAT]...</p>
                                 </span>
                             </label>
                         </div>

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -1270,7 +1270,7 @@ def initialize(consoleLogging=True):
 
             if hasattr(curTorrentProvider, 'append_identifier'):
                 curTorrentProvider.append_identifier = check_setting_str(CFG, curTorrentProvider.getID().upper(),
-                                                                         curTorrentProvider.getID() + '_append_identifier', '[' + curTorrentProvider.name + ']')
+                                                                         curTorrentProvider.getID() + '_append_identifier', '')
 
             if hasattr(curTorrentProvider, 'sorting'):
                 curTorrentProvider.sorting = check_setting_str(CFG, curTorrentProvider.getID().upper(),

--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -1266,7 +1266,7 @@ def initialize(consoleLogging=True):
 
             if hasattr(curTorrentProvider, 'onlyspasearch'):
                 curTorrentProvider.onlyspasearch = bool(check_setting_int(CFG, curTorrentProvider.getID().upper(),
-                                                                          curTorrentProvider.getID() + '_onlyspasearch', 1))
+                                                                          curTorrentProvider.getID() + '_onlyspasearch', 0))
 
             if hasattr(curTorrentProvider, 'append_identifier'):
                 curTorrentProvider.append_identifier = check_setting_str(CFG, curTorrentProvider.getID().upper(),


### PR DESCRIPTION
Make the append identifier blank by default ,the only spanish language shows disabled by default and add tooltip exaples to the append identifier..