### PR TITLE
Fix anime parsing

### DIFF
--- a/sickbeard/name_parser/parser.py
+++ b/sickbeard/name_parser/parser.py
@@ -394,15 +394,16 @@ class NameParser(object):
 
         return number
 
-    def parse(self, name, cache_result=True):
+    def parse(self, name, cache_result=True, use_cache=True):
         name = self._unicodify(name)
 
         if self.naming_pattern:
             cache_result = False
 
-        cached = name_parser_cache.get(name)
-        if cached:
-            return cached
+        if use_cache:
+            cached = name_parser_cache.get(name)
+            if cached:
+                return cached
 
         # break it into parts if there are any (dirname, file name, extension)
         dir_name, file_name = ek(os.path.split, name)

--- a/sickbeard/name_parser/regexes.py
+++ b/sickbeard/name_parser/regexes.py
@@ -187,7 +187,7 @@ normal_regexes = [
      # 01 - Ep Name
      # 01 - Ep Name
      r'''
-     ^((?P<series_name>.+?)(?:[. _-]{2,}|[. _]))?    # Show_Name and separator
+     ^((\[(.*?)\])[. _-])?((?P<series_name>.+?)(?:[. _-]{2,}|[. _]))?    # Show_Name and separator
      (?P<ep_num>\d{1,3})                             # 02
      (?:-(?P<extra_ep_num>\d{1,3}))*                 # -03-04-05 etc
      \s?of?\s?\d{1,3}?                               # of joiner (with or without spaces) and series total ep
@@ -239,14 +239,14 @@ anime_regexes = [
      # [ISLAND]One_Piece_679_[VOSTFR]_[8bit]_[720p]_[EB7838FC].mp4
      r'''
      ^\[(?P<release_group>ISLAND?)\]                                          # Release Group
-	 (?P<series_name>.+?)[ ._-]+                                              # Show_Name and separator
-	 (?P<ep_ab_num>\d{1,3})[ ._-]+                                            # Episode number
-	 (\[VOSTFR\])
-	 ([ ._-]+\[[vV](?P<version>[0-9])\])*[ ._-]+                              # Version
-	 (\[(8bit|10bit)\])?[ ._-]+
-	 \[(?P<extra_info>(\d{3,4}[xp]?\d{0,4})?[\.\w\s-]*)\][ ._-]+              # Extra info
-	 (\[(?P<crc>\w{8})\])?                                                    # CRC
-	 .*?
+     (?P<series_name>.+?)[ ._-]+                                              # Show_Name and separator
+     (?P<ep_ab_num>\d{1,3})[ ._-]+                                            # Episode number
+     (\[VOSTFR\])
+     ([ ._-]+\[[vV](?P<version>[0-9])\])*[ ._-]+                              # Version
+     (\[(8bit|10bit)\])?[ ._-]+
+     \[(?P<extra_info>(\d{3,4}[xp]?\d{0,4})?[\.\w\s-]*)\][ ._-]+              # Extra info
+     (\[(?P<crc>\w{8})\])?                                                    # CRC
+     .*?
      '''),
 
     ('anime_Kaerizaki-Fansub',
@@ -426,6 +426,11 @@ anime_regexes = [
      r'''
      ^(?P<ep_ab_num>\d{3,4})(-(?P<extra_ab_ep_num>\d{3,4}))?\.\s+(?P<series_name>.+?)\s-\s.*
      '''),
+     
+    ('anime_MangaOff',
+     # 003. Show Name - Ep Name.ext
+     # 003-004. Show Name - Ep Name.ext
+     ur'(?P<series_name>.+?)[ ._-]+(E(?P<ep_ab_num>\d{1,4})[ ._-]+)(.*)FANSUB[ ._-]+VOSTFR(.*?)([ ._-](\d{1,4}[pi])[ ._-])?(.*)[ ._-](?P<release_group>.*)'),     
 
     ('anime_bare',
      # One Piece - 102

--- a/sickbeard/postProcessor.py
+++ b/sickbeard/postProcessor.py
@@ -524,6 +524,23 @@ class PostProcessor(object):
 
         # show object
         show = parse_result.show
+        
+        if(hasattr(show, 'is_anime')):
+            previous_np = np    
+            previous_parse = parse_result         
+            try:
+                logger.log(u"Let s try to reparse since " + name + " is an anime", logger.DEBUG)       
+                myParser = NameParser(True, show, True)
+                parse_result = myParser.parse(name, use_cache=False)
+            except InvalidNameException:
+                parse_result = previous_parse
+                np = previous_np
+                logger.log(u"Unable to re-parse as anime the filename " + title + " into a valid episode", logger.DEBUG)
+            except InvalidShowException:
+                np = previous_np
+                parse_result = previous_parse
+                logger.log(u"Unable to re-parse as anime the filename " + title + " into a valid show", logger.DEBUG)                      
+        show = parse_result.show        
 
         if parse_result.is_air_by_date:
             season = -1

--- a/sickbeard/providers/generic.py
+++ b/sickbeard/providers/generic.py
@@ -392,7 +392,24 @@ class GenericProvider:
                 logger.log(u"Unable to parse the filename " + title + " into a valid show", logger.DEBUG)
                 continue
 
-            showObj = parse_result.show
+                
+            previous_parse = parse_result
+            if(hasattr(previous_parse.show, 'is_anime')):
+                try:
+                    logger.log(u"Let s try to reparse since " + title + " is an anime", logger.DEBUG)       
+                    myParser = NameParser(True, previous_parse.show, True)
+                    parse_result = myParser.parse(title, use_cache=False)
+                except InvalidNameException:
+                    parse_result = previous_parse
+                    logger.log(u"Unable to re-parse as anime the filename " + title + " into a valid episode", logger.DEBUG)
+                    continue
+                except InvalidShowException:
+                    parse_result = previous_parse
+                    logger.log(u"Unable to re-parse as anime the filename " + title + " into a valid show", logger.DEBUG)
+                    continue
+                                    
+                
+            showObj = parse_result.show 
             quality = parse_result.quality
             release_group = parse_result.release_group
             version = parse_result.version


### PR DESCRIPTION
Sometime, a show is parsed without knowing that's an anime.
That can lead to errors, for exemple : 
Show.Name.102.Source.Quality.Etc-Group 

If parsed as ALL_REGEX it will be validate as a TV show S01E02
If parsed as Anime, it will be validate as a Anime with absolute number : Episode 102

So, when i parse something as ALL_REGEX, if the result is a show who have is_anime == true, it will restart the parsing as anime.

Because most of the time, even if the TV episode number is wrong, it will at least match the episode name.

I just made a little change into regex for the no_season to have a better match of the episode name (for some case when the name start with [XXXX]Show_Name, to not include [XXXX] in the show name.