### PR TITLE
Add empty contraints.txt so the travis run command doesn't fail

### DIFF
--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -5,7 +5,7 @@ set -x
 git config --global user.email "echel0n@sickrage.ca"
 git config --global user.name "echel0n"
 
-pip install --upgrade -r sickrage/requirements.txt -c sickrage/constraints.txt
+pip install --upgrade -r requirements.txt -c constraints.txt
 
 chmod +x tests/*.py
 python -m unittest discover tests


### PR DESCRIPTION
Add an empty `contraints.txt` which should fix travis failing:
> +pip install --upgrade -r sickrage/requirements.txt -c sickrage/constraints.txt
> Could not open requirements file: [Errno 2] No such file or directory: 'sickrage/constraints.txt'

For example: https://travis-ci.org/SiCKRAGETV/SiCKRAGE/builds/221991397 (from https://github.com/SiCKRAGETV/SiCKRAGE/pull/3279)

Verified this by successfully running:
```sh
pip install --upgrade -r requirements.txt -c constraints.txt
```