### PR TITLE
Update clients/__init__.py for PEPs 8 and 263

### DIFF
--- a/sickbeard/clients/__init__.py
+++ b/sickbeard/clients/__init__.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 # Author: Nic Wolfe <nic@wolfeden.ca>
 # URL: http://code.google.com/p/sickbeard/
 #

--- a/sickbeard/clients/__init__.py
+++ b/sickbeard/clients/__init__.py
@@ -16,17 +16,16 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage.  If not, see <http://www.gnu.org/licenses/>.
 
-__all__ = ['utorrent',
-           'transmission',
-           'deluge',
-           'deluged',
-           'download_station',
-           'rtorrent',
-           'qbittorrent',
-           'mlnet'
+__all__ = [
+    'utorrent',
+    'transmission',
+    'deluge',
+    'deluged',
+    'download_station',
+    'rtorrent',
+    'qbittorrent',
+    'mlnet'
 ]
-
-
 
 # Mapping error status codes to official W3C names
 http_error_code = {
@@ -103,14 +102,15 @@ http_error_code = {
     599: 'Network connect timeout error '
 }
 
-default_host = {'utorrent': 'http://localhost:8000',
-                'transmission': 'http://localhost:9091',
-                'deluge': 'http://localhost:8112',
-                'deluged': 'scgi://localhost:58846',
-                'download_station': 'http://localhost:5000',
-                'rtorrent': 'scgi://localhost:5000',
-                'qbittorrent': 'http://localhost:8080',
-                'mlnet': 'http://localhost:4080'
+default_host = {
+    'utorrent': 'http://localhost:8000',
+    'transmission': 'http://localhost:9091',
+    'deluge': 'http://localhost:8112',
+    'deluged': 'scgi://localhost:58846',
+    'download_station': 'http://localhost:5000',
+    'rtorrent': 'scgi://localhost:5000',
+    'qbittorrent': 'http://localhost:8080',
+    'mlnet': 'http://localhost:4080'
 }
 
 

--- a/sickbeard/clients/__init__.py
+++ b/sickbeard/clients/__init__.py
@@ -30,6 +30,7 @@ __all__ = [
 
 # Mapping error status codes to official W3C names
 http_error_code = {
+    # todo: Handle error codes with duplicates (e.g. 451, 499)
     300: 'Multiple Choices',
     301: 'Moved Permanently',
     302: 'Found',


### PR DESCRIPTION
#### Formatting changes:
- b0ba95e PEP 8: Fix indentation and remove excess blank lines	
- 9f88c26 PEP 263: Add encoding declaration	
- 93990f0 Add a todo for handling duplicate http error codes in dict	