### PR TITLE
Fix errors in 7.0.22

### DIFF
--- a/sickrage/core/databases/__init__.py
+++ b/sickrage/core/databases/__init__.py
@@ -206,7 +206,7 @@ class Connection(object):
         """
         try:
             if self.hasTable('db_version'):
-                return self.select("SELECT db_version FROM db_version")
+                return self.select("SELECT db_version FROM db_version")[0]["db_version"]
         except:
             return 0
 

--- a/sickrage/core/databases/main_db.py
+++ b/sickrage/core/databases/main_db.py
@@ -1121,6 +1121,7 @@ class MainDB(Connection):
                     "CREATE TABLE tmdb_info (indexer_id INTEGER PRIMARY KEY, tmdb_id TEXT, name TEXT, first_air_date NUMERIC, akas TEXT, episode_run_time NUMERIC, genres TEXT, origin_country TEXT, languages TEXT, production_companies TEXT, popularity TEXT, vote_count INTEGER, last_air_date NUMERIC)")
 
             if not self.hasColumn("tv_shows", "tmdb_id"):
-                self.addColumn("tv_shows", "tmdb_id")
+                self.addColumn("tv_shows", "tmdb_id", "TEXT", "")
+
 
             self.incDBVersion()

--- a/sickrage/core/process_tv.py
+++ b/sickrage/core/process_tv.py
@@ -553,7 +553,7 @@ def process_media(processPath, videoFiles, nzbName, process_method, force, is_pr
             process_fail_message = ""
         except EpisodePostProcessingFailedException as e:
             result.result = False
-            process_fail_message = e
+            process_fail_message = e.message
 
         if processor:
             result.output += processor.log

--- a/sickrage/providers/torrent/rarbg.py
+++ b/sickrage/providers/torrent/rarbg.py
@@ -105,7 +105,7 @@ class RarbgProvider(TorrentProvider):
         if not self._doLogin():
             return results
 
-        if epObj is not None:
+        if epObj != None:
             ep_indexerid = epObj.show.indexerid
             ep_indexer = epObj.show.indexer
         else:
@@ -116,10 +116,10 @@ class RarbgProvider(TorrentProvider):
             sickrage.srLogger.debug("Search Mode: %s" % mode)
             for search_string in search_params[mode]:
 
-                if mode is not 'RSS':
+                if mode != 'RSS':
                     sickrage.srLogger.debug("Search string: %s " % search_string)
 
-                if mode is 'RSS':
+                if mode == 'RSS':
                     searchURL = self.urls['listing'] + self.defaultOptions
                 elif mode == 'Season':
                     if ep_indexer == INDEXER_TVDB:
@@ -203,7 +203,7 @@ class RarbgProvider(TorrentProvider):
 
                 try:
                     data = re.search(r'\[\{\"title\".*\}\]', data)
-                    if data is not None:
+                    if data != None:
                         data_json = json.loads(data.group())
                     else:
                         data_json = {}
@@ -226,7 +226,7 @@ class RarbgProvider(TorrentProvider):
                                 continue
 
                             item = title, download_url, size, seeders, leechers
-                            if mode is not 'RSS':
+                            if mode != 'RSS':
                                 sickrage.srLogger.debug("Found result: %s " % title)
                             items[mode].append(item)
 


### PR DESCRIPTION
Last night I updated sickrage (hadn't upgraded it since Jan 22) and it stopped working after reboot, first I had problems with `subliminal==2.0.3`, had to downgrade to `subliminal=1.1.1`, then the db upgrade didn't work (db version check and last migration was broken). Manual post-processing had runtime errors.

It now seems to be running normally. I hope you can release `7.0.23` until the next major version gets released. I also tried `develop` branch but couldn't get it to work, it had some problems with `guessit`.

Also after upgrading I had to manually run `Force Full-Update` for all my shows to avoid `Unable to parse the filename ... into a valid show`, I think it has to do something with the last migration adding empty `tmdb_id`.