### PR TITLE
Fixes for name cache

### DIFF
--- a/sickrage/core/caches/name_cache.py
+++ b/sickrage/core/caches/name_cache.py
@@ -37,6 +37,10 @@ class srNameCache(object):
         self.lastUpdate = datetime.fromtimestamp(int(time.mktime(datetime.today().timetuple())))
         self.minTime = sickrage.srConfig.NAMECACHE_FREQ
         self.cache = {}
+        sqlResults = cache_db.CacheDB(row_type='dict').select(
+                "SELECT indexer_id, name FROM scene_names")
+        for row in sqlResults:
+	    self.cache[row[b"name"]] = int(row[b"indexer_id"])
 
     def run(self, force=False):
         """
@@ -120,6 +124,7 @@ class srNameCache(object):
                 self._buildNameCache(show)
 
             self.lastUpdate = datetime.fromtimestamp(int(time.mktime(datetime.today().timetuple())))
+            self.saveNameCacheToDb()
 
     def _buildNameCache(self, show=None):
         """Build internal name cache for a single show"""

--- a/sickrage/core/caches/name_cache.py
+++ b/sickrage/core/caches/name_cache.py
@@ -115,19 +115,24 @@ class srNameCache(object):
             if not show:
                 retrieve_exceptions()
                 for show in sickrage.srCore.SHOWLIST:
-                    self.buildNameCache(show)
+                    self._buildNameCache(show)
             else:
-                self.lastUpdate = datetime.fromtimestamp(int(time.mktime(datetime.today().timetuple())))
+                self._buildNameCache(show)
 
-                sickrage.srLogger.debug("Building internal name cache for [{}]".format(show.name))
-                self.clearCache(show.indexerid)
-                for curSeason in [-1] + get_scene_seasons(show.indexerid):
-                    for name in list(set(get_scene_exceptions(
-                            show.indexerid, season=curSeason) + [show.name])):
+            self.lastUpdate = datetime.fromtimestamp(int(time.mktime(datetime.today().timetuple())))
 
-                        name = full_sanitizeSceneName(name)
-                        if name not in self.cache:
-                            self.cache[name] = int(show.indexerid)
+    def _buildNameCache(self, show=None):
+        """Build internal name cache for a single show"""
 
-                sickrage.srLogger.debug("Internal name cache for [{}] set to: [{}]".format(
-                    show.name, [key for key, value in self.cache.items() if value == show.indexerid][0]))
+	sickrage.srLogger.debug("Building internal name cache for [{}]".format(show.name))
+	self.clearCache(show.indexerid)
+	for curSeason in [-1] + get_scene_seasons(show.indexerid):
+	    for name in list(set(get_scene_exceptions(
+		    show.indexerid, season=curSeason) + [show.name])):
+
+		name = full_sanitizeSceneName(name)
+		if name not in self.cache:
+		    self.cache[name] = int(show.indexerid)
+
+	sickrage.srLogger.debug("Internal name cache for [{}] set to: [{}]".format(
+	    show.name, [key for key, value in self.cache.items() if value == show.indexerid][0]))


### PR DESCRIPTION
There are two problems with the current implementation of the name cache:

1. When srNameCache.buildNameCache() is called without arguments it only updates the first show in the list
2. The cache is not stored persistently across restarts

These problems cause backlog searches to fail, since NameParser does not get a result from sickrage.srCore.NAMECACHE.retrieveNameFromCache().  This is particularly troublesome after cache.db gets deleted since the scene_names table will be empty.