### PR TITLE
Fix Libertalia provider

### DIFF
--- a/sickbeard/providers/libertalia.py
+++ b/sickbeard/providers/libertalia.py
@@ -99,7 +99,7 @@ class LibertaliaProvider(generic.TorrentProvider):
                 with BS4Parser(data, features=["html5lib", "permissive"]) as html:
                     resultsTable = html.find("table", {"class" : "torrent_table"})
                     if resultsTable:
-                        rows = resultsTable.findAll("tr", {"class" : re.compile("torrent_row(.*)?")})
+                        rows = resultsTable.findAll("tr", {"class" : re.compile("torrent_row\.*")})
                         for row in rows:
 
                             # bypass first row because title only


### PR DESCRIPTION
Correct regex which makes Libertalia unusable

[Libertalia] :: Error while searching Libertalia, skipping: nothing to repeat