### PR TITLE
Fix for error in _sendPushbullet() due to missing requests lib

### DIFF
--- a/sickrage/notifiers/pushbullet.py
+++ b/sickrage/notifiers/pushbullet.py
@@ -90,7 +90,7 @@ class PushbulletNotifier(srNotifiers):
         headers = {'Content-Type': 'application/json', 'Authorization': 'Bearer %s' % pushbullet_api}
 
         try:
-            response = self.session.request(method, url, data=data, headers=headers)
+            response = sickrage.srCore.srWebSession.request(method, url, data=data, headers=headers)
         except Exception:
             sickrage.srCore.srLogger.debug('Pushbullet authorization failed with exception: %r' % traceback.format_exc())
             return False


### PR DESCRIPTION
The call to self.session.request() cause the following error: 

DEBUG::WEB::Pushbullet authorization failed with exception: 'Traceback (most recent call last):
File "/home/odroid/SiCKRAGE/sickrage/notifiers/pushbullet.py", line 93, in _sendPushbullet
response = self.session.request(method, url, data=data, headers=headers)
AttributeError: \'NoneType\' object has no attribute \'request\'

Changing that to use the srCore.srWebsession.