### PR TITLE
Changed heading to match what the autoProcessTV.py is looking for

### DIFF
--- a/sickrage/autoProcessTV/autoProcessTV.cfg.sample
+++ b/sickrage/autoProcessTV/autoProcessTV.cfg.sample
@@ -1,4 +1,4 @@
-[sickrage]
+[SiCKRAGE]
 host=localhost
 port=8081
 username=


### PR DESCRIPTION
Changed heading from sickrage to SiCKRAGE so that it matches what autoProcessTV.py is searching for in the lookups area.