### PR TITLE
add aria-haspopup to force ie11/edge to emulate hover on these elemen…

### DIFF
--- a/gui/slick/views/layouts/main.mako
+++ b/gui/slick/views/layouts/main.mako
@@ -109,7 +109,7 @@
                 <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
                     <ul class="nav navbar-nav navbar-right">
                         <li id="NAVhome" class="navbar-split dropdown${('', ' active')[topmenu == 'home']}">
-                            <a href="${srRoot}/home/" class="dropdown-toggle" data-toggle="dropdown" data-hover="dropdown">Shows
+                            <a href="${srRoot}/home/" class="dropdown-toggle" aria-haspopup="true" data-toggle="dropdown" data-hover="dropdown"><span>Shows</span>
                             <b class="caret"></b>
                             </a>
                             <ul class="dropdown-menu">
@@ -135,7 +135,7 @@
                         </li>
 
                         <li id="NAVmanage" class="navbar-split dropdown${('', ' active')[topmenu == 'manage']}">
-                            <a href="${srRoot}/manage/episodeStatuses/" class="dropdown-toggle" data-toggle="dropdown" data-hover="dropdown">Manage
+                            <a href="${srRoot}/manage/episodeStatuses/" class="dropdown-toggle" aria-haspopup="true" data-toggle="dropdown" data-hover="dropdown"><span>Manage</span>
                             <b class="caret"></b>
                             </a>
                             <ul class="dropdown-menu">
@@ -166,7 +166,7 @@
                         </li>
 
                         <li id="NAVconfig" class="navbar-split dropdown${('', ' active')[topmenu == 'config']}">
-                            <a href="${srRoot}/config/" class="dropdown-toggle" data-toggle="dropdown" data-hover="dropdown"><span class="visible-xs-inline">Config</span><img src="${srRoot}/images/menu/system18.png" class="navbaricon hidden-xs" />
+                            <a href="${srRoot}/config/" class="dropdown-toggle" aria-haspopup="true" data-toggle="dropdown" data-hover="dropdown"><span class="visible-xs-inline">Config</span><img src="${srRoot}/images/menu/system18.png" class="navbaricon hidden-xs" />
                             <b class="caret"></b>
                             </a>
                             <ul class="dropdown-menu">
@@ -203,7 +203,7 @@
                                 toolsBadge = ''
                         %>
                         <li id="NAVsystem" class="navbar-split dropdown${('', ' active')[topmenu == 'system']}">
-                            <a href="${srRoot}/home/status/" class="dropdown-toggle" data-toggle="dropdown" data-hover="dropdown"><span class="visible-xs-inline">Tools</span><img src="${srRoot}/images/menu/system18-2.png" class="navbaricon hidden-xs" />${toolsBadge}
+                            <a href="${srRoot}/home/status/" class="dropdown-toggle" aria-haspopup="true" data-toggle="dropdown" data-hover="dropdown"><span class="visible-xs-inline">Tools</span><img src="${srRoot}/images/menu/system18-2.png" class="navbaricon hidden-xs" />${toolsBadge}
                             <b class="caret"></b>
                             </a>
                             <ul class="dropdown-menu">


### PR DESCRIPTION
…ts, also add superfluous span so that bootstrap-hover-dropdown correctly attaches the events

Okay, i think i've finally got it this time. I've added aria-haspopup="true", which makes IE11 and Edge emulate a hover on touchscreens, so the menu pops up properly. See also http://www.w3.org/TR/wai-aria/states_and_properties The one weird thing is i had to add a superfluous span around the text inside the anchor for the anchors where there wasn't already a span or image. I have a sinking feeling this might be a bug/quirk in bootstrap-hover-dropdown, but trying to figure out what is going on there is a pretty dark hole. Tested on every browser i could get my hands on, in portrait, landscape and mobile, and it seems to work great everywhere.

Note this will probably conflict with my other pull request.