### PR TITLE
Bugfix for upstream issue #2, NameError in autoProcessTV.py

### DIFF
--- a/sickrage/autoProcessTV/autoProcessTV.py
+++ b/sickrage/autoProcessTV/autoProcessTV.py
@@ -32,7 +32,6 @@ except ImportError:
     import configparser
     import urllib.request as urllib2
     from urllib.parse import urlencode
-    HTTPBasicAuthHandler = urllib2.HTTPBasicAuthHandler
 
 
 def processEpisode(dir_to_process, org_NZB_name=None, status=None):
@@ -115,7 +114,7 @@ def processEpisode(dir_to_process, org_NZB_name=None, status=None):
     try:
         password_mgr = urllib2.HTTPPasswordMgrWithDefaultRealm()
         password_mgr.add_password(None, url, username, password)
-        handler = HTTPBasicAuthHandler(password_mgr)
+        handler = urllib2.HTTPBasicAuthHandler(password_mgr)
         opener = urllib2.build_opener(handler)
         urllib2.install_opener(opener)
 


### PR DESCRIPTION
```bash
sabnzbd@23ad80152c51:/datadir/postProcessing$ python sabToSiCKRAGE.py /some/dir
Loading config from autoProcessTV.cfg

Opening URL: https://…:443/home/postprocess/processEpisode?quiet=1&dir=%2Fsome%2Fdir
Traceback (most recent call last):
  File "sabToSiCKRAGE.py", line 35, in <module>
    autoProcessTV.processEpisode(sys.argv[1])
  File "/datadir/postProcessing/autoProcessTV.py", line 118, in processEpisode
    handler = HTTPBasicAuthHandler(password_mgr)
NameError: global name 'HTTPBasicAuthHandler' is not defined
```

```python
try:
    import ConfigParser as configparser
    import urllib2
    from urllib import urlencode
except ImportError:
    import configparser
    import urllib.request as urllib2
    from urllib.parse import urlencode
    HTTPBasicAuthHandler = urllib2.HTTPBasicAuthHandler
```

In case NO `ImportError` occurs, `HTTPBasicAuthHandler` will never be defined and it will throw a `NameError` on line 137.