### PR TITLE
Remove unused imports in mako

### DIFF
--- a/gui/slick/views/displayShow.mako
+++ b/gui/slick/views/displayShow.mako
@@ -7,9 +7,8 @@
     from sickbeard import subtitles, sbdatetime, network_timezones
     import sickbeard.helpers
 
-    from sickbeard.common import SKIPPED, WANTED, UNAIRED, ARCHIVED, IGNORED, SNATCHED, SNATCHED_PROPER, SNATCHED_BEST, FAILED
+    from sickbeard.common import SKIPPED, WANTED, UNAIRED, ARCHIVED, IGNORED, FAILED
     from sickbeard.common import Quality, qualityPresets, statusStrings, Overview
-
     from sickbeard.helpers import anon_url
 %>
 <%block name="scripts">

--- a/gui/slick/views/home.mako
+++ b/gui/slick/views/home.mako
@@ -2,10 +2,8 @@
 <%!
     import sickbeard
     import calendar
-    from sickbeard.common import SKIPPED, WANTED, UNAIRED, ARCHIVED, IGNORED, SNATCHED, SNATCHED_PROPER, SNATCHED_BEST, FAILED
-    from sickbeard.common import Quality, qualityPresets, qualityPresetStrings
-    from sickbeard import db, sbdatetime, network_timezones
-    import datetime
+    from sickbeard import sbdatetime
+    from sickbeard import network_timezones
     import re
 %>
 <%block name="metas">
@@ -404,7 +402,7 @@
         <%
             display_status = curShow.status
             if None is not display_status:
-                if re.search('(?i)(?:new|returning)\s*series', curShow.status):
+                if re.search(r'(?i)(?:new|returning)\s*series', curShow.status):
                     display_status = 'Continuing'
                 elif re.search('(?i)(?:nded)', curShow.status):
                     display_status = 'Ended'


### PR DESCRIPTION
@OmgImAlexis I figured out how to lint mako fairly ok, I just lint the py files in cache/mako =P