### PR TITLE
Remove extra comma in KODI notifier GetTVShows

### DIFF
--- a/sickbeard/notifiers/kodi.py
+++ b/sickbeard/notifiers/kodi.py
@@ -437,7 +437,7 @@ class KODINotifier:
             logging.debug("Updating library in KODI via JSON method for show " + showName)
 
             # let's try letting kodi filter the shows
-            showsCommand = '{"jsonrpc":"2.0","method":"VideoLibrary.GetTVShows","params":{"filter":{"field":"title","operator":"is","value":"%s"},"properties":["title",]},"id":"SiCKRAGE"}'
+            showsCommand = '{"jsonrpc":"2.0","method":"VideoLibrary.GetTVShows","params":{"filter":{"field":"title","operator":"is","value":"%s"},"properties":["title"]},"id":"SiCKRAGE"}'
 
             # get tvshowid by showName
             showsResponse = self._send_to_kodi_json(showsCommand % showName, host)


### PR DESCRIPTION
Fixes  the follow error thrown by KODI

"18:13:40 T:140392874936064   ERROR: JSONRPC: Failed to parse '{"jsonrpc":"2.0","method":"VideoLibrary.GetTVShows","params":{"filter":{"field":"title","operator":"is","value":"CSI: Cyber"},"properties":["title",]},"id":"SickRage"}'"
