### PR TITLE
Use showObj when referencing indexerid

### DIFF
--- a/sickrage/core/webserver/views.py
+++ b/sickrage/core/webserver/views.py
@@ -1520,7 +1520,7 @@ class Home(WebHandler):
 
         sickrage.srCore.srNotifications.message('%s has been %s' % (showObj.name, ('resumed', 'paused')[showObj.paused]))
 
-        return self.redirect("/home/displayShow?show=%i" % show.indexerid)
+        return self.redirect("/home/displayShow?show=%i" % showObj.indexerid)
 
     def deleteShow(self, show=None, full=0):
         if show is None:
@@ -1565,7 +1565,7 @@ class Home(WebHandler):
 
         time.sleep(cpu_presets[sickrage.srCore.srConfig.CPU_PRESET])
 
-        return self.redirect("/home/displayShow?show=" + str(show.indexerid))
+        return self.redirect("/home/displayShow?show=" + str(showObj.indexerid))
 
     def updateShow(self, show=None, force=0):
         if show is None:


### PR DESCRIPTION
Fixes the following error (when clicking 'Re-scan files')
```
Error

'unicode' object has no attribute 'indexerid'

Traceback

Traceback (most recent call last): 
File "/usr/local/lib/python2.7/dist-packages/tornado/web.py", line 1485, in _execute result = self.prepare() 
File "/usr/local/lib/python2.7/dist-packages/tornado/web.py", line 2894, in wrapper return method(self, *args, **kwargs) 
File "/opt/sickrage/sickrage/core/webserver/views.py", line 210, in prepare self.finish(self.route(method, **self.request.arguments)) 
File "/opt/sickrage/sickrage/core/webserver/views.py", line 193, in route recursive_unicode(kwargs.items())]) 
File "/opt/sickrage/sickrage/core/webserver/views.py", line 1568, in refreshShow return self.redirect("/home/displayShow?show=" + str(show.indexerid)) 
AttributeError: 'unicode' object has no attribute 'indexerid' 
```