### PR TITLE
update provider T411 : add UserAgent

### DIFF
--- a/sickbeard/providers/t411.py
+++ b/sickbeard/providers/t411.py
@@ -25,6 +25,7 @@ import logging
 import traceback
 from requests.auth import AuthBase
 from sickbeard import tvcache
+from sickbeard.common import USER_AGENT
 from sickbeard.providers import generic
 
 
@@ -49,6 +50,7 @@ class T411Provider(generic.TorrentProvider):
                      'download': 'https://api.t411.in/torrents/download/%s'}
 
         self.url = self.urls[b'base_url']
+        self.headers.update({'User-Agent': USER_AGENT})
 
         self.subcategories = [433, 637, 455, 639]
 


### PR DESCRIPTION
hello,

I updated the provider T411.
I have added the UserAgent information because it's needed by the api.

If this information is unset, the following error is returned :
HTTP POST error code: 403
HTTP POST error message: Forbidden
And in the sickrage log : 
[T411] Unable to connect to provider