### PR TITLE
No normal regex anime

### DIFF
--- a/sickbeard/helpers.py
+++ b/sickbeard/helpers.py
@@ -237,7 +237,7 @@ def isMediaFile(filename):
     """
 
     # ignore samples
-    if re.search(r'(^|[\W_])(sample\d*)[\W_]', filename, re.I):
+    if re.search(r'(^|[\W_])(?<!shomin.)(sample\d*)[\W_]', filename, re.I):
         return False
 
     # ignore RARBG release intro

--- a/sickbeard/name_parser/parser.py
+++ b/sickbeard/name_parser/parser.py
@@ -78,7 +78,7 @@ class NameParser(object):
     def _compile_regexes(self, regexMode):
         if regexMode == self.ANIME_REGEX:
             dbg_str = u"ANIME"
-            uncompiled_regex = [regexes.anime_regexes, regexes.normal_regexes]
+            uncompiled_regex = [regexes.anime_regexes]
         elif regexMode == self.NORMAL_REGEX:
             dbg_str = u"NORMAL"
             uncompiled_regex = [regexes.normal_regexes]

--- a/sickbeard/show_name_helpers.py
+++ b/sickbeard/show_name_helpers.py
@@ -34,8 +34,8 @@ from name_parser.parser import NameParser, InvalidNameException, InvalidShowExce
 
 resultFilters = [
     "sub(bed|ed|pack|s)",
-    "(dir|sample|sub|nfo)fix",
-    "sample",
+    "(dir|sub|nfo)fix",
+    "(?<!shomin.)sample",
     "(dvd)?extras",
     "dub(bed)?"
 ]


### PR DESCRIPTION
Shouldnt include normal regexes and confuse the score when we know the show is anime.
Dont ignore results/files that include the word "sample" if it is preceeded by shomin and a seperator.