### PR TITLE
Fix Schedule page episode details

### DIFF
--- a/gui/slick/views/schedule.mako
+++ b/gui/slick/views/schedule.mako
@@ -291,7 +291,7 @@
     <div class="tvshowDiv">
         <table width="100%" border="0" cellpadding="0" cellspacing="0">
         <tr>
-            <th ${('class="nobg"', 'rowspan="2"')['banner' == layout]} valign="top">
+            <th ${('class="nobg"')['banner' == layout]} valign="top">
                 <a href="${srRoot}/home/displayShow?show=${cur_result[b'showid']}">
                     <img alt="" class="${('posterThumb', 'bannerThumb')[layout == 'banner']}" src="${showImage(cur_result[b'showid'], (layout, 'poster_thumb')[layout == 'poster'])}" />
                 </a>


### PR DESCRIPTION
Removed erroneous rowspan in order to fix display of episode details on Schedule page. I personally experienced this error and found this bug report on the forum already from another user. https://sickrage.tv/forums/forum/help-support/bug-issue-reports/32330-episode-info-missing-on-schedule-page

Before:
![before](https://cloud.githubusercontent.com/assets/165084/11995259/9182e37e-aa1b-11e5-9790-605e6dd41aa7.png)

After:
![after](https://cloud.githubusercontent.com/assets/165084/11995260/96ef912c-aa1b-11e5-97fe-f9f5b3e93f27.png)