### PR TITLE
Fixed issue with anon_url whereby if the URI began with https:// it ...

### DIFF
--- a/sickrage/core/helpers/__init__.py
+++ b/sickrage/core/helpers/__init__.py
@@ -985,7 +985,11 @@ def anon_url(*url):
     """
 
     url = ''.join(map(str, url))
-    if not url.startswith('http://'):
+
+    # Handle URL's containing https or http, previously only handled http
+    uri_pattern = ur'^https?://'
+    unicode_uri_pattern = re.compile(uri_pattern, re.UNICODE)
+    if not re.search(unicode_uri_pattern, url):
         url = 'http://' + url
 
     return '{}{}'.format(sickrage.srCore.srConfig.ANON_REDIRECT, url)


### PR DESCRIPTION
added http:// + existing_url, so http://https://domain.com.... This normally
resulted in a broken link in most browsers.

Changed the logic to use re, in the existing style, and check to see whether
http or https first, then if neither, then only adding http://
