### PR TITLE
Convert statusstrings to a NumDict

### DIFF
--- a/sickbeard/__init__.py
+++ b/sickbeard/__init__.py
@@ -39,7 +39,7 @@ from sickbeard.providers.generic import GenericProvider
 from sickbeard.config import CheckSection, check_setting_int, check_setting_str, check_setting_float, ConfigMigrator, \
     naming_ep_type
 from sickbeard import searchBacklog, showUpdater, versionChecker, properFinder, autoPostProcesser, \
-    subtitles, traktChecker
+    subtitles, traktChecker, numdict
 from sickbeard import db
 from sickbeard import helpers
 from sickbeard import scheduler

--- a/sickbeard/common.py
+++ b/sickbeard/common.py
@@ -22,7 +22,13 @@ import operator
 import platform
 import re
 import uuid
-from UserDict import UserDict
+from numdict import NumDict
+
+import sys
+import os.path
+
+sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '../lib')))
+sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from random import shuffle
 
@@ -513,72 +519,43 @@ qualityPresetStrings = {SD: "SD",
                         ANY: "Any"}
 
 
-class StatusStrings(UserDict):
+class StatusStrings(NumDict):
     """
     Dictionary containing strings for status codes
-
-    Keys must be convertible to int or a ValueError will be raised.  This is intentional to match old functionality until
-    the old StatusStrings is fully deprecated, then we will raise a KeyError instead, where appropriate.
-
-    Membership checks using __contains__ (i.e. 'x in y') do not raise a ValueError to match expected dict functionality
     """
     # todo: Deprecate StatusStrings().statusStrings and use StatusStrings() directly
     # todo: Deprecate .has_key and switch to 'x in y'
-    # todo: Switch from raising ValueError to a saner KeyError
-    # todo: Raise KeyError when unable to resolve a missing key instead of returning ''
-    # todo: Make key of None match dict() functionality
+    # todo: Make views return Qualities too
+    # todo:
+
+    qualities = Quality.DOWNLOADED + Quality.SNATCHED + Quality.SNATCHED_PROPER + Quality.SNATCHED_BEST + Quality.ARCHIVED
 
     @property
     def statusStrings(self):  # for backwards compatibility
         return self.data
 
-    def __setitem__(self, key, value):
-        self.data[int(key)] = value  # make sure all keys being assigned values are ints
-
     def __missing__(self, key):
         """
-        If the key is not found, search for the missing key in qualities
+        If the key is not found try to determine a status from Quality
 
-        Keys must be convertible to int or a ValueError will be raised.  This is intentional to match old functionality until
-        the old StatusStrings is fully deprecated, then we will raise a KeyError instead, where appropriate.
+        :param key: A numeric key or None
+        :raise KeyError: if the key is invalid and can't be determined from Quality
         """
-        if isinstance(key, int):  # if the key is already an int...
-            if key in self.keys() + Quality.DOWNLOADED + Quality.SNATCHED + Quality.SNATCHED_PROPER + Quality.SNATCHED_BEST + Quality.ARCHIVED:
-                status, quality = Quality.splitCompositeStatus(key)
-                if quality == Quality.NONE:  # If a Quality is not listed... (shouldn't this be 'if not quality:'?)
-                    return self[status]  # ...return the status...
-                else:
-                    return self[status] + " (" + Quality.qualityStrings[quality] + ")"  # ...otherwise append the quality to the status
-            else:
-                return ''  # return '' to match old functionality when the numeric key is not found
-        return self[int(key)]  # Since the key was not an int, let's try int(key) instead
-
-    # Keep this until all has_key() checks are converted to 'key in dict'
-    # or else has_keys() won't search __missing__ for keys
-    def has_key(self, key):
-        """
-        Override has_key() to test membership using an 'x in y' search
-
-        Keys must be convertible to int or a ValueError will be raised.  This is intentional to match old functionality until
-        the old StatusStrings is fully deprecated, then we will raise a KeyError instead, where appropriate.
-        """
-        return key in self  # This will raise a ValueError if __missing__ can't convert the key to int
+        key = self.numeric(key)  # try to convert the key to a number which will raise KeyError if it can't
+        if key in self.qualities:  # the key wasn't found locally so check in qualities
+            status, quality = Quality.splitCompositeStatus(key)
+            return self[status] if not quality else self[status] + " (" + Quality.qualityStrings[quality] + ")"
+        else:  # the key wasn't found in qualities either
+            raise KeyError(key)  # ... so the key is invalid
 
     def __contains__(self, key):
-        """
-        Checks for existence of key
-
-        Unlike has_key() and __missing__() this will NOT raise a ValueError to match expected functionality
-        when checking for 'key in dict'
-        """
         try:
-            # This will raise a ValueError if we can't convert the key to int
-            return ((int(key) in self.data) or
-                    (int(key) in Quality.DOWNLOADED + Quality.SNATCHED + Quality.SNATCHED_PROPER + Quality.SNATCHED_BEST + Quality.ARCHIVED))
-        except ValueError:  # The key is not numeric and since we only want numeric keys...
-            # ...and we don't want this function to fail...
-            pass  # ...suppress the ValueError and do nothing, the key does not exist
+            key = self.numeric(key)
+            return key in self.data or key in self.qualities
+        except KeyError:
+            return False
 
+# Assign strings to statuses
 statusStrings = StatusStrings(
     {UNKNOWN: "Unknown",
      UNAIRED: "Unaired",
@@ -592,11 +569,11 @@ statusStrings = StatusStrings(
      SUBTITLED: "Subtitled",
      FAILED: "Failed",
      SNATCHED_BEST: "Snatched (Best)"
-     })
+     }
+)
 
 # pylint: disable=R0903
 class Overview(object):
-
     UNAIRED = UNAIRED  # 1
     QUAL = 2
     WANTED = WANTED  # 3
@@ -621,4 +598,4 @@ XML_NSMAP = {'xsi': 'http://www.w3.org/2001/XMLSchema-instance',
 countryList = {'Australia': 'AU',
                'Canada': 'CA',
                'USA': 'US'
-              }
+               }

--- a/sickbeard/numdict.py
+++ b/sickbeard/numdict.py
@@ -1,0 +1,126 @@
+# coding=utf-8
+
+"""
+class NumDict - A dict with numeric keys
+"""
+
+from collections import MutableMapping
+
+
+class NumDict(MutableMapping):
+    """
+    NumDict() -> new empty dictionary
+
+    NumDict(mapping) -> new dictionary initialized from a mapping object's
+        (key, value) pairs
+
+    NumDict(iterable) -> new dictionary initialized as if via:
+        d = {}
+        for k, v in iterable:
+            d[k] = v
+
+    NumDict(**kwargs) -> TypeError - key words cannot be numeric
+
+    All keys must be numeric or None
+    """
+
+    def __init__(self, iterable=None, **kwargs):
+        self.data = {}
+        iterable = kwargs.pop('dict', None) if iterable is None else iterable
+        if iterable is not None:
+            self.update(iterable)
+        if len(kwargs):
+            self.update(kwargs)
+
+    def __len__(self):
+        return len(self.data)
+
+    def __getitem__(self, key):
+        key = self.numeric(key)
+        if key in self.data:
+            return self.data[key]
+        if hasattr(self.__class__, "__missing__"):
+            # noinspection PyUnresolvedReferences
+            return self.__class__.__missing__(self, key)
+        raise KeyError(key)
+
+    def __setitem__(self, key, item):
+        try:
+            key = self.numeric(key)
+        except KeyError:
+            raise TypeError(key)
+        self.data[key] = item
+
+    def __delitem__(self, key):
+        key = self.numeric(key)
+        del self.data[key]
+
+    def __iter__(self):
+        return iter(self.data)
+
+    def __contains__(self, key):
+        try:
+            key = self.numeric(key)
+            return key in self.data
+        except KeyError:
+            return False
+
+    def __repr__(self):
+        return repr(self.data)
+
+    def has_key(self, key):
+        """
+        DEPRECATED: Check for existence of key
+
+        :param key: A numeric key
+        :return: True if key is found, else False
+        """
+        return key in self
+
+    def copy(self):
+        """
+        Create a copy of a NumDict
+        :return: A copy
+        """
+        if self.__class__ is NumDict:
+            return NumDict(self.data.copy())
+        import copy
+        data = self.data
+        try:
+            self.data = {}
+            c = copy.copy(self)
+        finally:
+            self.data = data
+        c.update(self)
+        return c
+
+    @classmethod
+    def fromkeys(cls, iterable, value=None):
+        """
+        Build a NumDict from a dictionary
+
+        :param iterable:
+        :param value:
+        :return:
+        """
+        d = cls()
+        for key in iterable:
+            key = cls.numeric(key)
+            d[key] = value
+        return d
+
+    @staticmethod
+    def numeric(key):
+        """
+        Converts a key to its numeric representation
+
+        :param key: numeric dict key
+        :raise KeyError: if key can't be converted to an integer
+        :return: a numeric key
+        :rtype: int
+        """
+        try:
+            return int(key)
+        except (TypeError, ValueError):
+            if key is not None:
+                raise KeyError(key)

--- a/tests/common_tests.py
+++ b/tests/common_tests.py
@@ -8,6 +8,7 @@ import unittest
 
 from sickbeard import common
 
+
 class QualityTests(unittest.TestCase):
 
     # TODO: repack / proper ? air-by-date ? season rip? multi-ep?
@@ -99,6 +100,59 @@ class QualityTests(unittest.TestCase):
 #        self.assertEqual(common.Quality.FULLHDBLURAY, common.Quality.nameQuality("Test Show - S01E02 - 1080p BluRay - GROUP"))
 #        self.assertEqual(common.Quality.UNKNOWN, common.Quality.nameQuality("Test Show - S01E02 - Unknown - SiCKBEARD"))
 
+
+class StatusStringsTest(unittest.TestCase):
+    # todo: Split tests into separate tests and add additional tests
+    def test_all(self):
+        ss = common.statusStrings
+
+        valid = 1, 112, '1', '112'
+        unused = 122, 99998989899878676, '99998989899878676', None
+        invalid = 'Elephant', (4, 1), [1, 233, 4, None]
+
+        for i in valid:
+            self.assertTrue(i in ss)
+
+        for i in unused:
+            self.assertFalse(i in ss)
+            with self.assertRaises(KeyError):
+                ss[i]
+
+        for i in ss:
+            self.assertEqual(ss[i], ss[str(i)])
+            self.assertEqual(i in ss, str(i) in ss)
+            self.assertEqual(ss.has_key(i), ss.has_key(str(i)))
+            self.assertEqual(i in ss, ss.has_key(i))
+            # self.assertEqual(ss.statusStrings[i], ss.statusStrings[str(i)])  # fails with KeyError
+
+        for i in ss.qualities:
+            self.assertEqual(ss[i], ss[str(i)])
+            self.assertEqual(i in ss, str(i) in ss)
+            self.assertEqual(ss.has_key(i), ss.has_key(str(i)))
+            self.assertEqual(i in ss, ss.has_key(i))
+            # self.assertEqual(ss.statusStrings[i], ss.statusStrings[str(i)])  # fails with KeyError
+
+        for i in invalid:
+            with self.assertRaises(TypeError):
+                ss[i] = 1
+
+        for i in unused:
+            if i is None:
+                with self.assertRaises(TypeError):
+                    ss[str(i)] = 1  # converting None to a string makes this invalid since 'None' != None...
+                ss[i] = 1  # ...but None can still be used as a key
+            else:
+                ss[str(i)] = 1
+            self.assertEqual(ss[i], 1)
+
 if __name__ == '__main__':
+    print "======================="
+    print "STARTING - COMMON TESTS"
+    print "======================="
+    print "######################################################################"
+
     suite = unittest.TestLoader().loadTestsFromTestCase(QualityTests)
+    unittest.TextTestRunner(verbosity=2).run(suite)
+
+    suite = unittest.TestLoader().loadTestsFromTestCase(StatusStringsTest)
     unittest.TextTestRunner(verbosity=2).run(suite)

--- a/tests/common_tests.py
+++ b/tests/common_tests.py
@@ -1,155 +1,251 @@
+# coding=utf-8
+
+"""
+Unit Tests for sickbeard/common.py
+"""
+
 import sys
 import os.path
+import unittest
 
 sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '../lib')))
 sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-
-import unittest
 
 from sickbeard import common
 
 
 class QualityTests(unittest.TestCase):
+    """
+    Test Case for common.Quality
+    """
 
     # TODO: repack / proper ? air-by-date ? season rip? multi-ep?
 
     def test_SDTV(self):
-        self.assertEqual(common.Quality.SDTV, common.Quality.nameQuality("Test.Show.S01E02.PDTV.XViD-GROUP"))
-        self.assertEqual(common.Quality.SDTV, common.Quality.nameQuality("Test.Show.S01E02.PDTV.x264-GROUP"))
-        self.assertEqual(common.Quality.SDTV, common.Quality.nameQuality("Test.Show.S01E02.HDTV.XViD-GROUP"))
-        self.assertEqual(common.Quality.SDTV, common.Quality.nameQuality("Test.Show.S01E02.HDTV.x264-GROUP"))
-        self.assertEqual(common.Quality.SDTV, common.Quality.nameQuality("Test.Show.S01E02.DSR.XViD-GROUP"))
-        self.assertEqual(common.Quality.SDTV, common.Quality.nameQuality("Test.Show.S01E02.DSR.x264-GROUP"))
-        self.assertEqual(common.Quality.SDTV, common.Quality.nameQuality("Test.Show.S01E02.TVRip.XViD-GROUP"))
-        self.assertEqual(common.Quality.SDTV, common.Quality.nameQuality("Test.Show.S01E02.TVRip.x264-GROUP"))
-        self.assertEqual(common.Quality.SDTV, common.Quality.nameQuality("Test.Show.S01E02.WEBRip.XViD-GROUP"))
-        self.assertEqual(common.Quality.SDTV, common.Quality.nameQuality("Test.Show.S01E02.WEBRip.x264-GROUP"))
-        self.assertEqual(common.Quality.SDTV, common.Quality.nameQuality("Test.Show.S01E02.WEB-DL.x264-GROUP"))
-        self.assertEqual(common.Quality.SDTV, common.Quality.nameQuality("Test.Show.S01E02.WEB-DL.AAC2.0.H.264-GROUP"))
-        self.assertEqual(common.Quality.SDTV, common.Quality.nameQuality("Test.Show.S01E02 WEB-DL H 264-GROUP"))
-        self.assertEqual(common.Quality.SDTV, common.Quality.nameQuality("Test.Show.S01E02_WEB-DL_H_264-GROUP"))
-        self.assertEqual(common.Quality.SDTV, common.Quality.nameQuality("Test.Show.S01E02.WEB-DL.AAC2.0.H264-GROUP"))
+        """
+        Test SDTV against nameQuality
+        """
+        tests = [
+            "Test.Show.S01E02.PDTV.XViD-GROUP",
+            "Test.Show.S01E02.PDTV.x264-GROUP",
+            "Test.Show.S01E02.HDTV.XViD-GROUP",
+            "Test.Show.S01E02.HDTV.x264-GROUP",
+            "Test.Show.S01E02.DSR.XViD-GROUP",
+            "Test.Show.S01E02.DSR.x264-GROUP",
+            "Test.Show.S01E02.TVRip.XViD-GROUP",
+            "Test.Show.S01E02.TVRip.x264-GROUP",
+            "Test.Show.S01E02.WEBRip.XViD-GROUP",
+            "Test.Show.S01E02.WEBRip.x264-GROUP",
+            "Test.Show.S01E02.WEB-DL.x264-GROUP",
+            "Test.Show.S01E02.WEB-DL.AAC2.0.H.264-GROUP",
+            "Test.Show.S01E02 WEB-DL H 264-GROUP",
+            "Test.Show.S01E02_WEB-DL_H_264-GROUP",
+            "Test.Show.S01E02.WEB-DL.AAC2.0.H264-GROUP",
+        ]
+        for test in tests:
+            self.assertEqual(common.Quality.SDTV, common.Quality.nameQuality(test))
 
     def test_SDDVD(self):
-        self.assertEqual(common.Quality.SDDVD, common.Quality.nameQuality("Test.Show.S01E02.DVDRiP.XViD-GROUP"))
-        self.assertEqual(common.Quality.SDDVD, common.Quality.nameQuality("Test.Show.S01E02.DVDRiP.DiVX-GROUP"))
-        self.assertEqual(common.Quality.SDDVD, common.Quality.nameQuality("Test.Show.S01E02.DVDRiP.x264-GROUP"))
-        self.assertEqual(common.Quality.SDDVD, common.Quality.nameQuality("Test.Show.S01E02.DVDRip.WS.XViD-GROUP"))
-        self.assertEqual(common.Quality.SDDVD, common.Quality.nameQuality("Test.Show.S01E02.DVDRip.WS.DiVX-GROUP"))
-        self.assertEqual(common.Quality.SDDVD, common.Quality.nameQuality("Test.Show.S01E02.DVDRip.WS.x264-GROUP"))
-        self.assertEqual(common.Quality.SDDVD, common.Quality.nameQuality("Test.Show.S01E02.BDRIP.XViD-GROUP"))
-        self.assertEqual(common.Quality.SDDVD, common.Quality.nameQuality("Test.Show.S01E02.BDRIP.DiVX-GROUP"))
-        self.assertEqual(common.Quality.SDDVD, common.Quality.nameQuality("Test.Show.S01E02.BDRIP.x264-GROUP"))
-        self.assertEqual(common.Quality.SDDVD, common.Quality.nameQuality("Test.Show.S01E02.BDRIP.WS.XViD-GROUP"))
-        self.assertEqual(common.Quality.SDDVD, common.Quality.nameQuality("Test.Show.S01E02.BDRIP.WS.DiVX-GROUP"))
-        self.assertEqual(common.Quality.SDDVD, common.Quality.nameQuality("Test.Show.S01E02.BDRIP.WS.x264-GROUP"))
+        """
+        Test SDDVD against nameQuality
+        """
+        tests = [
+            "Test.Show.S01E02.DVDRiP.XViD-GROUP",
+            "Test.Show.S01E02.DVDRiP.DiVX-GROUP",
+            "Test.Show.S01E02.DVDRiP.x264-GROUP",
+            "Test.Show.S01E02.DVDRip.WS.XViD-GROUP",
+            "Test.Show.S01E02.DVDRip.WS.DiVX-GROUP",
+            "Test.Show.S01E02.DVDRip.WS.x264-GROUP",
+            "Test.Show.S01E02.BDRIP.XViD-GROUP",
+            "Test.Show.S01E02.BDRIP.DiVX-GROUP",
+            "Test.Show.S01E02.BDRIP.x264-GROUP",
+            "Test.Show.S01E02.BDRIP.WS.XViD-GROUP",
+            "Test.Show.S01E02.BDRIP.WS.DiVX-GROUP",
+            "Test.Show.S01E02.BDRIP.WS.x264-GROUP",
+        ]
+        for test in tests:
+            self.assertEqual(common.Quality.SDDVD, common.Quality.nameQuality(test))
 
     def test_HDTV(self):
-        self.assertEqual(common.Quality.HDTV, common.Quality.nameQuality("Test.Show.S01E02.720p.HDTV.x264-GROUP"))
-        self.assertEqual(common.Quality.HDTV, common.Quality.nameQuality("Test.Show.S01E02.HR.WS.PDTV.x264-GROUP"))
+        """
+        Test HDTV against nameQuality
+        """
+        tests = [
+            "Test.Show.S01E02.720p.HDTV.x264-GROUP",
+            "Test.Show.S01E02.HR.WS.PDTV.x264-GROUP",
+        ]
+        for test in tests:
+            self.assertEqual(common.Quality.HDTV, common.Quality.nameQuality(test))
 
     def test_RAWHDTV(self):
-        self.assertEqual(common.Quality.RAWHDTV, common.Quality.nameQuality("Test.Show.S01E02.720p.HDTV.DD5.1.MPEG2-GROUP"))
-        self.assertEqual(common.Quality.RAWHDTV, common.Quality.nameQuality("Test.Show.S01E02.1080i.HDTV.DD2.0.MPEG2-GROUP"))
-        self.assertEqual(common.Quality.RAWHDTV, common.Quality.nameQuality("Test.Show.S01E02.1080i.HDTV.H.264.DD2.0-GROUP"))
-        self.assertEqual(common.Quality.RAWHDTV, common.Quality.nameQuality("Test Show - S01E02 - 1080i HDTV MPA1.0 H.264 - GROUP"))
-        self.assertEqual(common.Quality.RAWHDTV, common.Quality.nameQuality("Test.Show.S01E02.1080i.HDTV.DD.5.1.h264-GROUP"))
+        """
+        Test RAWHDTV against nameQuality
+        """
+        tests = [
+            "Test.Show.S01E02.720p.HDTV.DD5.1.MPEG2-GROUP",
+            "Test.Show.S01E02.1080i.HDTV.DD2.0.MPEG2-GROUP",
+            "Test.Show.S01E02.1080i.HDTV.H.264.DD2.0-GROUP",
+            "Test Show - S01E02 - 1080i HDTV MPA1.0 H.264 - GROUP",
+            "Test.Show.S01E02.1080i.HDTV.DD.5.1.h264-GROUP",
+        ]
+        for test in tests:
+            self.assertEqual(common.Quality.RAWHDTV, common.Quality.nameQuality(test))
 
     def test_FULLHDTV(self):
-        self.assertEqual(common.Quality.FULLHDTV, common.Quality.nameQuality("Test.Show.S01E02.1080p.HDTV.x264-GROUP"))
+        """
+        Test FULLHDTV against nameQuality
+        """
+        tests = [
+            "Test.Show.S01E02.1080p.HDTV.x264-GROUP",
+        ]
+        for test in tests:
+            self.assertEqual(common.Quality.FULLHDTV, common.Quality.nameQuality(test))
 
     def test_HDWEBDL(self):
-        self.assertEqual(common.Quality.HDWEBDL, common.Quality.nameQuality("Test.Show.S01E02.720p.WEB-DL-GROUP"))
-        self.assertEqual(common.Quality.HDWEBDL, common.Quality.nameQuality("Test.Show.S01E02.720p.WEBRip-GROUP"))
-        self.assertEqual(common.Quality.HDWEBDL, common.Quality.nameQuality("Test.Show.S01E02.WEBRip.720p.H.264.AAC.2.0-GROUP"))
-        self.assertEqual(common.Quality.HDWEBDL, common.Quality.nameQuality("Test.Show.S01E02.720p.WEB-DL.AAC2.0.H.264-GROUP"))
-        self.assertEqual(common.Quality.HDWEBDL, common.Quality.nameQuality("Test Show S01E02 720p WEB-DL AAC2 0 H 264-GROUP"))
-        self.assertEqual(common.Quality.HDWEBDL, common.Quality.nameQuality("Test_Show.S01E02_720p_WEB-DL_AAC2.0_H264-GROUP"))
-        self.assertEqual(common.Quality.HDWEBDL, common.Quality.nameQuality("Test.Show.S01E02.720p.WEB-DL.AAC2.0.H264-GROUP"))
-        self.assertEqual(common.Quality.HDWEBDL, common.Quality.nameQuality("Test.Show.S01E02.720p.iTunes.Rip.H264.AAC-GROUP"))
+        """
+        Test HDWEBDL against nameQuality
+        """
+        tests = [
+            "Test.Show.S01E02.720p.WEB-DL-GROUP",
+            "Test.Show.S01E02.720p.WEBRip-GROUP",
+            "Test.Show.S01E02.WEBRip.720p.H.264.AAC.2.0-GROUP",
+            "Test.Show.S01E02.720p.WEB-DL.AAC2.0.H.264-GROUP",
+            "Test Show S01E02 720p WEB-DL AAC2 0 H 264-GROUP",
+            "Test_Show.S01E02_720p_WEB-DL_AAC2.0_H264-GROUP",
+            "Test.Show.S01E02.720p.WEB-DL.AAC2.0.H264-GROUP",
+            "Test.Show.S01E02.720p.iTunes.Rip.H264.AAC-GROUP",
+        ]
+        for test in tests:
+            self.assertEqual(common.Quality.HDWEBDL, common.Quality.nameQuality(test))
 
     def test_FULLHDWEBDL(self):
-        self.assertEqual(common.Quality.FULLHDWEBDL, common.Quality.nameQuality("Test.Show.S01E02.1080p.WEB-DL-GROUP"))
-        self.assertEqual(common.Quality.FULLHDWEBDL, common.Quality.nameQuality("Test.Show.S01E02.1080p.WEBRip-GROUP"))
-        self.assertEqual(common.Quality.FULLHDWEBDL, common.Quality.nameQuality("Test.Show.S01E02.WEBRip.1080p.H.264.AAC.2.0-GROUP"))
-        self.assertEqual(common.Quality.FULLHDWEBDL, common.Quality.nameQuality("Test.Show.S01E02.WEBRip.1080p.H264.AAC.2.0-GROUP"))
-        self.assertEqual(common.Quality.FULLHDWEBDL, common.Quality.nameQuality("Test.Show.S01E02.1080p.iTunes.H.264.AAC-GROUP"))
-        self.assertEqual(common.Quality.FULLHDWEBDL, common.Quality.nameQuality("Test Show S01E02 1080p iTunes H 264 AAC-GROUP"))
-        self.assertEqual(common.Quality.FULLHDWEBDL, common.Quality.nameQuality("Test_Show_S01E02_1080p_iTunes_H_264_AAC-GROUP"))
+        """
+        Test FULLHDWEBDL against nameQuality
+        """
+        tests = [
+            "Test.Show.S01E02.1080p.WEB-DL-GROUP",
+            "Test.Show.S01E02.1080p.WEBRip-GROUP",
+            "Test.Show.S01E02.WEBRip.1080p.H.264.AAC.2.0-GROUP",
+            "Test.Show.S01E02.WEBRip.1080p.H264.AAC.2.0-GROUP",
+            "Test.Show.S01E02.1080p.iTunes.H.264.AAC-GROUP",
+            "Test Show S01E02 1080p iTunes H 264 AAC-GROUP",
+            "Test_Show_S01E02_1080p_iTunes_H_264_AAC-GROUP",
+        ]
+        for test in tests:
+            self.assertEqual(common.Quality.FULLHDWEBDL, common.Quality.nameQuality(test))
 
     def test_HDBLURAY(self):
-        self.assertEqual(common.Quality.HDBLURAY, common.Quality.nameQuality("Test.Show.S01E02.720p.BluRay.x264-GROUP"))
-        self.assertEqual(common.Quality.HDBLURAY, common.Quality.nameQuality("Test.Show.S01E02.720p.HDDVD.x264-GROUP"))
+        """
+        Test HDBLURAY against nameQuality
+        """
+        tests = [
+            "Test.Show.S01E02.720p.BluRay.x264-GROUP",
+            "Test.Show.S01E02.720p.HDDVD.x264-GROUP",
+        ]
+        for test in tests:
+            self.assertEqual(common.Quality.HDBLURAY, common.Quality.nameQuality(test))
 
     def test_FULLHDBLURAY(self):
-        self.assertEqual(common.Quality.FULLHDBLURAY, common.Quality.nameQuality("Test.Show.S01E02.1080p.BluRay.x264-GROUP"))
-        self.assertEqual(common.Quality.FULLHDBLURAY, common.Quality.nameQuality("Test.Show.S01E02.1080p.HDDVD.x264-GROUP"))
+        """
+        Test FULLHDBLURAY against nameQuality
+        """
+        tests = [
+            "Test.Show.S01E02.1080p.BluRay.x264-GROUP",
+            "Test.Show.S01E02.1080p.HDDVD.x264-GROUP",
+        ]
+        for test in tests:
+            self.assertEqual(common.Quality.FULLHDBLURAY, common.Quality.nameQuality(test))
 
     def test_UNKNOWN(self):
-        self.assertEqual(common.Quality.UNKNOWN, common.Quality.nameQuality("Test.Show.S01E02-SiCKBEARD"))
+        """
+        Test UNKNOWN against nameQuality
+        """
+        tests = [
+            "Test.Show.S01E02-SiCKBEARD",
+        ]
+        for test in tests:
+            self.assertEqual(common.Quality.UNKNOWN, common.Quality.nameQuality(test))
 
-#    def test_reverse_parsing(self):
-#        self.assertEqual(common.Quality.SDTV, common.Quality.nameQuality("Test Show - S01E02 - SDTV - GROUP"))
-#        self.assertEqual(common.Quality.SDDVD, common.Quality.nameQuality("Test Show - S01E02 - SD DVD - GROUP"))
-#        self.assertEqual(common.Quality.HDTV, common.Quality.nameQuality("Test Show - S01E02 - HDTV - GROUP"))
-#        self.assertEqual(common.Quality.RAWHDTV, common.Quality.nameQuality("Test Show - S01E02 - RawHD - GROUP"))
-#        self.assertEqual(common.Quality.FULLHDTV, common.Quality.nameQuality("Test Show - S01E02 - 1080p HDTV - GROUP"))
-#        self.assertEqual(common.Quality.HDWEBDL, common.Quality.nameQuality("Test Show - S01E02 - 720p WEB-DL - GROUP"))
-#        self.assertEqual(common.Quality.FULLHDWEBDL, common.Quality.nameQuality("Test Show - S01E02 - 1080p WEB-DL - GROUP"))
-#        self.assertEqual(common.Quality.HDBLURAY, common.Quality.nameQuality("Test Show - S01E02 - 720p BluRay - GROUP"))
-#        self.assertEqual(common.Quality.FULLHDBLURAY, common.Quality.nameQuality("Test Show - S01E02 - 1080p BluRay - GROUP"))
-#        self.assertEqual(common.Quality.UNKNOWN, common.Quality.nameQuality("Test Show - S01E02 - Unknown - SiCKBEARD"))
+    @unittest.expectedFailure
+    # reverse parsing does not work
+    def test_reverse_parsing(self):
+        """
+        Test reverse parsing for all qualities
+        """
+        tests = [
+            (common.Quality.SDTV, "Test Show - S01E02 - SDTV - GROUP"),
+            (common.Quality.SDDVD, "Test Show - S01E02 - SD DVD - GROUP"),
+            (common.Quality.HDTV, "Test Show - S01E02 - HDTV - GROUP"),
+            (common.Quality.RAWHDTV, "Test Show - S01E02 - RawHD - GROUP"),
+            (common.Quality.FULLHDTV, "Test Show - S01E02 - 1080p HDTV - GROUP"),
+            (common.Quality.HDWEBDL, "Test Show - S01E02 - 720p WEB-DL - GROUP"),
+            (common.Quality.FULLHDWEBDL, "Test Show - S01E02 - 1080p WEB-DL - GROUP"),
+            (common.Quality.HDBLURAY, "Test Show - S01E02 - 720p BluRay - GROUP"),
+            (common.Quality.FULLHDBLURAY, "Test Show - S01E02 - 1080p BluRay - GROUP"),
+            (common.Quality.UNKNOWN, "Test Show - S01E02 - Unknown - SiCKBEARD"),
+        ]
+        for test in tests:
+            quality, test = test
+            self.assertEqual(quality, common.Quality.nameQuality(test),
+                             (quality, common.Quality.nameQuality(test), test))
 
 
 class StatusStringsTest(unittest.TestCase):
-    # todo: Split tests into separate tests and add additional tests
+    """
+    Test Case for common.StatusStrings
+    """
+    # TODO: Split tests into separate tests and add additional tests
+
+    # Until .has_key() is removed from SickRage, we will test that it still works as expected
+    # pylint disable:W0402
+    # Use of a deprecated module
     def test_all(self):
-        ss = common.statusStrings
+        """
+        Run all status strings tests
+        """
+        status_strings = common.statusStrings
 
         valid = 1, 112, '1', '112'
         unused = 122, 99998989899878676, '99998989899878676', None
         invalid = 'Elephant', (4, 1), [1, 233, 4, None]
 
         for i in valid:
-            self.assertTrue(i in ss)
+            self.assertTrue(i in status_strings)
 
         for i in unused:
-            self.assertFalse(i in ss)
+            self.assertFalse(i in status_strings)
             with self.assertRaises(KeyError):
-                ss[i]
+                self.assertTrue(status_strings[i])
 
-        for i in ss:
-            self.assertEqual(ss[i], ss[str(i)])
-            self.assertEqual(i in ss, str(i) in ss)
-            self.assertEqual(ss.has_key(i), ss.has_key(str(i)))
-            self.assertEqual(i in ss, ss.has_key(i))
-            # self.assertEqual(ss.statusStrings[i], ss.statusStrings[str(i)])  # fails with KeyError
+        for i in status_strings:
+            self.assertEqual(status_strings[i], status_strings[str(i)])
+            self.assertEqual(i in status_strings, str(i) in status_strings)
+            self.assertEqual(status_strings.has_key(i), status_strings.has_key(str(i)))
+            self.assertEqual(i in status_strings, status_strings.has_key(i))
 
-        for i in ss.qualities:
-            self.assertEqual(ss[i], ss[str(i)])
-            self.assertEqual(i in ss, str(i) in ss)
-            self.assertEqual(ss.has_key(i), ss.has_key(str(i)))
-            self.assertEqual(i in ss, ss.has_key(i))
-            # self.assertEqual(ss.statusStrings[i], ss.statusStrings[str(i)])  # fails with KeyError
+        for i in status_strings.qualities:
+            self.assertEqual(status_strings[i], status_strings[str(i)])
+            self.assertEqual(i in status_strings, str(i) in status_strings)
+            self.assertEqual(status_strings.has_key(i), status_strings.has_key(str(i)))
+            self.assertEqual(i in status_strings, status_strings.has_key(i))
 
         for i in invalid:
             with self.assertRaises(TypeError):
-                ss[i] = 1
+                status_strings[i] = 1
 
         for i in unused:
             if i is None:
                 with self.assertRaises(TypeError):
-                    ss[str(i)] = 1  # converting None to a string makes this invalid since 'None' != None...
-                ss[i] = 1  # ...but None can still be used as a key
+                    status_strings[str(i)] = 1  # 'None' != None
+                status_strings[i] = 1  # ...but None can still be used as a key
             else:
-                ss[str(i)] = 1
-            self.assertEqual(ss[i], 1)
+                status_strings[str(i)] = 1
+            self.assertEqual(status_strings[i], 1)
 
 if __name__ == '__main__':
     print "======================="
     print "STARTING - COMMON TESTS"
     print "======================="
-    print "######################################################################"
 
     suite = unittest.TestLoader().loadTestsFromTestCase(QualityTests)
     unittest.TextTestRunner(verbosity=2).run(suite)

--- a/tests/numdict_tests.py
+++ b/tests/numdict_tests.py
@@ -1,0 +1,499 @@
+# coding=utf-8
+
+"""
+Unit Tests for sickbeard/numdict.py
+"""
+
+import sys
+import os.path
+import unittest
+
+sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '../lib')))
+sys.path.insert(1, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from sickbeard.numdict import NumDict
+
+PY3 = sys.version_info >= (3, )
+
+if PY3:
+    from collections import UserDict
+else:
+    from UserDict import UserDict
+
+
+class NumDictTest(unittest.TestCase):
+    """
+    Test the NumDict class
+    """
+    def test_constructors(self):
+        """
+        Test NumDict constructors
+        """
+        # dicts for testing
+        d0 = {}  # Empty dictionary
+        d1 = {1: 'Elephant'}  # Single numeric key
+        d2 = {1: 'Elephant', 2: 'Mouse'}  # Multiple numeric keys
+        d3 = {'3': 'Aardvark'}  # Numeric string key
+        d4 = {'3': 'Aardvark', '4': 'Ant'}  # Multiple numeric string keys
+        d5 = {5: 'Cat', '6': 'Dog'}  # Mixed numeric and numeric string keys
+        d6 = {1: None, '2': None}  # None as values
+        d7 = {None: 'Empty'}  # None as key
+
+        # Construct NumDicts from dicts
+        n = NumDict()
+        n0 = NumDict(d0)
+        n1 = NumDict(d1)
+        n2 = NumDict(d2)
+        n3 = NumDict(d3)
+        n4 = NumDict(d4)
+        n5 = NumDict(d5)
+        n6 = NumDict(d6)
+        n7 = NumDict(d7)
+
+        # Most NumDicts from dicts should compare equal...
+        self.assertEqual(n, {})
+        self.assertEqual(n0, d0)
+        self.assertEqual(n1, d1)
+        self.assertEqual(n2, d2)
+
+        # ...however, numeric keys are not equal to numeric string keys...
+        self.assertNotEqual(n3, d3)
+        self.assertNotEqual(n4, d4)
+        self.assertNotEqual(n5, d5)
+        self.assertNotEqual(n6, d6)
+
+        # ...but None keys work just fine
+        self.assertEqual(n7, d7)
+
+        # Construct dicts from NumDicts
+        dn = dict(n)
+        dn1 = dict(n1)
+        dn2 = dict(n2)
+        dn3 = dict(n3)
+        dn4 = dict(n4)
+        dn5 = dict(n5)
+        dn6 = dict(n6)
+        dn7 = dict(n7)
+
+        # All dicts from NumDicts should compare equal
+        self.assertEqual(n, dn)
+        self.assertEqual(n1, dn1)
+        self.assertEqual(n2, dn2)
+        self.assertEqual(n3, dn3)
+        self.assertEqual(n4, dn4)
+        self.assertEqual(n5, dn5)
+        self.assertEqual(n6, dn6)
+        self.assertEqual(n7, dn7)
+
+        # Construct NumDicts from NumDicts
+        nn = NumDict(n)
+        nn0 = NumDict(n0)
+        nn1 = NumDict(n1)
+        nn2 = NumDict(n2)
+        nn3 = NumDict(n3)
+        nn4 = NumDict(n4)
+        nn5 = NumDict(n5)
+        nn6 = NumDict(n6)
+        nn7 = NumDict(n7)
+
+        # All NumDicts from NumDicts should compare equal
+        self.assertEqual(n, nn)
+        self.assertEqual(n0, nn0)
+        self.assertEqual(n1, nn1)
+        self.assertEqual(n2, nn2)
+        self.assertEqual(n3, nn3)
+        self.assertEqual(n4, nn4)
+        self.assertEqual(n5, nn5)
+        self.assertEqual(n6, nn6)
+        self.assertEqual(n7, nn7)
+
+        # keyword arg constructor should fail
+        with self.assertRaises(TypeError):
+            NumDict(one=1, two=2)  # Raise TypeError since we can't have numeric keywords
+
+        # item sequence constructors work fine...
+        self.assertEqual(NumDict([(1, 'Elephant'), (2, 'Mouse')]), dn2)
+        self.assertEqual(NumDict(dict=[(1, 'Elephant'), (2, 'Mouse')]), dn2)
+        self.assertEqual(NumDict([(1, 'Elephant'), ('2', 'Mouse')]), dn2)
+        self.assertEqual(NumDict(dict=[('1', 'Elephant'), (2, 'Mouse')]), dn2)
+
+        # ...unless you have a non-numeric key
+        with self.assertRaises(TypeError):
+            NumDict([('Rat', 11), ('Snake', 12)])
+        with self.assertRaises(TypeError):
+            NumDict(dict=[('Rat', 11), ('Snake', 12)])
+
+        # combining item sequence constructors with keyword args does not work
+        with self.assertRaises(TypeError):  # Raise TypeError since we can't have numeric keywords
+            NumDict([(1, 'one'), (2, 'two')], two=3, five=4)
+
+        # alternate constructors
+        d8 = {1: 'Echo', 2: 'Echo'}
+
+        self.assertEqual(NumDict.fromkeys('1 2'.split()), dn6)
+        self.assertEqual(NumDict().fromkeys('1 2'.split()), dn6)
+        self.assertEqual(NumDict.fromkeys('1 2'.split(), 'Echo'), d8)
+        self.assertEqual(NumDict().fromkeys('1 2'.split(), 'Echo'), d8)
+        self.assertTrue(n1.fromkeys('1 2'.split()) is not n1)
+        self.assertIsInstance(n1.fromkeys('1 2'.split()), NumDict)
+        self.assertIsInstance(n2.fromkeys('1 2'.split()), NumDict)
+        self.assertIsInstance(n3.fromkeys('1 2'.split()), NumDict)
+        self.assertIsInstance(n4.fromkeys('1 2'.split()), NumDict)
+
+    def test_repr(self):
+        # dicts for testing
+        d0 = {}  # Empty dictionary
+        d1 = {1: 'Elephant'}  # Single numeric key
+        d2 = {1: 'Elephant', 2: 'Mouse'}  # Multiple numeric keys
+        d3 = {'3': 'Aardvark'}  # Numeric string key
+        d4 = {'3': 'Aardvark', '4': 'Ant'}  # Multiple numeric string keys
+        d5 = {5: 'Cat', '6': 'Dog'}  # Mixed numeric and numeric string keys
+        d6 = {1: None, '2': None}  # None as values
+        d7 = {None: 'Empty'}  # None as key
+
+        #  Construct NumDicts from dicts
+        n = NumDict()
+        n0 = NumDict(d0)
+        n1 = NumDict(d1)
+        n2 = NumDict(d2)
+        n3 = NumDict(d3)
+        n4 = NumDict(d4)
+        n5 = NumDict(d5)
+        n6 = NumDict(d6)
+        n7 = NumDict(d7)
+
+        reps = (
+            "{}",
+            "{1: 'Elephant'}",
+            "{1: 'Elephant', 2: 'Mouse'}",
+            "'3': 'Aardvark'",
+            "{'3': 'Aardvark', '4': 'Ant'}",
+            "{5: 'Cat', '6': 'Dog'}",
+            "{1: None, '2': None}",
+            "{None: 'Empty'}",
+        )
+
+        # Most representations of NumDicts should compare equal to dicts...
+        self.assertEqual(str(n), str({}))
+        self.assertEqual(repr(n), repr({}))
+        self.assertIn(repr(n), reps)
+
+        self.assertEqual(str(n0), str(d0))
+        self.assertEqual(repr(n0), repr(d0))
+        self.assertIn(repr(n0), reps)
+
+        self.assertEqual(str(n1), str(d1))
+        self.assertEqual(repr(n1), repr(d1))
+        self.assertIn(repr(n1), reps)
+
+        self.assertEqual(str(n2), str(d2))
+        self.assertEqual(repr(n2), repr(d2))
+        self.assertIn(repr(n2), reps)
+
+        # ...however, numeric keys are not equal to numeric string keys...
+        # ...so the string representations for those are different...
+        self.assertNotEqual(str(n3), str(d3))
+        self.assertNotEqual(repr(n3), repr(d3))
+        self.assertNotIn(repr(n3), reps)
+
+        self.assertNotEqual(str(n4), str(d4))
+        self.assertNotEqual(repr(n4), repr(d4))
+        self.assertNotIn(repr(n4), reps)
+
+        self.assertNotEqual(str(n5), str(d5))
+        self.assertNotEqual(repr(n5), repr(d5))
+        self.assertNotIn(repr(n5), reps)
+
+        self.assertNotEqual(str(n6), str(d6))
+        self.assertNotEqual(repr(n6), repr(d6))
+        self.assertNotIn(repr(n6), reps)
+
+        # ...but None keys work just fine
+        self.assertEqual(str(n7), str(d7))
+        self.assertEqual(repr(n7), repr(d7))
+        self.assertIn(repr(n7), reps)
+
+    def test_rich_comparison_and_len(self):
+        # dicts for testing
+        d0 = {}  # Empty dictionary
+        d1 = {1: 'Elephant'}  # Single numeric key
+        d2 = {1: 'Elephant', 2: 'Mouse'}  # Multiple numeric keys
+
+        # Construct NumDicts from dicts
+        n = NumDict()
+        n0 = NumDict(d0)
+        n1 = NumDict(d1)
+        n2 = NumDict(d2)
+
+        # Construct NumDicts from NumDicts
+        nn = NumDict(n)
+        nn0 = NumDict(n0)
+        nn1 = NumDict(n1)
+        nn2 = NumDict(n2)
+
+        all_dicts = [d0, d1, d2, n, n0, n1, n2, nn, nn0, nn1, nn2]
+        for a in all_dicts:
+            for b in all_dicts:
+                self.assertEqual(a == b, len(a) == len(b))
+
+    def test_dict_access_and_modification(self):
+        # dicts for testing
+        d0 = {}  # Empty dictionary
+        d1 = {1: 'Elephant'}  # Single numeric key
+        d2 = {1: 'Elephant', 2: 'Mouse'}  # Multiple numeric keys
+
+        #  Construct NumDicts from dicts
+        n0 = NumDict()
+        n1 = NumDict(d1)
+        n2 = NumDict(d2)
+
+        # test __getitem__
+        self.assertEqual(n2[1], 'Elephant')
+        with self.assertRaises(KeyError):
+            n1['Mouse']  # key is not numeric
+        with self.assertRaises(KeyError):
+            n1.__getitem__('Mouse')  # key is not numeric
+        with self.assertRaises(KeyError):
+            n1[None]  # key does not exist
+        with self.assertRaises(KeyError):
+            n1.__getitem__(None)  # key does not exist
+
+        # Test __setitem__
+        n3 = NumDict(n2)
+        self.assertEqual(n2, n3)
+
+        n3[2] = 'Frog'
+        self.assertNotEqual(n2, n3)
+
+        # Check None keys and numeric key conversion
+        n3['3'] = 'Armadillo'
+        n3[None] = 'Cockroach'
+
+        # Check long ints
+        n3[12390809518259081208909880312] = 'Squid'
+        n3['12390809518259081208909880312'] = 'Octopus'
+        self.assertEqual(n3[12390809518259081208909880312], 'Octopus')
+
+        with self.assertRaises(TypeError):
+            n3.__setitem__('Gorilla', 1)  # key is not numeric
+        with self.assertRaises(TypeError):
+            n3['Chimpanzee'] = 1  # key is not numeric
+        with self.assertRaises(TypeError):
+            n3[(4, 1)] = 1  # key is not numeric
+        with self.assertRaises(TypeError):
+            n3[[1, 3, 4]] = 1  # key is not numeric and is not hashable
+
+        # Test __delitem__
+        del n3[3]
+        del n3[None]
+        with self.assertRaises(KeyError):
+            del n3[3]  # already deleted
+        with self.assertRaises(KeyError):
+            n3.__delitem__(3)  # already deleted
+        with self.assertRaises(KeyError):
+            del n3['Mouse']  # key would not exist, since it is not numeric
+
+        # Test clear
+        n3.clear()
+        self.assertEqual(n3, {})
+
+        # Test copy()
+        n2a = d2.copy()
+        self.assertEqual(n2, n2a)
+        n2b = n2.copy()
+        self.assertEqual(n2b, n2)
+        n2c = UserDict({1: 'Elephant', 2: 'Mouse'})
+        n2d = n2c.copy()  # making a copy of a UserDict is special cased
+        self.assertEqual(n2c, n2d)
+
+        class MyNumDict(NumDict):
+            """
+            subclass Numdict for testing
+            """
+            def display(self):
+                """
+                add a method to subclass to differentiate from superclass
+                """
+                print('MyNumDict:', self)
+
+        m2 = MyNumDict(n2)
+        m2a = m2.copy()
+        self.assertEqual(m2a, m2)
+
+        m2[1] = 'Frog'
+        self.assertNotEqual(m2a, m2)
+
+        # Test keys, items, values
+        self.assertEqual(sorted(n2.keys()), sorted(d2.keys()))
+        self.assertEqual(sorted(n2.items()), sorted(d2.items()))
+        self.assertEqual(sorted(n2.values()), sorted(d2.values()))
+
+        # Test "in".
+        for i in n2:
+            self.assertIn(i, n2)
+            self.assertEqual(i in n1, i in d1)
+            self.assertEqual(i in n0, i in d0)
+
+        self.assertFalse(None in n2)
+        self.assertEqual(None in n2, None in d2)
+
+        d2[None] = 'Cow'
+        n2[None] = d2[None]
+        self.assertTrue(None in n2)
+        self.assertEqual(None in n2, None in d2)
+
+        self.assertEqual(n2.has_key(None), None in d2)
+        if not PY3:
+            self.assertEqual(n2.has_key(None), d2.has_key(None))
+        self.assertFalse('Penguin' in n2)
+
+        # Test update
+        t = NumDict()
+        t.update(d2)
+        self.assertEqual(t, n2)
+
+        # Test get
+        for i in n2:
+            self.assertEqual(n2.get(i), n2[i])
+            self.assertEqual(n1.get(i), d1.get(i))
+            self.assertEqual(n0.get(i), d0.get(i))
+
+        for i in ['purple', None, 12312301924091284, 23]:
+            self.assertEqual(n2.get(i), d2.get(i), i)
+
+        with self.assertRaises(AssertionError):
+            i = '1'
+            self.assertEqual(n2.get(i), d2.get(i), i)  # d2 expects string key which does not exist
+
+        # Test "in" iteration.
+        n2b = n2
+        for i in range(20):
+            n2[i] = str(i)
+            n2b[str(i)] = str(i)
+        self.assertEqual(n2, n2b)
+
+        ikeys = []
+        for k in n2:
+            ikeys.append(k)
+        self.assertEqual(set(ikeys), set(n2.keys()))
+
+        # Test setdefault
+        x = 1
+        t = NumDict()
+        self.assertEqual(t.setdefault(x, 42), 42)
+        self.assertEqual(t.setdefault(x, '42'), 42)
+        self.assertNotEqual(t.setdefault(x, 42), '42')
+        self.assertNotEqual(t.setdefault(x, '42'), '42')
+        self.assertIn(x, t)
+
+        self.assertEqual(t.setdefault(x, 23), 42)
+        self.assertEqual(t.setdefault(x, '23'), 42)
+        self.assertNotEqual(t.setdefault(x, 23), '42')
+        self.assertNotEqual(t.setdefault(x, '23'), '42')
+        self.assertIn(x, t)
+
+        # Test pop
+        x = 1
+        t = NumDict({x: 42})
+        self.assertEqual(t.pop(x), 42)
+        self.assertRaises(KeyError, t.pop, x)
+        self.assertEqual(t.pop(x, 1), 1)
+        t[x] = 42
+        self.assertEqual(t.pop(x, 1), 42)
+
+        # Test popitem
+        x = 1
+        t = NumDict({x: 42})
+        self.assertEqual(t.popitem(), (x, 42))
+        self.assertRaises(KeyError, t.popitem)
+
+    def test_missing(self):
+        # Make sure NumDict doesn't have a __missing__ method
+        self.assertEqual(hasattr(NumDict, "__missing__"), False)
+
+        class D(NumDict):
+            """
+            subclass defines __missing__ method returning a value
+            """
+            def __missing__(self, key):
+                return 42
+
+        d = D({1: 2, 3: 4})
+        self.assertEqual(d[1], 2)
+        self.assertEqual(d[3], 4)
+        self.assertNotIn(2, d)
+        self.assertNotIn(2, d.keys())
+        self.assertEqual(d[2], 42)
+
+        class E(NumDict):
+            """
+            subclass defines __missing__ method raising RuntimeError
+            """
+            def __missing__(self, key):
+                raise RuntimeError(key)
+
+        e = E()
+        try:
+            e[42]
+        except RuntimeError as err:
+            self.assertEqual(err.args, (42,))
+        else:
+            self.fail("e[42] didn't raise RuntimeError")
+
+        class F(NumDict):
+            """
+            subclass sets __missing__ instance variable (no effect)
+            """
+            def __init__(self):
+                # An instance variable __missing__ should have no effect
+                self.__missing__ = lambda key: None
+                NumDict.__init__(self)
+        f = F()
+        try:
+            f[42]
+        except KeyError as err:
+            self.assertEqual(err.args, (42,))
+        else:
+            self.fail("f[42] didn't raise KeyError")
+
+        class G(NumDict):
+            """
+            subclass doesn't define __missing__ at a all
+            """
+            pass
+
+        g = G()
+        try:
+            g[42]
+        except KeyError as err:
+            self.assertEqual(err.args, (42,))
+        else:
+            self.fail("g[42] didn't raise KeyError")
+
+        class H(D):
+            """
+            subclass calls super classes __missing__ and modifies the value before returning it
+            """
+            def __missing__(self, key):
+                return super(H, self).__missing__(key) + 1
+
+        h = H()
+        self.assertEqual(h[None], d[None]+1)
+
+
+def test_main():
+    import logging
+    log = logging.getLogger(__name__)
+    logging.basicConfig(level=logging.DEBUG)
+
+    log.info("=======================")
+    log.info("STARTING - COMMON TESTS")
+    log.info("=======================")
+    log.info("######################################################################")
+
+    suite = unittest.TestLoader().loadTestsFromTestCase(NumDictTest)
+    unittest.TextTestRunner(verbosity=2).run(suite)
+
+
+if __name__ == "__main__":
+    test_main()


### PR DESCRIPTION
##### Code Changes:
- Change from UserDict to NumDict and add unittests for NumDict and new statusstrings
- Streamline common tests and PEPs

This fixes issues with recursion in the UserDict implementation of statusstrings, adds the unit tests required, is Python 3 compatible, and NumDict can be further leveraged to streamline common.Quality in the future.