### PR TITLE
Remove webRoot from submenu title

### DIFF
--- a/sickrage/core/webserver/gui/default/views/layouts/main.mako
+++ b/sickrage/core/webserver/gui/default/views/layouts/main.mako
@@ -291,7 +291,7 @@
                     % if 'requires' not in menuItem or menuItem['requires']:
                         <% icon_class = '' if 'icon' not in menuItem else ' ' + menuItem['icon'] %>
                         % if type(menuItem['path']) == dict:
-                        ${("</span><span>", "")[bool(first)]}<b>${srWebRoot}${menuItem['title']}</b>
+                        ${("</span><span>", "")[bool(first)]}<b>${menuItem['title']}</b>
                         <%
                             first = False
                             inner_first = True
@@ -303,7 +303,7 @@
                         % endfor
                         % else:
                             <a href="${srWebRoot}${menuItem['path']}"
-                               class="btn${('', (' confirm ' + menuItem.get('class', '')))['confirm' in menuItem]}">${('', '<span class="pull-left ' + icon_class + '"></span> ')[bool(icon_class)]}${srWebRoot}${menuItem['title']}</a>
+                               class="btn${('', (' confirm ' + menuItem.get('class', '')))['confirm' in menuItem]}">${('', '<span class="pull-left ' + icon_class + '"></span> ')[bool(icon_class)]}${menuItem['title']}</a>
                         <% first = False %>
                         % endif
                     % endif


### PR DESCRIPTION
https://github.com/SiCKRAGETV/SiCKRAGE/commit/4a8fc9c94d6c8019cce01e3245504d6bbd6a7bd1 was a bit overzealous with the `${srWebRoot}`s.

![capture](https://cloud.githubusercontent.com/assets/5223519/25057289/5a90d864-2123-11e7-9c91-8576ebdc7c04.PNG)
