### PR TITLE
Fix post processing non-ascii

### DIFF
--- a/sickbeard/processTV.py
+++ b/sickbeard/processTV.py
@@ -28,7 +28,7 @@ from sickbeard import logger
 from sickbeard.name_parser.parser import NameParser, InvalidNameException, InvalidShowException
 from sickbeard import common
 from sickbeard import failedProcessor
-from sickrage.helper.encoding import ek
+from sickrage.helper.encoding import ek, ss
 from sickrage.helper.exceptions import EpisodePostProcessingFailedException, ex, FailedPostProcessingFailedException
 
 from unrar2 import RarFile
@@ -516,7 +516,7 @@ def already_postprocessed(dirName, videofile, force, result):
 
         search_sql += " and tv_episodes.status IN (" + ",".join([str(x) for x in common.Quality.DOWNLOADED]) + ")"
         search_sql += " and history.resource LIKE ?"
-        sqlResult = myDB.select(search_sql, [u'%' + videofile])
+        sqlResult = myDB.select(search_sql, ['%' + videofile])
         if sqlResult:
             # result.output += logHelper(u"You're trying to post process a video that's already been processed, skipping", logger.DEBUG)
             return True

--- a/sickbeard/webserve.py
+++ b/sickbeard/webserve.py
@@ -2192,8 +2192,10 @@ class HomePostProcess(Home):
         if not proc_dir:
             return self.redirect("/home/postprocess/")
         else:
+            nzbName = ss(nzbName) if nzbName else nzbName
+
             result = processTV.processDir(
-                proc_dir, nzbName, process_method=process_method, force=argToBool(force),
+                ss(proc_dir), nzbName, process_method=process_method, force=argToBool(force),
                 is_priority=argToBool(is_priority), delete_on=argToBool(delete_on), failed=argToBool(failed), proc_type=proc_type
             )
 


### PR DESCRIPTION
This makes post processing work again. I am sure there are other ascii decoding fixes needed still in other places, especially notifiers.

Need to make everything work without the reload(sys) and setdefault encoding before moving on to removing ek/ss calls.