### PR TITLE
Fix for pushbullet configuration in webserver

### DIFF
--- a/sickrage/core/webserver/gui/default/js/core.js
+++ b/sickrage/core/webserver/gui/default/js/core.js
@@ -4103,11 +4103,11 @@ jQuery(document).ready(function ($) {
                     });
 
                     $('#getPushbulletDevices').click(function () {
-                        SICKRAGE.config.postprocessing.get_pushbullet_devices("Device list updated. Please choose a device to push to.");
+                        SICKRAGE.config.notifications.get_pushbullet_devices("Device list updated. Please choose a device to push to.");
                     });
 
                     // we have to call this function on dom ready to create the devices select
-                    SICKRAGE.config.postprocessing.get_pushbullet_devices();
+                    SICKRAGE.config.notifications.get_pushbullet_devices();
 
                     $('#email_show').on('change', function () {
                         var key = parseInt($('#email_show').val(), 10);
@@ -4128,7 +4128,7 @@ jQuery(document).ready(function ($) {
                     });
 
                     // Load the per show notify lists everytime this page is loaded
-                    SICKRAGE.config.postprocessing.load_show_notify_lists();
+                    SICKRAGE.config..load_show_notify_lists();
 
                     $('#email_show_save').click(function () {
                         $.post("/home/saveShowNotifyList", {

--- a/sickrage/core/webserver/gui/default/js/core.js
+++ b/sickrage/core/webserver/gui/default/js/core.js
@@ -4128,7 +4128,7 @@ jQuery(document).ready(function ($) {
                     });
 
                     // Load the per show notify lists everytime this page is loaded
-                    SICKRAGE.config..load_show_notify_lists();
+                    SICKRAGE.config.notifications.load_show_notify_lists();
 
                     $('#email_show_save').click(function () {
                         $.post("/home/saveShowNotifyList", {


### PR DESCRIPTION
In the pushbullet configuration section, the function get_pushbullet_devices() is called on postprocessing instead of notifications. This is causing the following javascript error:

core.min.js:3 Uncaught TypeError: b.config.postprocessing.get_pushbullet_devices is not a function(…)

Same for load_show_notify_lists()