### PR TITLE
Fix speed.cd logins failing

### DIFF
--- a/sickbeard/providers/speedcd.py
+++ b/sickbeard/providers/speedcd.py
@@ -40,7 +40,7 @@ class SpeedCDProvider(generic.TorrentProvider):
         self.minleech = None
 
         self.urls = {'base_url': 'http://speed.cd/',
-                     'login': 'http://speed.cd/take_login.php',
+                     'login': 'http://speed.cd/take.login.php',
                      'detail': 'http://speed.cd/t/%s',
                      'search': 'http://speed.cd/V3/API/API.php',
                      'download': 'http://speed.cd/download.php?torrent=%s'}


### PR DESCRIPTION
Speed.cd login page location changed from take_login.php to take.login.php