### PR TITLE
Update metadata/__init__.py for PEPs 8 and 263

### DIFF
--- a/sickbeard/metadata/__init__.py
+++ b/sickbeard/metadata/__init__.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 # Author: Nic Wolfe <nic@wolfeden.ca>
 # URL: http://code.google.com/p/sickbeard/
 #

--- a/sickbeard/metadata/__init__.py
+++ b/sickbeard/metadata/__init__.py
@@ -16,10 +16,10 @@
 # You should have received a copy of the GNU General Public License
 # along with SickRage.  If not, see <http://www.gnu.org/licenses/>.
 
-__all__ = ['generic', 'helpers', 'kodi', 'kodi_12plus', 'mediabrowser', 'ps3', 'wdtv', 'tivo', 'mede8er']
-
 import sys
 from sickbeard.metadata import kodi, kodi_12plus, mediabrowser, ps3, wdtv, tivo, mede8er, generic, helpers
+
+__all__ = ['generic', 'helpers', 'kodi', 'kodi_12plus', 'mediabrowser', 'ps3', 'wdtv', 'tivo', 'mede8er']
 
 
 def available_generators():

--- a/sickbeard/metadata/__init__.py
+++ b/sickbeard/metadata/__init__.py
@@ -25,6 +25,7 @@ __all__ = ['generic', 'helpers', 'kodi', 'kodi_12plus', 'mediabrowser', 'ps3', '
 def available_generators():
     return [x for x in __all__ if x not in ['generic', 'helpers']]
 
+
 def _getMetadataModule(name):
     name = name.lower()
     prefix = "sickbeard.metadata."


### PR DESCRIPTION
#### Formatting changes:
- 91009f7 PEP 0008: Move module level imports to top of file	
- ef5a113 PEP 0008: Add and remove blank lines for consistency	
- 275b55f PEP 0263: Add encoding declaration	