### PR TITLE
fixing TypeError

### DIFF
--- a/sickbeard/metadata/tivo.py
+++ b/sickbeard/metadata/tivo.py
@@ -326,7 +326,7 @@ class TIVOMetadata(generic.GenericMetadata):
 
             with ek(io.open, nfo_file_path, 'w') as nfo_file:
                 # Calling encode directly, b/c often descriptions have wonky characters.
-                nfo_file.write(data.encode("utf-8"))
+                nfo_file.write(data)
 
             helpers.chmodAsParent(nfo_file_path)
 


### PR DESCRIPTION
I kept getting the following tracebacks : 

```
2015-12-07 20:04:03 ERROR    POSTPROCESSER::Exception generated in thread POSTPROCESSER: must be unicode, not str
Traceback (most recent call last):
  File "/srv/share/sick_rage/sickbeard/scheduler.py", line 105, in run                                                                                
    self.action.run(self.force)
  File "/srv/share/sick_rage/sickbeard/autoPostProcesser.py", line 56, in run
    processTV.processDir(sickbeard.TV_DOWNLOAD_DIR)
  File "/srv/share/sick_rage/sickbeard/processTV.py", line 269, in processDir
    process_media(processPath, videoFiles, nzbName, process_method, force, is_priority, result)
  File "/srv/share/sick_rage/sickbeard/processTV.py", line 545, in process_media
    result.result = processor.process()
  File "/srv/share/sick_rage/sickbeard/postProcessor.py", line 1107, in process
    ep_obj.createMetaFiles()
  File "/srv/share/sick_rage/sickbeard/tv.py", line 1832, in createMetaFiles
    self.createNFO()
  File "/srv/share/sick_rage/sickbeard/tv.py", line 1843, in createNFO
    result = cur_provider.create_episode_metadata(self) or result
  File "/srv/share/sick_rage/sickbeard/metadata/generic.py", line 259, in create_episode_metadata
    return self.write_ep_file(ep_obj)
  File "/srv/share/sick_rage/sickbeard/metadata/tivo.py", line 326, in write_ep_file
    nfo_file.write(data.encode("utf-8"))
TypeError: must be unicode, not str
```

So I striped the ```encode("utf8")``` part, now it works fine. Worth merging ?