### PR TITLE
Add API subdomain to usenet-crawler.com

### DIFF
--- a/sickrage/providers/__init__.py
+++ b/sickrage/providers/__init__.py
@@ -1276,7 +1276,7 @@ class NewznabProvider(NZBProvider):
             cls('NZB.Cat', 'https://nzb.cat', '', '5030,5040,5010', 'eponly', True, True, True, True),
             cls('NZBGeek', 'https://api.nzbgeek.info', '', '5030,5040', 'eponly', False, False, False, True),
             cls('NZBs.org', 'https://nzbs.org', '', '5030,5040', 'eponly', False, False, False, True),
-            cls('Usenet-Crawler', 'https://usenet-crawler.com', '', '5030,5040', 'eponly', False, False, False, True)
+            cls('Usenet-Crawler', 'https://api.usenet-crawler.com', '', '5030,5040', 'eponly', False, False, False, True)
         ]
 
 


### PR DESCRIPTION
See: https://www.usenet-crawler.com/

"26 January 2018
I have separated the api and website. This should lower the amount of open connections a lot, hopefully making the site more snappy. New url https://api.usenet-crawler.com"