### PR TITLE
Added handlers for the ".enabler" class in config_notifications.js

### DIFF
--- a/gui/slick/js/new/config_notifications.js
+++ b/gui/slick/js/new/config_notifications.js
@@ -1,3 +1,15 @@
 $(document).ready(function(){
     $('#config-components').tabs();
+
+    $(".enabler").each(function () {
+        if (!$(this).prop('checked')) { $('#content_' + $(this).attr('id')).hide(); }
+    });
+
+    $(".enabler").click(function () {
+        if ($(this).prop('checked')) {
+            $('#content_' + $(this).attr('id')).fadeIn("fast", "linear");
+        } else {
+            $('#content_' + $(this).attr('id')).fadeOut("fast", "linear");
+        }
+    });
 });


### PR DESCRIPTION
I think OmgImAlexis has been working on updating the gui in the development branch.   In this commit (https://goo.gl/Em9J5g) he removed the contents of config.js, which broke the "enabler" class functionality on the notifications configuration page/tabs.

It was probably just an oversight; however, this pull request adds the enabler class hide/show functionality back to the notifications configuration page/tabs.

In my testing, adding this code makes the notifications configuration page/tabs appear to work the same as on 'master'; however, I did not dig deeply to see if anything else was missing.